### PR TITLE
MNT: Single function call to create an event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ target/
 *.pyc
 *.swp
 *.bak
+
+# Pycharm project files
+.idea/

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -131,10 +131,12 @@ class RunEngine(object):
             #data.update({'timestamp': time.time()})
             # pass data onto Demuxer for distribution
             print('datapoint[{}]: {}'.format(seqno,detvals))
-            event = data_collection.format_event(hdr, evdesc,
-                                              seq_no=seqno,
-                                              data=detvals)
-            data_collection.write_to_event_PV(event)
+
+            # single function call to insert the event into the metadatastore
+            # and publish it to a PV so that replay can watch it
+            data_collection.create_and_publish_event(hdr, evdesc,
+                                                     seq_no=seqno,
+                                                     data=detvals)
             seqno += 1
             #update the 'data' object from detvals dict
             for k,v in detvals.iteritems():
@@ -159,15 +161,17 @@ class RunEngine(object):
         data = {k:[] for k in keys}
         print('keys = %s'%keys)
         #event_descriptor = {'a': 1, 'b':2}
+        # create the event descriptor
         event_descriptor = data_collection.create_event_descriptor(
                             run_header=header, event_type_id=1, data_keys=keys,
                             descriptor_name='Scan Foo')
+        #write the header and event_descriptor to the header PV
+        data_collection.write_to_hdr_PV(header, event_descriptor)
+        # format scan_args
         if scan_args is not None:
             scan_args['header'] = header
             scan_args['event_descriptor'] = event_descriptor
             scan_args['data'] = data
-        #write the header and event_descriptor to the header PV
-        data_collection.write_to_hdr_PV(header, event_descriptor)
 
         self._begin_run(begin_args)
 


### PR DESCRIPTION
- The previous implementation formatted the event and then
  published it to an epics PV.  A server was monitoring that PV
  and then wrote it into metadatastore.  That's a stupid
  implementation (sorry!) because then data can be lost if
  the PV is overwritten before the server can grab it and
  publish it to metadatastore
- This implementation just writes the event into metadatastore
  and then publishes it to a PV.  The only possible information
  loss is in the live viewer which is not a big deal (Stuart
  confirms that this is not a big deal)
