### PR TITLE
ENH: limits on EpicsSignals and Positioners (issue #25)

### DIFF
--- a/examples/motor.py
+++ b/examples/motor.py
@@ -51,6 +51,23 @@ def test():
     logger.info('--> move to 0')
     m1.move(0, wait=False, moved_cb=done_moving)
     time.sleep(2)
+
+    logger.debug('limits are: {}'.format(m1.limits))
+    low_lim, high_lim = m1.low_limit, m1.high_limit
+    try:
+        m1.move(high_lim + 1)
+    except ValueError as ex:
+        logger.debug('Failed move, as expected (%s)' % ex)
+    else:
+        raise ValueError('Move should have failed')
+
+    try:
+        m1.move(low_lim - 1)
+    except ValueError as ex:
+        logger.debug('Failed move, as expected (%s)' % ex)
+    else:
+        raise ValueError('Move should have failed')
+
     # m2.move(1)
 
 


### PR DESCRIPTION
Simple-ish fix for limits all around. Recall that the motor record sets lower and upper ctrl limits on the `VAL` field, so special handling isn't really necessary.

One improvement I can suggest is to (somehow) automatically check if limits should be enabled for the `EpicsSignal`. As it is, using it for all EPICS signals causes issues with many other signals (try setting `limits=True` in `EpicsSignal`'s initializer and running the areadetector example).
