### PR TITLE
time estimates for plans

### DIFF
--- a/ophyd/EstTime.py
+++ b/ophyd/EstTime.py
@@ -72,7 +72,7 @@ class DefaultEstTime:
 
         return out_time
 
-    def _set_record(status_object=None):
+    def _set_record(self, status_object=None):
         '''This is a function that records telemetry for the set command.
 
         PARAMETER
@@ -90,7 +90,7 @@ class DefaultEstTime:
             data['position'] = {'start': status_object.start_pos,
                                 'stop': status_object.finish_pos}
 
-            record_telemetry(status_object.obj_name, 'set', data)
+            record_telemetry(status_object.obj.name, 'set', data)
 
     set.record = _set_record
 

--- a/ophyd/EstTime.py
+++ b/ophyd/EstTime.py
@@ -81,6 +81,7 @@ class DefaultEstTime:
             This is a status object that contains information collected about
             the action to be stored in telemetry.
         '''
+
         if status_object:
             data = {}
             data['estimation'] = {'time': status_object.est_time.est_time,
@@ -357,7 +358,6 @@ class EpicsMotorEstTime(DefaultEstTime):
         if type(start_pos) is tuple:
             start_pos = start_pos[0][0]
 
-
         attributes = [_AttrTuple('velocity', velocity, None)]
 
         velocity_list = self._extract_velocity_list(
@@ -391,7 +391,7 @@ class EpicsMotorEstTime(DefaultEstTime):
 
         return out_time
 
-    def _set_record(status_object=None):
+    def _set_record(self, status_object=None):
         '''This is a function that records telemetry for the set command.
 
         PARAMETER
@@ -409,9 +409,9 @@ class EpicsMotorEstTime(DefaultEstTime):
             data['position'] = {'start': status_object.start_pos,
                                 'stop': status_object.finish_pos}
             data['velocity'] = {
-                'setpoint': status_object.pos.velocity.position}
+                'setpoint': status_object.pos.velocity.get()}
             data['settle_time'] = {
-                'setpoint': status_object.pos.settle_time.position}
+                'setpoint': status_object.pos.settle_time.get()}
 
             record_telemetry(status_object.pos.name, 'set', data)
 
@@ -558,15 +558,15 @@ class ADEstTime(DefaultEstTime):
             data['time'] = {'start': status_object.start_ts,
                             'stop': status_object.finish_ts}
             data['trigger_mode'] = {
-                'setpoint': status_object.device.trigger_mode.position}
+                'setpoint': status_object.device.trigger_mode.get()}
             data['num_images'] = {
-                'setpoint': status_object.device.num_images.position}
+                'setpoint': status_object.device.num_images.get()}
             data['settle_time'] = {
-                'setpoint': status_object.device.settle_time.position}
+                'setpoint': status_object.device.settle_time.get()}
             data['acquire_period'] = {
-                'setpoint': status_object.device.acquire_period.position}
+                'setpoint': status_object.device.acquire_period.get()}
             data['acquire_time'] = {
-                'setpoint': status_object.device.acquire_time.position}
+                'setpoint': status_object.device.acquire_time.get()}
 
             record_telemetry(status_object.device.name, 'trigger', data)
 

--- a/ophyd/EstTime.py
+++ b/ophyd/EstTime.py
@@ -1,0 +1,612 @@
+from .telemetry import TelemetryUI
+from collections import namedtuple
+import statistics
+import math
+
+# define the statistics error
+StatisticsError = statistics.StatisticsError
+
+# define a named tuple classes for use later.
+_TimeStats = namedtuple('TimeStats', 'est_time std_dev')
+_AttrTuple = namedtuple('AttrTuple', 'name start stop')
+
+# define some functions
+record_telemetry = TelemetryUI.record_telemetry
+fetch_telemetry = TelemetryUI.fetch_telemetry
+
+
+class DefaultEstTime:
+    '''The base class for the time estimation on all OphydObjs.
+
+    This allows the devices to provide an estimate of how long it takes to
+    perform specific commands on them via the addition of obj.est_time.cmd
+    method attributes. This must also interact with the telemetry class in
+    order to use time statistics if they exist to improve the time estimation.
+    '''
+
+    def __init__(self, obj_name):
+        '''The initialization method.
+        Parameters
+        ----------
+        obj_name, str
+            The object name that this class is being instantiated on.
+        '''
+        self.obj_name = obj_name
+
+    def set(self, start_pos, target):
+        '''Estimates the time (est_time) to perform 'set' on this object.
+
+        This method returns an estimated time (est_time) to perform set between
+        start pos and target. If telemetry for this action, and start_pos and
+        target values, exist it uses mean values and works out a standard
+        deviation (std_dev). Otherwise it uses the argument values to determine
+        an est_time and returns float('nan') for std_dev.
+
+        PARAMETERS
+        ----------
+        start_pos : float or string.
+            The start position for the set.
+        target : float or string.
+            The end position for the set.
+
+        RETURNS
+        -------
+        stats : named tuple.
+            A named tuple containing the est_time as the first element and the
+            std_dev as the second element.
+        '''
+        attributes = []
+        attributes.append(_AttrTuple('position', start_pos, target))
+
+        time_list = self._extract_time_list(fetch_telemetry(self.obj_name,
+                                                            'set'),
+                                            attributes=attributes)
+        try:
+            out_time = _TimeStats(statistics.mean(time_list),
+                                  statistics.stdev(time_list))
+        except StatisticsError:
+            try:
+                out_time = _TimeStats(statistics.mean(time_list), float('nan'))
+            except StatisticsError:
+                out_time = _TimeStats(float('nan'), float('nan'))
+
+        return out_time
+
+    def _set_record(status_object=None):
+        '''This is a function that records telemetry for the set command.
+
+        PARAMETER
+        ---------
+        status_object : StatusObject.
+            This is a status object that contains information collected about
+            the action to be stored in telemetry.
+        '''
+        if status_object:
+            data = {}
+            data['estimation'] = {'time': status_object.est_time.est_time,
+                                  'std_dev': status_object.est_time.std_dev}
+            data['time'] = {'start': status_object.start_ts,
+                            'stop': status_object.finish_ts}
+            data['position'] = {'start': status_object.start_pos,
+                                'stop': status_object.finish_pos}
+
+            record_telemetry(status_object.obj_name, 'set', data)
+
+    set.record = _set_record
+
+    def trigger(self):
+        '''Estimates the time (est_time) to perform 'trigger' on this object.
+
+        This method returns an estimated time (est_time) to perform trigger. If
+        telemetry for this action exist it uses mean values and works out a
+        standard deviation (std_dev). Otherwise it uses the argument values to
+        determine an est_time and returns float('nan') std_dev.
+
+        PARAMETERS
+        ----------
+        None.
+
+        RETURNS
+        -------
+        stats : named tuple.
+            A named tuple containing the est_time as the first element and the
+            std_dev as the second element.
+        '''
+
+        time_list = self._extract_time_list(fetch_telemetry(self.obj_name,
+                                                            'trigger'))
+
+        try:
+            out_time = _TimeStats(statistics.mean(time_list),
+                                  statistics.stdev(time_list))
+        except StatisticsError:
+            try:
+                out_time = _TimeStats(statistics.mean(time_list), float('nan'))
+            except StatisticsError:
+                out_time = _TimeStats(float('nan'), float('nan'))
+
+        return out_time
+
+    def _trigger_record(status_object=None):
+        '''This is a function that records telemetry for the trigger command.
+
+        PARAMETER
+        ---------
+        status_object : StatusObject.
+            This is a status object that contains information collected about
+            the action to be stored in telemetry.
+        '''
+        if status_object:
+            data = {}
+            data['estimation'] = {'time': status_object.est_time.est_time,
+                                  'std_dev': status_object.est_time.std_dev}
+            data['time'] = {'start': status_object.start_ts,
+                            'stop': status_object.finish_ts}
+
+            record_telemetry(status_object.obj_name, 'trigger', data)
+
+    trigger.record = _trigger_record
+
+    def stage(self):
+        '''Estimates the time (est_time) to perform 'stage' on this object.
+
+        This method returns an estimated time (est_time) to perform stage. If
+        telemetry for this action exist it uses mean values and works out a
+        standard deviation (std_dev). Otherwise it uses the argument values to
+        determine an est_time and returns float('nan')
+        for both est_time and std_dev.
+
+        PARAMETERS
+        ----------
+        None.
+
+        RETURNS
+        -------
+        stats : named tuple.
+            A named tuple containing the est_time as the first element and the
+            std_dev as the second element.
+        '''
+
+        time_list = self._extract_time_list(fetch_telemetry(self.obj_name,
+                                                            'stage'))
+
+        try:
+            out_time = _TimeStats(statistics.mean(time_list),
+                                  statistics.stdev(time_list))
+        except StatisticsError:
+            try:
+                out_time = _TimeStats(statistics.mean(time_list), float('nan'))
+            except StatisticsError:
+                out_time = _TimeStats(float('nan'), float('nan'))
+
+        return out_time
+
+    def _stage_record(status_object=None):
+        '''This is a function that records telemetry for the stage command.
+
+        PARAMETER
+        ---------
+        status_object : StatusObject.
+            This is a status object that contains information collected about
+            the action to be stored in telemetry.
+        '''
+
+        if status_object:
+            data = {}
+            data['estimation'] = {'time': status_object.est_time.est_time,
+                                  'std_dev': status_object.est_time.std_dev}
+            data['time'] = {'start': status_object.start_ts,
+                            'stop': status_object.finish_ts}
+
+            record_telemetry(status_object.obj_name, 'stage', data)
+
+    stage.record = _stage_record
+
+    def unstage(self):
+        '''Estimates the time (est_time) to perform 'unstage' on this object.
+
+        This method returns an estimated time (est_time) to perform unstage.
+        If telemetry for this action exist it uses mean values and works out a
+        standard deviation (std_dev). Otherwise it uses the argument values to
+        determine an est_time and returns float('nan') for std_dev.
+
+        PARAMETERS
+        ----------
+        None.
+
+        RETURNS
+        -------
+        stats : named tuple.
+            A named tuple containing the est_time as the first element and the
+            std_dev as the second element.
+        '''
+
+        time_list = self._extract_time_list(fetch_telemetry(self.obj_name,
+                                                            'unstage'))
+
+        try:
+            out_time = _TimeStats(statistics.mean(time_list),
+                                  statistics.stdev(time_list))
+        except StatisticsError:
+            try:
+                out_time = _TimeStats(statistics.mean(time_list), float('nan'))
+            except StatisticsError:
+                out_time = _TimeStats(float('nan'), float('nan'))
+
+        return out_time
+
+    def _unstage_record(status_object=None):
+        '''This is a function that records telemetry for the unstage command.
+
+        PARAMETER
+        ---------
+        status_object : StatusObject.
+            This is a status object that contains information collected about
+            the action to be stored in telemetry.
+        '''
+
+        if status_object:
+            data = {}
+            data['estimation'] = {'time': status_object.est_time.est_time,
+                                  'std_dev': status_object.est_time.std_dev}
+            data['time'] = {'start': status_object.start_ts,
+                            'stop': status_object.finish_ts}
+
+            record_telemetry(status_object.obj_name, 'unstage', data)
+
+    unstage.record = _unstage_record
+
+    def _extract_time_list(self, telemetry, attributes=None):
+        '''Extracts a time list for the given attribute:
+
+        This extracts out all of the values from the 'measured' list that match
+        a start_position and a stop_position for an attribute, +/- 1% for
+        floats, in telemetry.
+
+        PARAMETERS
+        ----------
+        telemetry, dict.
+            The telemetry dictionary to extract information out of.
+        attributes, list of named tuples, optional.
+            A list of named tuples relating to a specific attribute, containing
+            (name, start, stop) values. By default this is None and returns the
+            time for every point in the telemetry list. If the attribute does
+            not change during the action then 'stop' should be None.
+
+        RETURNS
+        -------
+        out_list, list
+            A list containing the time for each action.
+        '''
+        if attributes is not None:
+            for attribute in attributes:
+                for action in telemetry:
+                    if isinstance(attribute.start, float):
+                        if not math.isclose(action[attribute.name]['start'],
+                                            attribute.start, rel_tol=.01):
+                            if attribute['stop'] is None or \
+                               not math.isclose(action[attribute.name]['stop'],
+                                                attribute.stop, rel_tol=.01):
+                                telemetry.remove(action)
+
+                    elif isinstance(attribute.start, str):
+                        if action[attribute.name]['start'] is not \
+                           attribute.start:
+                            if attribute.stop is None or \
+                             action[attribute.name]['stop'] is not \
+                             attribute.stop:
+                                telemetry.remove(action)
+
+        out_list = []
+        for action in telemetry:
+            out_list.append(action['time']['stop']-action['time']['start'])
+
+        return out_list
+
+
+class EpicsMotorEstTime(DefaultEstTime):
+    '''This is the EstTime class for the time estimation on EpicsMotor Devices.
+    This allows the devices to provide an estimate of how long it takes to
+    perform specific commands on them via the addition of obj.est_time and
+    obj.est_time.cmd methods attributes. This must also interact with the
+    'stats' methods in order to use time statistics if they exist to improve
+    the time estimation.
+    '''
+
+    def __init__(self, obj_name):
+        '''The initialization method.
+
+        Parameters
+        ----------
+        obj_name, name of objectobject
+            The object name that this class is being instantiated on.
+        '''
+        self.obj_name = obj_name
+
+    def set(self, start_pos, target, velocity, settle_time):
+        '''Estimates the time (est_time) to perform 'set' on this object.
+
+        This method returns an estimated time (est_time) to perform set between
+        start position and stop position. If telemetry for this action, and the
+        argument values, exist it uses mean values and works out a standard
+        deviation (std_dev). Otherwise it uses the argument values to determine
+        an est_time and returns float('nan') for std_dev.
+
+        PARAMETERS
+        ----------
+        start_pos : float, str or tuple.
+            The start position for the set, it may be a tuple of the form
+            (args, kwargs) as this is the generic 'set' input, if this is the
+            case it takes args[0] as the value.
+        target : float or str.
+            The end position for the set.
+        veloctiy : float.
+            The setpoint of the velocity at which the motor moves.
+        settle_time : float.
+            The amount of time that the device will 'wait' after performing the
+            move.
+
+        RETURNS
+        -------
+        stats : namedtuple.
+            A namedtuple containing the est_time as the first element and the
+            std_dev as the second element.
+        '''
+
+        # if the start_pos is a tuple
+        if type(start_pos) is tuple:
+            start_pos = start_pos[0][0]
+
+
+        attributes = [_AttrTuple('velocity', velocity, None)]
+
+        velocity_list = self._extract_velocity_list(
+                        fetch_telemetry(self.obj_name, 'set'),
+                        attributes=attributes)
+
+        if velocity_list:
+            mean_velocity = statistics.mean(velocity_list)
+            try:
+                std_dev_velocity = statistics.stdev(velocity_list)
+            except StatisticsError:
+                std_dev_velocity = float('nan')
+
+            if mean_velocity == 0:
+                mean_velocity = float('nan')
+
+            est_time = abs(start_pos - target)/mean_velocity + settle_time
+            est_time_max = abs(start_pos - target) /\
+                              (mean_velocity + std_dev_velocity) + settle_time
+            est_time_min = abs(start_pos - target) /\
+                              (mean_velocity - std_dev_velocity) + settle_time
+
+            std_dev_est_time = max(abs(est_time - est_time_max),
+                                   abs(est_time - est_time_min))
+
+            out_time = _TimeStats(est_time, std_dev_est_time)
+        else:
+
+            est_time = abs(start_pos - target)/velocity + settle_time
+            out_time = _TimeStats(est_time, float('NaN'))
+
+        return out_time
+
+    def _set_record(status_object=None):
+        '''This is a function that records telemetry for the set command.
+
+        PARAMETER
+        ---------
+        status_object: StatusObject.
+            This is a status object that contains information collected about
+            the action to be stored in telemetry.
+        '''
+        if status_object:
+            data = {}
+            data['estimation'] = {'time': status_object.est_time.est_time,
+                                  'std_dev': status_object.est_time.std_dev}
+            data['time'] = {'start': status_object.start_ts,
+                            'stop': status_object.finish_ts}
+            data['position'] = {'start': status_object.start_pos,
+                                'stop': status_object.finish_pos}
+            data['velocity'] = {
+                'setpoint': status_object.pos.velocity.position}
+            data['settle_time'] = {
+                'setpoint': status_object.pos.settle_time.position}
+
+            record_telemetry(status_object.pos.name, 'set', data)
+
+    set.record = _set_record
+
+    def _extract_velocity_list(self, telemetry, attributes=None):
+        '''Extracts a list of velocities for an attribute.
+
+        This extracts out all of the velocites from the 'measured' list that
+        match a start_position and a stop_position for an attribute, +/- 1%
+        for floats, in telemetry.
+
+        PARAMETERS
+        ----------
+        telemetry, dict.
+            The telemetry dictionary to extract information out of.
+        attributes, list of named tuples, optional.
+            A list of named tuples relating to a specific attribute, containing
+            (name, start, stop) values. By default this is None and returns the
+            time for every point in the telemetry list. If the attribute does
+            not change during the action then 'stop' should be None.
+
+        RETURNS
+        -------
+        out_list, list
+            A list containing the velocity for each action.
+        '''
+
+        if attributes is not None:
+            for attribute in attributes:
+                for action in telemetry:
+                    if not math.isclose(action[attribute.name]['setpoint'],
+                                        attribute.start, rel_tol=.01):
+                        telemetry.remove(action)
+        out_list = []
+
+        for action in telemetry:
+
+            delta_distance = abs(action['position']['start'] -
+                                 action['position']['stop'])
+            delta_time = abs(action['time']['start'] - action['time']['stop'])
+            settle_time = action['settle_time']['setpoint']
+            out_list.append(delta_distance/(delta_time - settle_time))
+
+        return out_list
+
+
+class ADEstTime(DefaultEstTime):
+    '''This is the EstTime class for the time estimation on AreaDetector
+       devices.
+
+    This allows the devices to provide an estimate of how long it takes to
+    perform specific commands on them via the addition of obj.est_time and
+    obj.est_time.cmd methods attributes. This must also interact with the
+    'stats' methods in order to use time statistics if they exist to improve
+    the time estimation.
+    '''
+
+    def __init__(self, obj_name):
+        '''The initialization method.
+
+        Parameters
+        ----------
+        obj_name, name of objectobject
+            The object name that this class is being instantiated on.
+        '''
+        self.obj_name = obj_name
+
+    def trigger(self, acquire_time, acquire_period, trigger_mode, num_images,
+                settle_time):
+        '''Estimates the time (est_time) to perform 'trigger' on this object.
+
+        This method returns an estimated time (est_time) to perform trigge. If
+        telemetry for this action, and the argument values, exist it uses mean
+        values and works out a standard deviation (std_dev). Otherwise it uses
+        the argument values to determine an est_time and returns float('nan')
+        for both est_time and std_dev.
+
+        PARAMETERS
+        ----------
+        acquire_period : float.
+            The acquire period used if trigger_mode is 'fixed'.
+        acquire_time : float.
+            The acquire time used if trigger_mode is not 'fixed'.
+        trigger_mode : string.
+            The trigger_mode.
+        num_images : int.
+            The number of images per step.
+        settle_time : float.
+            The amount of time that the device will 'wait' after performing
+            the move.
+
+        RETURNS
+        -------
+        stats : namedtuple.
+            A namedtuple containing the est_time as the first element and the
+            std_dev as the second element.
+        '''
+
+        if trigger_mode is 'fixed_mode':
+            attributes = [_AttrTuple('acquire_period', acquire_time, None)]
+        else:
+            attributes = [_AttrTuple('acquire_time', acquire_time, None)]
+
+        acquire_time_list = self._extract_acquire_time_list(fetch_telemetry(
+                            self.obj_name, 'trigger'), attributes=attributes)
+
+        if acquire_time_list:
+            mean_acquire_time = statistics.mean(acquire_time_list)
+            try:
+                std_dev_acquire_time = statistics.stdev(acquire_time_list)
+            except StatisticsError:
+                std_dev_acquire_time = float('nan')
+
+            est_time = (mean_acquire_time + settle_time) * num_images
+            est_time_max = (mean_acquire_time + std_dev_acquire_time +
+                            settle_time) * num_images
+            est_time_min = (mean_acquire_time - std_dev_acquire_time +
+                            settle_time) * num_images
+
+            std_dev_est_time = max(abs(est_time - est_time_max),
+                                   abs(est_time - est_time_min))
+
+            out_time = _TimeStats(est_time, std_dev_est_time)
+        else:
+            est_time = (acquire_time + settle_time) * num_images
+            out_time = _TimeStats(est_time, float('nan'))
+
+        return out_time
+
+    def _trigger_record(status_object=None):
+        '''This is a function that records telemetry for the trigger command.
+
+        PARAMETER
+        ---------
+        status_object : StatusObject.
+            This is a status object that contains information collected about
+            the action to be stored in telemetry.
+        '''
+        if status_object:
+            data = {}
+            data['estimation'] = {'time': status_object.est_time.est_time,
+                                  'std_dev': status_object.est_time.std_dev}
+            data['time'] = {'start': status_object.start_ts,
+                            'stop': status_object.finish_ts}
+            data['trigger_mode'] = {
+                'setpoint': status_object.device.trigger_mode.position}
+            data['num_images'] = {
+                'setpoint': status_object.device.num_images.position}
+            data['settle_time'] = {
+                'setpoint': status_object.device.settle_time.position}
+            data['acquire_period'] = {
+                'setpoint': status_object.device.acquire_period.position}
+            data['acquire_time'] = {
+                'setpoint': status_object.device.acquire_time.position}
+
+            record_telemetry(status_object.device.name, 'trigger', data)
+
+    trigger.record = _trigger_record
+
+    def _extract_acquire_time_list(self, telemetry, attributes=None):
+        '''This extracts out all of the acquire_periods/ aqcuire_times from the
+           'measured' list that match a start_position and a stop_position for
+           an attribute, +/- 1% for floats, in telemetry.
+
+        PARAMETERS
+        ----------
+        telemetry : dict.
+            The telemetry dictionary to extract information out of.
+        attributes : list of named tuples, optional.
+            A list of named tuples relating to a specific attribute,
+            containing (name, start, stop) values. By default this is None and
+            returns the time for every point in the telemetry list. If the
+            attribute does not change during the action the 'stop' should be
+            None.
+
+        RETURNS
+        -------
+        out_list : list
+            A list containing the velocity for each action.
+        '''
+
+        if attributes is not None:
+            for attribute in attributes:
+                for action in telemetry:
+                    if not math.isclose(action[attribute.name]['setpoint'],
+                                        attribute.start, rel_tol=.01):
+                        telemetry.remove(action)
+
+        out_list = []
+        for action in telemetry:
+            delta_time = abs(action['time']['start'] - action['time']['stop'])
+            num_images = action['num_images']['setpoint']
+            settle_time = action['settle_time']['setpoint']
+
+            out_list.append((delta_time/num_images - settle_time))
+
+        return out_list

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -12,6 +12,7 @@ from . import docs
 from ..signal import (EpicsSignal, DerivedSignal, EpicsSignalRO)
 from ..device import (Device, Component, DynamicDeviceComponent)
 from ..signal import (ArrayAttributeSignal)
+from ..EstTime import ADEstTime
 
 
 class EpicsSignalWithRBV(EpicsSignal):
@@ -213,6 +214,10 @@ class ADBase(Device):
 
     This serves as the base for all detectors and plugins
     '''
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.est_time = ADEstTime(self.name)
 
     _html_docs = ['areaDetectorDoc.html']
     _default_read_attrs = ()

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -36,7 +36,8 @@ from .. import (Device, Component, FormattedComponent as FCpt)
 from ..signal import (EpicsSignalRO, EpicsSignal, ArrayAttributeSignal)
 from ..device import GenerateDatumInterface
 from ..utils import enum, set_and_wait
-from ..utils.errors import (PluginMisconfigurationError, DestroyedError, UnprimedPlugin)
+from ..utils.errors import (PluginMisconfigurationError, DestroyedError,
+                            UnprimedPlugin)
 
 
 logger = logging.getLogger(__name__)
@@ -265,7 +266,8 @@ class PluginBase(ADBase, version=(1, 9, 1), version_type='ADCore'):
     nd_array_address = Cpt(SignalWithRBV, 'NDArrayAddress')
     nd_array_port = Cpt(SignalWithRBV, 'NDArrayPort', kind='config')
     ndimensions = Cpt(EpicsSignalRO, 'NDimensions_RBV')
-    plugin_type = Cpt(EpicsSignalRO, 'PluginType_RBV', lazy=False, kind='config')
+    plugin_type = Cpt(EpicsSignalRO, 'PluginType_RBV', lazy=False,
+                      kind='config')
 
     queue_free = Cpt(EpicsSignal, 'QueueFree')
     queue_free_low = Cpt(EpicsSignal, 'QueueFreeLow')
@@ -349,10 +351,14 @@ class StatsPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
         doc='The centroid XY',
     )
 
-    compute_centroid = Cpt(SignalWithRBV, 'ComputeCentroid', string=True, kind='config')
-    compute_histogram = Cpt(SignalWithRBV, 'ComputeHistogram', string=True, kind='config')
-    compute_profiles = Cpt(SignalWithRBV, 'ComputeProfiles', string=True, kind='config')
-    compute_statistics = Cpt(SignalWithRBV, 'ComputeStatistics', string=True, kind='config')
+    compute_centroid = Cpt(SignalWithRBV, 'ComputeCentroid', string=True,
+                           kind='config')
+    compute_histogram = Cpt(SignalWithRBV, 'ComputeHistogram', string=True,
+                            kind='config')
+    compute_profiles = Cpt(SignalWithRBV, 'ComputeProfiles', string=True,
+                           kind='config')
+    compute_statistics = Cpt(SignalWithRBV, 'ComputeStatistics', string=True,
+                             kind='config')
 
     cursor = DDC_SignalWithRBV(
         ('x', 'CursorX'),
@@ -483,18 +489,27 @@ class ProcessPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     _html_docs = ['NDPluginProcess.html']
     _plugin_type = 'NDPluginProcess'
 
-    auto_offset_scale = Cpt(EpicsSignal, 'AutoOffsetScale', string=True, kind='config')
-    auto_reset_filter = Cpt(SignalWithRBV, 'AutoResetFilter', string=True, kind='config')
+    auto_offset_scale = Cpt(EpicsSignal, 'AutoOffsetScale', string=True,
+                            kind='config')
+    auto_reset_filter = Cpt(SignalWithRBV, 'AutoResetFilter', string=True,
+                            kind='config')
     average_seq = Cpt(EpicsSignal, 'AverageSeq', kind='config')
     copy_to_filter_seq = Cpt(EpicsSignal, 'CopyToFilterSeq', kind='config')
-    data_type_out = Cpt(SignalWithRBV, 'DataTypeOut', string=True, kind='config')
+    data_type_out = Cpt(SignalWithRBV, 'DataTypeOut', string=True,
+                        kind='config')
     difference_seq = Cpt(EpicsSignal, 'DifferenceSeq', kind='config')
-    enable_background = Cpt(SignalWithRBV, 'EnableBackground', string=True, kind='config')
-    enable_filter = Cpt(SignalWithRBV, 'EnableFilter', string=True, kind='config')
-    enable_flat_field = Cpt(SignalWithRBV, 'EnableFlatField', string=True, kind='config')
-    enable_high_clip = Cpt(SignalWithRBV, 'EnableHighClip', string=True, kind='config')
-    enable_low_clip = Cpt(SignalWithRBV, 'EnableLowClip', string=True, kind='config')
-    enable_offset_scale = Cpt(SignalWithRBV, 'EnableOffsetScale', string=True, kind='config')
+    enable_background = Cpt(SignalWithRBV, 'EnableBackground', string=True,
+                            kind='config')
+    enable_filter = Cpt(SignalWithRBV, 'EnableFilter', string=True,
+                        kind='config')
+    enable_flat_field = Cpt(SignalWithRBV, 'EnableFlatField', string=True,
+                            kind='config')
+    enable_high_clip = Cpt(SignalWithRBV, 'EnableHighClip', string=True,
+                           kind='config')
+    enable_low_clip = Cpt(SignalWithRBV, 'EnableLowClip', string=True,
+                          kind='config')
+    enable_offset_scale = Cpt(SignalWithRBV, 'EnableOffsetScale', string=True,
+                              kind='config')
 
     fc = DDC_SignalWithRBV(
         ('fc1', 'FC1'),
@@ -507,7 +522,8 @@ class ProcessPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
 
     foffset = Cpt(SignalWithRBV, 'FOffset', kind='config')
     fscale = Cpt(SignalWithRBV, 'FScale', kind='config')
-    filter_callbacks = Cpt(SignalWithRBV, 'FilterCallbacks', string=True, kind='config')
+    filter_callbacks = Cpt(SignalWithRBV, 'FilterCallbacks', string=True,
+                           kind='config')
     filter_type = Cpt(EpicsSignal, 'FilterType', string=True, kind='config')
     filter_type_seq = Cpt(EpicsSignal, 'FilterTypeSeq', kind='config')
     high_clip = Cpt(SignalWithRBV, 'HighClip', kind='config')
@@ -537,7 +553,8 @@ class ProcessPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     )
 
     roffset = Cpt(SignalWithRBV, 'ROffset', kind='config')
-    recursive_ave_diff_seq = Cpt(EpicsSignal, 'RecursiveAveDiffSeq', kind='config')
+    recursive_ave_diff_seq = Cpt(EpicsSignal, 'RecursiveAveDiffSeq',
+                                 kind='config')
     recursive_ave_seq = Cpt(EpicsSignal, 'RecursiveAveSeq', kind='config')
     reset_filter = Cpt(SignalWithRBV, 'ResetFilter', kind='config')
     save_background = Cpt(SignalWithRBV, 'SaveBackground', kind='config')
@@ -545,8 +562,10 @@ class ProcessPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     scale = Cpt(SignalWithRBV, 'Scale', kind='config')
     scale_flat_field = Cpt(SignalWithRBV, 'ScaleFlatField', kind='config')
     sum_seq = Cpt(EpicsSignal, 'SumSeq', kind='config')
-    valid_background = Cpt(EpicsSignalRO, 'ValidBackground_RBV', string=True, kind='config')
-    valid_flat_field = Cpt(EpicsSignalRO, 'ValidFlatField_RBV', string=True, kind='config')
+    valid_background = Cpt(EpicsSignalRO, 'ValidBackground_RBV', string=True,
+                           kind='config')
+    valid_flat_field = Cpt(EpicsSignalRO, 'ValidFlatField_RBV', string=True,
+                           kind='config')
 
 
 class Overlay(ADBase, version=(1, 9, 1), version_type='ADCore'):
@@ -639,8 +658,10 @@ class ROIPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
         kind='config',
     )
 
-    data_type_out = Cpt(SignalWithRBV, 'DataTypeOut', string=True, kind='config')
-    enable_scale = Cpt(SignalWithRBV, 'EnableScale', string=True, kind='config')
+    data_type_out = Cpt(SignalWithRBV, 'DataTypeOut', string=True,
+                        kind='config')
+    enable_scale = Cpt(SignalWithRBV, 'EnableScale', string=True,
+                       kind='config')
 
     roi_enable = DDC_SignalWithRBV(
         ('x', 'EnableX'),
@@ -776,7 +797,8 @@ class TransformPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     )
 
 
-class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_type='ADCore'):
+class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1),
+                 version_type='ADCore'):
     _default_suffix = ''
     _html_docs = ['NDPluginFile.html']
     _plugin_type = 'NDPluginFile'
@@ -793,9 +815,11 @@ class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_
     file_number_write = Cpt(EpicsSignal, 'FileNumber_write')
     file_path = Cpt(SignalWithRBV, 'FilePath', string=True, kind='config')
     file_path_exists = Cpt(EpicsSignalRO, 'FilePathExists_RBV', kind='config')
-    file_template = Cpt(SignalWithRBV, 'FileTemplate', string=True, kind='config')
+    file_template = Cpt(SignalWithRBV, 'FileTemplate', string=True,
+                        kind='config')
     file_write_mode = Cpt(SignalWithRBV, 'FileWriteMode', kind='config')
-    full_file_name = Cpt(EpicsSignalRO, 'FullFileName_RBV', string=True, kind='config')
+    full_file_name = Cpt(EpicsSignalRO, 'FullFileName_RBV', string=True,
+                         kind='config')
     num_capture = Cpt(SignalWithRBV, 'NumCapture', kind='config')
     num_captured = Cpt(EpicsSignalRO, 'NumCaptured_RBV')
     read_file = Cpt(SignalWithRBV, 'ReadFile')
@@ -839,8 +863,10 @@ class NexusPlugin(FilePlugin, version=(1, 9, 1), version_type='ADCore'):
     _plugin_type = 'NDPluginNexus'
 
     file_template_valid = Cpt(EpicsSignal, 'FileTemplateValid')
-    template_file_name = Cpt(SignalWithRBV, 'TemplateFileName', string=True, kind='config')
-    template_file_path = Cpt(SignalWithRBV, 'TemplateFilePath', string=True, kind='config')
+    template_file_name = Cpt(SignalWithRBV, 'TemplateFileName', string=True,
+                             kind='config')
+    template_file_path = Cpt(SignalWithRBV, 'TemplateFilePath', string=True,
+                             kind='config')
 
 
 @register_plugin
@@ -897,7 +923,7 @@ class HDF5Plugin(FilePlugin, version=(1, 9, 1), version_type='ADCore'):
         sigs = OrderedDict([(self.parent.cam.array_callbacks, 1),
                             (self.parent.cam.image_mode, 'Single'),
                             (self.parent.cam.trigger_mode, 'Internal'),
-                            # just in case tha acquisition time is set very long...
+                            # just in case tha acquis. time is set very long...
                             (self.parent.cam.acquire_time, 1),
                             (self.parent.cam.acquire_period, 1),
                             (self.parent.cam.acquire, 1)])
@@ -943,7 +969,8 @@ class PluginBase_V20(PluginBase, version=(2, 0), version_of=PluginBase):
 
 class PluginBase_V22(PluginBase_V20, version=(2, 2), version_of=PluginBase):
     ad_core_version = Cpt(EpicsSignalRO, "ADCoreVersion_RBV", string=True)
-    array_callbacks = Cpt(SignalWithRBV, "ArrayCallbacks", string=True, doc="0='Disable' 1='Enable'")
+    array_callbacks = Cpt(SignalWithRBV, "ArrayCallbacks", string=True,
+                          doc="0='Disable' 1='Enable'")
     array_size_int = Cpt(EpicsSignalRO, "ArraySize_RBV")
     color_mode = Cpt(
         SignalWithRBV, "ColorMode", string=True,
@@ -951,7 +978,8 @@ class PluginBase_V22(PluginBase_V20, version=(2, 2), version_of=PluginBase):
     )
     data_type = Cpt(
         SignalWithRBV, "DataType", string=True,
-        doc="0=Int8 1=UInt8 2=Int16 3=UInt16 4=Int32 5=UInt32 6=Float32 7=Float64",
+        doc="0=Int8 1=UInt8 2=Int16 3=UInt16 4=Int32 5=UInt32"
+            "6=Float32 7=Float64",
     )
     array_size_xyz = DDC_EpicsSignalRO(
         ("array_size_x", "ArraySizeX_RBV"),
@@ -1004,7 +1032,8 @@ class PluginBase_V31(PluginBase_V26, version=(3, 1), version_of=PluginBase):
     nd_attributes_macros = Cpt(EpicsSignal, "NDAttributesMacros")
     nd_attributes_status = Cpt(
         EpicsSignal, "NDAttributesStatus", string=True,
-        doc="0='Attributes file OK' 1='File not found' 2='XML syntax error' 3='Macro substitution error'",
+        doc="0='Attributes file OK' 1='File not found' 2='XML syntax error'"
+            " 3='Macro substitution error'",
     )
     num_threads = Cpt(SignalWithRBV, "NumThreads")
     process_plugin = Cpt(EpicsSignal, "ProcessPlugin", string=True)
@@ -1031,15 +1060,18 @@ class PluginBase_V34(PluginBase_V33, version=(3, 4), version_of=PluginBase):
 
 # --- NDFile ---
 
-class FilePlugin_V20(PluginBase_V20, FilePlugin, version=(2, 0), version_of=FilePlugin):
+class FilePlugin_V20(PluginBase_V20, FilePlugin, version=(2, 0),
+                     version_of=FilePlugin):
     ...
 
 
 class FilePlugin_V21(FilePlugin_V20, version=(2, 1), version_of=FilePlugin):
-    lazy_open = Cpt(SignalWithRBV, "LazyOpen", string=True, doc="0='No' 1='Yes'")
+    lazy_open = Cpt(SignalWithRBV, "LazyOpen", string=True,
+                    doc="0='No' 1='Yes'")
 
 
-class FilePlugin_V22(PluginBase_V22, FilePlugin_V21, version=(2, 2), version_of=FilePlugin):
+class FilePlugin_V22(PluginBase_V22, FilePlugin_V21, version=(2, 2),
+                     version_of=FilePlugin):
     create_directory = Cpt(SignalWithRBV, "CreateDirectory")
     file_number = Cpt(SignalWithRBV, "FileNumber")
     file_number_sync = None  # REMOVED
@@ -1047,73 +1079,90 @@ class FilePlugin_V22(PluginBase_V22, FilePlugin_V21, version=(2, 2), version_of=
     temp_suffix = Cpt(SignalWithRBV, "TempSuffix", string=True)
 
 
-class FilePlugin_V25(PluginBase_V25, FilePlugin_V22, version=(2, 5), version_of=FilePlugin):
+class FilePlugin_V25(PluginBase_V25, FilePlugin_V22, version=(2, 5),
+                     version_of=FilePlugin):
     ...
 
 
-class FilePlugin_V26(PluginBase_V26, FilePlugin_V25, version=(2, 6), version_of=FilePlugin):
+class FilePlugin_V26(PluginBase_V26, FilePlugin_V25, version=(2, 6),
+                     version_of=FilePlugin):
     ...
 
 
-class FilePlugin_V31(PluginBase_V31, FilePlugin_V26, version=(3, 1), version_of=FilePlugin):
+class FilePlugin_V31(PluginBase_V31, FilePlugin_V26, version=(3, 1),
+                     version_of=FilePlugin):
     ...
 
 
-class FilePlugin_V33(PluginBase_V33, FilePlugin_V31, version=(3, 3), version_of=FilePlugin):
+class FilePlugin_V33(PluginBase_V33, FilePlugin_V31, version=(3, 3),
+                     version_of=FilePlugin):
     ...
 
 
-class FilePlugin_V34(PluginBase_V34, FilePlugin_V33, version=(3, 4), version_of=FilePlugin):
+class FilePlugin_V34(PluginBase_V34, FilePlugin_V33, version=(3, 4),
+                     version_of=FilePlugin):
     ...
 
 
 # --- ColorConvPlugin ---
 
-class ColorConvPlugin_V20(PluginBase_V20, ColorConvPlugin, version=(2, 0), version_of=ColorConvPlugin):
+class ColorConvPlugin_V20(PluginBase_V20, ColorConvPlugin, version=(2, 0),
+                          version_of=ColorConvPlugin):
     ...
 
 
-class ColorConvPlugin_V22(PluginBase_V22, ColorConvPlugin_V20, version=(2, 2), version_of=ColorConvPlugin):
+class ColorConvPlugin_V22(PluginBase_V22, ColorConvPlugin_V20, version=(2, 2),
+                          version_of=ColorConvPlugin):
     ...
 
 
-class ColorConvPlugin_V25(PluginBase_V25, ColorConvPlugin_V22, version=(2, 5), version_of=ColorConvPlugin):
+class ColorConvPlugin_V25(PluginBase_V25, ColorConvPlugin_V22, version=(2, 5),
+                          version_of=ColorConvPlugin):
     ...
 
 
-class ColorConvPlugin_V26(PluginBase_V26, ColorConvPlugin_V25, version=(2, 6), version_of=ColorConvPlugin):
+class ColorConvPlugin_V26(PluginBase_V26, ColorConvPlugin_V25, version=(2, 6),
+                          version_of=ColorConvPlugin):
     ...
 
 
-class ColorConvPlugin_V31(PluginBase_V31, ColorConvPlugin_V26, version=(3, 1), version_of=ColorConvPlugin):
+class ColorConvPlugin_V31(PluginBase_V31, ColorConvPlugin_V26, version=(3, 1),
+                          version_of=ColorConvPlugin):
     ...
 
 
-class ColorConvPlugin_V33(PluginBase_V33, ColorConvPlugin_V31, version=(3, 3), version_of=ColorConvPlugin):
+class ColorConvPlugin_V33(PluginBase_V33, ColorConvPlugin_V31, version=(3, 3),
+                          version_of=ColorConvPlugin):
     ...
 
 
-class ColorConvPlugin_V34(PluginBase_V34, ColorConvPlugin_V33, version=(3, 4), version_of=ColorConvPlugin):
+class ColorConvPlugin_V34(PluginBase_V34, ColorConvPlugin_V33, version=(3, 4),
+                          version_of=ColorConvPlugin):
     ...
 
 
 # --- NDFileHDF5 ---
 
-class HDF5Plugin_V20(FilePlugin_V20, HDF5Plugin, version=(2, 0), version_of=HDF5Plugin):
+class HDF5Plugin_V20(FilePlugin_V20, HDF5Plugin, version=(2, 0),
+                     version_of=HDF5Plugin):
     ...
 
 
-class HDF5Plugin_V21(FilePlugin_V21, HDF5Plugin_V20, version=(2, 1), version_of=HDF5Plugin):
+class HDF5Plugin_V21(FilePlugin_V21, HDF5Plugin_V20, version=(2, 1),
+                     version_of=HDF5Plugin):
     xml_error_msg = Cpt(EpicsSignalRO, "XMLErrorMsg_RBV")
     xml_file_name = Cpt(SignalWithRBV, "XMLFileName")
-    xml_valid = Cpt(EpicsSignalRO, "XMLValid_RBV", string=True, doc="0='No' 1='Yes'")
+    xml_valid = Cpt(EpicsSignalRO, "XMLValid_RBV", string=True,
+                    doc="0='No' 1='Yes'")
 
 
-class HDF5Plugin_V22(FilePlugin_V22, HDF5Plugin_V21, version=(2, 2), version_of=HDF5Plugin):
+class HDF5Plugin_V22(FilePlugin_V22, HDF5Plugin_V21, version=(2, 2),
+                     version_of=HDF5Plugin):
     nd_attribute_chunk = Cpt(SignalWithRBV, "NDAttributeChunk")
 
 
-class HDF5Plugin_V25(FilePlugin_V25, HDF5Plugin_V22, version=(2, 5), version_of=HDF5Plugin):
+class HDF5Plugin_V25(FilePlugin_V25, HDF5Plugin_V22, version=(2, 5),
+                     version_of=HDF5Plugin):
     dim_att_datasets = Cpt(SignalWithRBV, "DimAttDatasets", string=True,
                            doc="0='No' 1='Yes'")
     fill_value = Cpt(SignalWithRBV, "FillValue")
@@ -1194,17 +1243,20 @@ class HDF5Plugin_V25(FilePlugin_V25, HDF5Plugin_V22, version=(2, 5), version_of=
     )
 
 
-class HDF5Plugin_V26(FilePlugin_V26, HDF5Plugin_V25, version=(2, 6), version_of=HDF5Plugin):
+class HDF5Plugin_V26(FilePlugin_V26, HDF5Plugin_V25, version=(2, 6),
+                     version_of=HDF5Plugin):
     ...
 
 
-class HDF5Plugin_V31(FilePlugin_V31, HDF5Plugin_V26, version=(3, 1), version_of=HDF5Plugin):
+class HDF5Plugin_V31(FilePlugin_V31, HDF5Plugin_V26, version=(3, 1),
+                     version_of=HDF5Plugin):
     ...
 
 
 class HDF5Plugin_V32(HDF5Plugin_V31, version=(3, 2), version_of=HDF5Plugin):
-    blosc_compressor = Cpt(SignalWithRBV, "BloscCompressor", string=True,
-                           doc="0=blosclz 1=lz4 2=lz4hc 3=snappy 4=zlib 5=zstd")
+    blosc_compressor = Cpt(
+        SignalWithRBV, "BloscCompressor", string=True,
+        doc="0=blosclz 1=lz4 2=lz4hc 3=snappy 4=zlib 5=zstd")
     blosc_level = Cpt(SignalWithRBV, "BloscLevel")
     blosc_shuffle = Cpt(SignalWithRBV, "BloscShuffle", string=True,
                         doc="0=None 1=ByteShuffle 2=BitShuffle")
@@ -1212,182 +1264,224 @@ class HDF5Plugin_V32(HDF5Plugin_V31, version=(3, 2), version_of=HDF5Plugin):
                       doc="0=None 1=N-bit 2=szip 3=zlib 4=blosc")
 
 
-class HDF5Plugin_V33(FilePlugin_V33, HDF5Plugin_V32, version=(3, 3), version_of=HDF5Plugin):
+class HDF5Plugin_V33(FilePlugin_V33, HDF5Plugin_V32, version=(3, 3),
+                     version_of=HDF5Plugin):
     ...
 
 
-class HDF5Plugin_V34(FilePlugin_V34, HDF5Plugin_V33, version=(3, 4), version_of=HDF5Plugin):
+class HDF5Plugin_V34(FilePlugin_V34, HDF5Plugin_V33, version=(3, 4),
+                     version_of=HDF5Plugin):
     ...
 
 
 # --- NDStdArrays ---
 
 
-class ImagePlugin_V20(PluginBase_V20, ImagePlugin, version=(2, 0), version_of=ImagePlugin):
+class ImagePlugin_V20(PluginBase_V20, ImagePlugin, version=(2, 0),
+                      version_of=ImagePlugin):
     ...
 
 
-class ImagePlugin_V22(PluginBase_V22, ImagePlugin_V20, version=(2, 2), version_of=ImagePlugin):
+class ImagePlugin_V22(PluginBase_V22, ImagePlugin_V20, version=(2, 2),
+                      version_of=ImagePlugin):
     ...
 
 
-class ImagePlugin_V25(PluginBase_V25, ImagePlugin_V22, version=(2, 5), version_of=ImagePlugin):
+class ImagePlugin_V25(PluginBase_V25, ImagePlugin_V22, version=(2, 5),
+                      version_of=ImagePlugin):
     ...
 
 
-class ImagePlugin_V26(PluginBase_V26, ImagePlugin_V25, version=(2, 6), version_of=ImagePlugin):
+class ImagePlugin_V26(PluginBase_V26, ImagePlugin_V25, version=(2, 6),
+                      version_of=ImagePlugin):
     ...
 
 
-class ImagePlugin_V31(PluginBase_V31, ImagePlugin_V26, version=(3, 1), version_of=ImagePlugin):
+class ImagePlugin_V31(PluginBase_V31, ImagePlugin_V26, version=(3, 1),
+                      version_of=ImagePlugin):
     ...
 
 
-class ImagePlugin_V33(PluginBase_V33, ImagePlugin_V31, version=(3, 3), version_of=ImagePlugin):
+class ImagePlugin_V33(PluginBase_V33, ImagePlugin_V31, version=(3, 3),
+                      version_of=ImagePlugin):
     ...
 
 
-class ImagePlugin_V34(PluginBase_V34, ImagePlugin_V33, version=(3, 4), version_of=ImagePlugin):
+class ImagePlugin_V34(PluginBase_V34, ImagePlugin_V33, version=(3, 4),
+                      version_of=ImagePlugin):
     ...
 
 
 # --- NDFileJPEG ---
 
 
-class JPEGPlugin_V20(FilePlugin_V20, JPEGPlugin, version=(2, 0), version_of=JPEGPlugin):
+class JPEGPlugin_V20(FilePlugin_V20, JPEGPlugin, version=(2, 0),
+                     version_of=JPEGPlugin):
     ...
 
 
-class JPEGPlugin_V21(FilePlugin_V21, JPEGPlugin_V20, version=(2, 1), version_of=JPEGPlugin):
+class JPEGPlugin_V21(FilePlugin_V21, JPEGPlugin_V20, version=(2, 1),
+                     version_of=JPEGPlugin):
     ...
 
 
-class JPEGPlugin_V22(FilePlugin_V22, JPEGPlugin_V21, version=(2, 2), version_of=JPEGPlugin):
+class JPEGPlugin_V22(FilePlugin_V22, JPEGPlugin_V21, version=(2, 2),
+                     version_of=JPEGPlugin):
     ...
 
 
-class JPEGPlugin_V25(FilePlugin_V25, JPEGPlugin_V22, version=(2, 5), version_of=JPEGPlugin):
+class JPEGPlugin_V25(FilePlugin_V25, JPEGPlugin_V22, version=(2, 5),
+                     version_of=JPEGPlugin):
     ...
 
 
-class JPEGPlugin_V26(FilePlugin_V26, JPEGPlugin_V25, version=(2, 6), version_of=JPEGPlugin):
+class JPEGPlugin_V26(FilePlugin_V26, JPEGPlugin_V25, version=(2, 6),
+                     version_of=JPEGPlugin):
     ...
 
 
-class JPEGPlugin_V31(FilePlugin_V31, JPEGPlugin_V26, version=(3, 1), version_of=JPEGPlugin):
+class JPEGPlugin_V31(FilePlugin_V31, JPEGPlugin_V26, version=(3, 1),
+                     version_of=JPEGPlugin):
     ...
 
 
-class JPEGPlugin_V33(FilePlugin_V33, JPEGPlugin_V31, version=(3, 3), version_of=JPEGPlugin):
+class JPEGPlugin_V33(FilePlugin_V33, JPEGPlugin_V31, version=(3, 3),
+                     version_of=JPEGPlugin):
     ...
 
 
-class JPEGPlugin_V34(FilePlugin_V34, JPEGPlugin_V33, version=(3, 4), version_of=JPEGPlugin):
+class JPEGPlugin_V34(FilePlugin_V34, JPEGPlugin_V33, version=(3, 4),
+                     version_of=JPEGPlugin):
     ...
 
 
 # --- NDFileMagick ---
 
 
-class MagickPlugin_V20(FilePlugin_V20, MagickPlugin, version=(2, 0), version_of=MagickPlugin):
+class MagickPlugin_V20(FilePlugin_V20, MagickPlugin, version=(2, 0),
+                       version_of=MagickPlugin):
     ...
 
 
-class MagickPlugin_V21(FilePlugin_V21, MagickPlugin_V20, version=(2, 1), version_of=MagickPlugin):
+class MagickPlugin_V21(FilePlugin_V21, MagickPlugin_V20, version=(2, 1),
+                       version_of=MagickPlugin):
     ...
 
 
-class MagickPlugin_V22(FilePlugin_V22, MagickPlugin_V21, version=(2, 2), version_of=MagickPlugin):
+class MagickPlugin_V22(FilePlugin_V22, MagickPlugin_V21, version=(2, 2),
+                       version_of=MagickPlugin):
     ...
 
 
-class MagickPlugin_V25(FilePlugin_V25, MagickPlugin_V22, version=(2, 5), version_of=MagickPlugin):
+class MagickPlugin_V25(FilePlugin_V25, MagickPlugin_V22, version=(2, 5),
+                       version_of=MagickPlugin):
     ...
 
 
-class MagickPlugin_V26(FilePlugin_V26, MagickPlugin_V25, version=(2, 6), version_of=MagickPlugin):
+class MagickPlugin_V26(FilePlugin_V26, MagickPlugin_V25, version=(2, 6),
+                       version_of=MagickPlugin):
     ...
 
 
-class MagickPlugin_V31(FilePlugin_V31, MagickPlugin_V26, version=(3, 1), version_of=MagickPlugin):
-    bit_depth = Cpt(SignalWithRBV, 'BitDepth', string=True, doc="1=1 8=8 16=16 32=32")
+class MagickPlugin_V31(FilePlugin_V31, MagickPlugin_V26, version=(3, 1),
+                       version_of=MagickPlugin):
+    bit_depth = Cpt(SignalWithRBV, 'BitDepth', string=True,
+                    doc="1=1 8=8 16=16 32=32")
 
 
-class MagickPlugin_V33(FilePlugin_V33, MagickPlugin_V31, version=(3, 3), version_of=MagickPlugin):
+class MagickPlugin_V33(FilePlugin_V33, MagickPlugin_V31, version=(3, 3),
+                       version_of=MagickPlugin):
     ...
 
 
-class MagickPlugin_V34(FilePlugin_V34, MagickPlugin_V33, version=(3, 4), version_of=MagickPlugin):
+class MagickPlugin_V34(FilePlugin_V34, MagickPlugin_V33, version=(3, 4),
+                       version_of=MagickPlugin):
     ...
 
 
 # --- NDFileNetCDF ---
 
 
-class NetCDFPlugin_V20(FilePlugin_V20, NetCDFPlugin, version=(2, 0), version_of=NetCDFPlugin):
+class NetCDFPlugin_V20(FilePlugin_V20, NetCDFPlugin, version=(2, 0),
+                       version_of=NetCDFPlugin):
     ...
 
 
-class NetCDFPlugin_V21(FilePlugin_V21, NetCDFPlugin_V20, version=(2, 1), version_of=NetCDFPlugin):
+class NetCDFPlugin_V21(FilePlugin_V21, NetCDFPlugin_V20, version=(2, 1),
+                       version_of=NetCDFPlugin):
     ...
 
 
-class NetCDFPlugin_V22(FilePlugin_V22, NetCDFPlugin_V21, version=(2, 2), version_of=NetCDFPlugin):
+class NetCDFPlugin_V22(FilePlugin_V22, NetCDFPlugin_V21, version=(2, 2),
+                       version_of=NetCDFPlugin):
     ...
 
 
-class NetCDFPlugin_V25(FilePlugin_V25, NetCDFPlugin_V22, version=(2, 5), version_of=NetCDFPlugin):
+class NetCDFPlugin_V25(FilePlugin_V25, NetCDFPlugin_V22, version=(2, 5),
+                       version_of=NetCDFPlugin):
     ...
 
 
-class NetCDFPlugin_V26(FilePlugin_V26, NetCDFPlugin_V25, version=(2, 6), version_of=NetCDFPlugin):
+class NetCDFPlugin_V26(FilePlugin_V26, NetCDFPlugin_V25, version=(2, 6),
+                       version_of=NetCDFPlugin):
     ...
 
 
-class NetCDFPlugin_V31(FilePlugin_V31, NetCDFPlugin_V26, version=(3, 1), version_of=NetCDFPlugin):
+class NetCDFPlugin_V31(FilePlugin_V31, NetCDFPlugin_V26, version=(3, 1),
+                       version_of=NetCDFPlugin):
     ...
 
 
-class NetCDFPlugin_V33(FilePlugin_V33, NetCDFPlugin_V31, version=(3, 3), version_of=NetCDFPlugin):
+class NetCDFPlugin_V33(FilePlugin_V33, NetCDFPlugin_V31, version=(3, 3),
+                       version_of=NetCDFPlugin):
     ...
 
 
-class NetCDFPlugin_V34(FilePlugin_V34, NetCDFPlugin_V33, version=(3, 4), version_of=NetCDFPlugin):
+class NetCDFPlugin_V34(FilePlugin_V34, NetCDFPlugin_V33, version=(3, 4),
+                       version_of=NetCDFPlugin):
     ...
 
 
 # --- NDFileNexus ---
 
 
-class NexusPlugin_V20(FilePlugin_V20, NexusPlugin, version=(2, 0), version_of=NexusPlugin):
+class NexusPlugin_V20(FilePlugin_V20, NexusPlugin, version=(2, 0),
+                      version_of=NexusPlugin):
     ...
 
 
-class NexusPlugin_V21(FilePlugin_V21, NexusPlugin_V20, version=(2, 1), version_of=NexusPlugin):
+class NexusPlugin_V21(FilePlugin_V21, NexusPlugin_V20, version=(2, 1),
+                      version_of=NexusPlugin):
     ...
 
 
-class NexusPlugin_V22(FilePlugin_V22, NexusPlugin_V21, version=(2, 2), version_of=NexusPlugin):
+class NexusPlugin_V22(FilePlugin_V22, NexusPlugin_V21, version=(2, 2),
+                      version_of=NexusPlugin):
     ...
 
 
-class NexusPlugin_V25(FilePlugin_V25, NexusPlugin_V22, version=(2, 5), version_of=NexusPlugin):
+class NexusPlugin_V25(FilePlugin_V25, NexusPlugin_V22, version=(2, 5),
+                      version_of=NexusPlugin):
     ...
 
 
-class NexusPlugin_V26(FilePlugin_V26, NexusPlugin_V25, version=(2, 6), version_of=NexusPlugin):
+class NexusPlugin_V26(FilePlugin_V26, NexusPlugin_V25, version=(2, 6),
+                      version_of=NexusPlugin):
     ...
 
 
-class NexusPlugin_V31(FilePlugin_V31, NexusPlugin_V26, version=(3, 1), version_of=NexusPlugin):
+class NexusPlugin_V31(FilePlugin_V31, NexusPlugin_V26, version=(3, 1),
+                      version_of=NexusPlugin):
     ...
 
 
-class NexusPlugin_V33(FilePlugin_V33, NexusPlugin_V31, version=(3, 3), version_of=NexusPlugin):
+class NexusPlugin_V33(FilePlugin_V33, NexusPlugin_V31, version=(3, 3),
+                      version_of=NexusPlugin):
     ...
 
 
-class NexusPlugin_V34(FilePlugin_V34, NexusPlugin_V33, version=(3, 4), version_of=NexusPlugin):
+class NexusPlugin_V34(FilePlugin_V34, NexusPlugin_V33, version=(3, 4),
+                      version_of=NexusPlugin):
     ...
 
 
@@ -1414,7 +1508,8 @@ class Overlay_V21(Overlay, version=(2, 1), version_of=Overlay):
 
 
 class Overlay_V26(Overlay_V21, version=(2, 6), version_of=Overlay):
-    shape = Cpt(SignalWithRBV, 'Shape', string=True, doc="0=Cross 1=Rectangle 2=Text 3=Ellipse ")
+    shape = Cpt(SignalWithRBV, 'Shape', string=True,
+                doc="0=Cross 1=Rectangle 2=Text 3=Ellipse ")
     center = DDC_SignalWithRBV(
         ("x", "CenterX"),
         ("y", "CenterY"),
@@ -1444,71 +1539,86 @@ class Overlay_V31(Overlay_V26, version=(3, 1), version_of=Overlay):
 # --- NDOverlay ---
 
 
-class OverlayPlugin_V20(PluginBase_V20, OverlayPlugin, version=(2, 0), version_of=OverlayPlugin):
+class OverlayPlugin_V20(PluginBase_V20, OverlayPlugin, version=(2, 0),
+                        version_of=OverlayPlugin):
     ...
 
 
-class OverlayPlugin_V22(PluginBase_V22, OverlayPlugin_V20, version=(2, 2), version_of=OverlayPlugin):
+class OverlayPlugin_V22(PluginBase_V22, OverlayPlugin_V20, version=(2, 2),
+                        version_of=OverlayPlugin):
     ...
 
 
-class OverlayPlugin_V25(PluginBase_V25, OverlayPlugin_V22, version=(2, 5), version_of=OverlayPlugin):
+class OverlayPlugin_V25(PluginBase_V25, OverlayPlugin_V22, version=(2, 5),
+                        version_of=OverlayPlugin):
     ...
 
 
-class OverlayPlugin_V26(PluginBase_V26, OverlayPlugin_V25, version=(2, 6), version_of=OverlayPlugin):
+class OverlayPlugin_V26(PluginBase_V26, OverlayPlugin_V25, version=(2, 6),
+                        version_of=OverlayPlugin):
     ...
 
 
-class OverlayPlugin_V31(PluginBase_V31, OverlayPlugin_V26, version=(3, 1), version_of=OverlayPlugin):
+class OverlayPlugin_V31(PluginBase_V31, OverlayPlugin_V26, version=(3, 1),
+                        version_of=OverlayPlugin):
     ...
 
 
-class OverlayPlugin_V33(PluginBase_V33, OverlayPlugin_V31, version=(3, 3), version_of=OverlayPlugin):
+class OverlayPlugin_V33(PluginBase_V33, OverlayPlugin_V31, version=(3, 3),
+                        version_of=OverlayPlugin):
     ...
 
 
-class OverlayPlugin_V34(PluginBase_V34, OverlayPlugin_V33, version=(3, 4), version_of=OverlayPlugin):
+class OverlayPlugin_V34(PluginBase_V34, OverlayPlugin_V33, version=(3, 4),
+                        version_of=OverlayPlugin):
     ...
 
 
 # --- NDProcess ---
 
 
-class ProcessPlugin_V20(PluginBase_V20, ProcessPlugin, version=(2, 0), version_of=ProcessPlugin):
+class ProcessPlugin_V20(PluginBase_V20, ProcessPlugin, version=(2, 0),
+                        version_of=ProcessPlugin):
     ...
 
 
-class ProcessPlugin_V22(PluginBase_V22, ProcessPlugin_V20, version=(2, 2), version_of=ProcessPlugin):
+class ProcessPlugin_V22(PluginBase_V22, ProcessPlugin_V20, version=(2, 2),
+                        version_of=ProcessPlugin):
     ...
 
 
-class ProcessPlugin_V25(PluginBase_V25, ProcessPlugin_V22, version=(2, 5), version_of=ProcessPlugin):
+class ProcessPlugin_V25(PluginBase_V25, ProcessPlugin_V22, version=(2, 5),
+                        version_of=ProcessPlugin):
     ...
 
 
-class ProcessPlugin_V26(PluginBase_V26, ProcessPlugin_V25, version=(2, 6), version_of=ProcessPlugin):
+class ProcessPlugin_V26(PluginBase_V26, ProcessPlugin_V25, version=(2, 6),
+                        version_of=ProcessPlugin):
     ...
 
 
-class ProcessPlugin_V31(PluginBase_V31, ProcessPlugin_V26, version=(3, 1), version_of=ProcessPlugin):
+class ProcessPlugin_V31(PluginBase_V31, ProcessPlugin_V26, version=(3, 1),
+                        version_of=ProcessPlugin):
     ...
 
 
-class ProcessPlugin_V33(PluginBase_V33, ProcessPlugin_V31, version=(3, 3), version_of=ProcessPlugin):
+class ProcessPlugin_V33(PluginBase_V33, ProcessPlugin_V31, version=(3, 3),
+                        version_of=ProcessPlugin):
     port_backup = Cpt(EpicsSignal, "PortBackup", string=True)
     read_background_tiff_seq = Cpt(EpicsSignal, "ReadBackgroundTIFFSeq")
     read_flat_field_tiff_seq = Cpt(EpicsSignal, "ReadFlatFieldTIFFSeq")
 
 
-class ProcessPlugin_V34(PluginBase_V34, ProcessPlugin_V33, version=(3, 4), version_of=ProcessPlugin):
+class ProcessPlugin_V34(PluginBase_V34, ProcessPlugin_V33, version=(3, 4),
+                        version_of=ProcessPlugin):
     ...
 
 
 # --- NDROI ---
 
 
-class ROIPlugin_V20(PluginBase_V20, ROIPlugin, version=(2, 0), version_of=ROIPlugin):
+class ROIPlugin_V20(PluginBase_V20, ROIPlugin, version=(2, 0),
+                    version_of=ROIPlugin):
     array_size_xyz = DDC_EpicsSignalRO(
         ("x", "ArraySizeX_RBV"),
         ("y", "ArraySizeY_RBV"),
@@ -1521,27 +1631,34 @@ class ROIPlugin_V20(PluginBase_V20, ROIPlugin, version=(2, 0), version_of=ROIPlu
     )
 
 
-class ROIPlugin_V22(PluginBase_V22, ROIPlugin_V20, version=(2, 2), version_of=ROIPlugin):
+class ROIPlugin_V22(PluginBase_V22, ROIPlugin_V20, version=(2, 2),
+                    version_of=ROIPlugin):
     ...
 
 
-class ROIPlugin_V25(PluginBase_V25, ROIPlugin_V22, version=(2, 5), version_of=ROIPlugin):
+class ROIPlugin_V25(PluginBase_V25, ROIPlugin_V22, version=(2, 5),
+                    version_of=ROIPlugin):
     ...
 
 
-class ROIPlugin_V26(PluginBase_V26, ROIPlugin_V25, version=(2, 6), version_of=ROIPlugin):
-    collapse_dims = Cpt(SignalWithRBV, "CollapseDims", string=True, doc="0='Disable' 1='Enable'")
+class ROIPlugin_V26(PluginBase_V26, ROIPlugin_V25, version=(2, 6),
+                    version_of=ROIPlugin):
+    collapse_dims = Cpt(SignalWithRBV, "CollapseDims", string=True,
+                        doc="0='Disable' 1='Enable'")
 
 
-class ROIPlugin_V31(PluginBase_V31, ROIPlugin_V26, version=(3, 1), version_of=ROIPlugin):
+class ROIPlugin_V31(PluginBase_V31, ROIPlugin_V26, version=(3, 1),
+                    version_of=ROIPlugin):
     ...
 
 
-class ROIPlugin_V33(PluginBase_V33, ROIPlugin_V31, version=(3, 3), version_of=ROIPlugin):
+class ROIPlugin_V33(PluginBase_V33, ROIPlugin_V31, version=(3, 3),
+                    version_of=ROIPlugin):
     ...
 
 
-class ROIPlugin_V34(PluginBase_V34, ROIPlugin_V33, version=(3, 4), version_of=ROIPlugin):
+class ROIPlugin_V34(PluginBase_V34, ROIPlugin_V33, version=(3, 4),
+                    version_of=ROIPlugin):
     ...
 
 
@@ -1556,35 +1673,44 @@ class ROIStatPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginROIStat'
 
 
-class ROIStatPlugin_V22(PluginBase_V22, ROIStatPlugin, version=(2, 2), version_of=ROIStatPlugin):
+class ROIStatPlugin_V22(PluginBase_V22, ROIStatPlugin, version=(2, 2),
+                        version_of=ROIStatPlugin):
     reset_all = Cpt(EpicsSignal, "ResetAll", string=True, doc="")
 
 
-class ROIStatPlugin_V23(ROIStatPlugin_V22, version=(2, 3), version_of=ROIStatPlugin):
-    ts_acquiring = Cpt(EpicsSignal, "TSAcquiring", string=True, doc="0='Done' 1='Acquiring'")
-    ts_control = Cpt(EpicsSignal, "TSControl", string=True, doc="0=Erase/Start 1=Start 2=Stop 3=Read")
+class ROIStatPlugin_V23(ROIStatPlugin_V22, version=(2, 3),
+                        version_of=ROIStatPlugin):
+    ts_acquiring = Cpt(EpicsSignal, "TSAcquiring", string=True,
+                       doc="0='Done' 1='Acquiring'")
+    ts_control = Cpt(EpicsSignal, "TSControl", string=True,
+                     doc="0=Erase/Start 1=Start 2=Stop 3=Read")
     ts_current_point = Cpt(EpicsSignal, "TSCurrentPoint")
     ts_num_points = Cpt(EpicsSignal, "TSNumPoints")
     ts_read = Cpt(EpicsSignal, "TSRead")
 
 
-class ROIStatPlugin_V25(PluginBase_V25, ROIStatPlugin_V23, version=(2, 5), version_of=ROIStatPlugin):
+class ROIStatPlugin_V25(PluginBase_V25, ROIStatPlugin_V23, version=(2, 5),
+                        version_of=ROIStatPlugin):
     ...
 
 
-class ROIStatPlugin_V26(PluginBase_V26, ROIStatPlugin_V25, version=(2, 6), version_of=ROIStatPlugin):
+class ROIStatPlugin_V26(PluginBase_V26, ROIStatPlugin_V25, version=(2, 6),
+                        version_of=ROIStatPlugin):
     ...
 
 
-class ROIStatPlugin_V31(PluginBase_V31, ROIStatPlugin_V26, version=(3, 1), version_of=ROIStatPlugin):
+class ROIStatPlugin_V31(PluginBase_V31, ROIStatPlugin_V26, version=(3, 1),
+                        version_of=ROIStatPlugin):
     ...
 
 
-class ROIStatPlugin_V33(PluginBase_V33, ROIStatPlugin_V31, version=(3, 3), version_of=ROIStatPlugin):
+class ROIStatPlugin_V33(PluginBase_V33, ROIStatPlugin_V31, version=(3, 3),
+                        version_of=ROIStatPlugin):
     ...
 
 
-class ROIStatPlugin_V34(PluginBase_V34, ROIStatPlugin_V33, version=(3, 4), version_of=ROIStatPlugin):
+class ROIStatPlugin_V34(PluginBase_V34, ROIStatPlugin_V33, version=(3, 4),
+                        version_of=ROIStatPlugin):
     ...
 
 
@@ -1596,7 +1722,8 @@ class ROIStatNPlugin(Device, version_type='ADCore'):
     ...
 
 
-class ROIStatNPlugin_V22(ROIStatNPlugin, version=(2, 2), version_of=ROIStatNPlugin):
+class ROIStatNPlugin_V22(ROIStatNPlugin, version=(2, 2),
+                         version_of=ROIStatNPlugin):
     bgd_width = Cpt(SignalWithRBV, "BgdWidth")
     max_value = Cpt(EpicsSignalRO, "MaxValue_RBV")
     mean_value = Cpt(EpicsSignalRO, "MeanValue_RBV")
@@ -1623,7 +1750,8 @@ class ROIStatNPlugin_V22(ROIStatNPlugin, version=(2, 2), version_of=ROIStatNPlug
     )
 
 
-class ROIStatNPlugin_V23(ROIStatNPlugin_V22, version=(2, 3), version_of=ROIStatNPlugin):
+class ROIStatNPlugin_V23(ROIStatNPlugin_V22, version=(2, 3),
+                         version_of=ROIStatNPlugin):
     ts_max_value = Cpt(EpicsSignal, "TSMaxValue")
     ts_mean_value = Cpt(EpicsSignal, "TSMeanValue")
     ts_min_value = Cpt(EpicsSignal, "TSMinValue")
@@ -1631,18 +1759,21 @@ class ROIStatNPlugin_V23(ROIStatNPlugin_V22, version=(2, 3), version_of=ROIStatN
     ts_total = Cpt(EpicsSignal, "TSTotal")
 
 
-class ROIStatNPlugin_V25(ROIStatNPlugin_V23, version=(2, 5), version_of=ROIStatNPlugin):
+class ROIStatNPlugin_V25(ROIStatNPlugin_V23, version=(2, 5),
+                         version_of=ROIStatNPlugin):
     ts_timestamp = Cpt(EpicsSignal, "TSTimestamp")
 
 
 # --- NDStats ---
 
 
-class StatsPlugin_V20(PluginBase_V20, StatsPlugin, version=(2, 0), version_of=StatsPlugin):
+class StatsPlugin_V20(PluginBase_V20, StatsPlugin, version=(2, 0),
+                      version_of=StatsPlugin):
     ...
 
 
-class StatsPlugin_V22(PluginBase_V22, StatsPlugin_V20, version=(2, 2), version_of=StatsPlugin):
+class StatsPlugin_V22(PluginBase_V22, StatsPlugin_V20, version=(2, 2),
+                      version_of=StatsPlugin):
     hist_entropy = Cpt(SignalWithRBV, "HistEntropy")
     max_value = Cpt(SignalWithRBV, "MaxValue")
     mean_value = Cpt(SignalWithRBV, "MeanValue")
@@ -1680,11 +1811,13 @@ class StatsPlugin_V22(PluginBase_V22, StatsPlugin_V20, version=(2, 2), version_o
     data_type = Cpt(SignalWithRBV, 'DataType', string=True)
 
 
-class StatsPlugin_V25(PluginBase_V25, StatsPlugin_V22, version=(2, 5), version_of=StatsPlugin):
+class StatsPlugin_V25(PluginBase_V25, StatsPlugin_V22, version=(2, 5),
+                      version_of=StatsPlugin):
     ts_timestamp = Cpt(EpicsSignal, "TSTimestamp")
 
 
-class StatsPlugin_V26(PluginBase_V26, StatsPlugin_V25, version=(2, 6), version_of=StatsPlugin):
+class StatsPlugin_V26(PluginBase_V26, StatsPlugin_V25, version=(2, 6),
+                      version_of=StatsPlugin):
     centroid_total = Cpt(SignalWithRBV, "CentroidTotal")
     eccentricity = Cpt(SignalWithRBV, "Eccentricity")
     hist_above = Cpt(SignalWithRBV, "HistAbove")
@@ -1720,7 +1853,8 @@ class StatsPlugin_V26(PluginBase_V26, StatsPlugin_V25, version=(2, 6), version_o
     )
 
 
-class StatsPlugin_V31(PluginBase_V31, StatsPlugin_V26, version=(3, 1), version_of=StatsPlugin):
+class StatsPlugin_V31(PluginBase_V31, StatsPlugin_V26, version=(3, 1),
+                      version_of=StatsPlugin):
     ...
 
 
@@ -1728,7 +1862,8 @@ class StatsPlugin_V32(StatsPlugin_V31, version=(3, 2), version_of=StatsPlugin):
     histogram_x = Cpt(EpicsSignalRO, "HistogramX_RBV")
 
 
-class StatsPlugin_V33(PluginBase_V33, StatsPlugin_V32, version=(3, 3), version_of=StatsPlugin):
+class StatsPlugin_V33(PluginBase_V33, StatsPlugin_V32, version=(3, 3),
+                      version_of=StatsPlugin):
     ts_acquiring = None  # REMOVED
     ts_control = None  # REMOVED
     ts_current_point = None  # REMOVED
@@ -1740,49 +1875,59 @@ class StatsPlugin_V33(PluginBase_V33, StatsPlugin_V32, version=(3, 3), version_o
         doc="ts_sigma")
 
 
-class StatsPlugin_V34(PluginBase_V34, StatsPlugin_V33, version=(3, 4), version_of=StatsPlugin):
+class StatsPlugin_V34(PluginBase_V34, StatsPlugin_V33, version=(3, 4),
+                      version_of=StatsPlugin):
     ...
 
 
 # --- NDFileTIFF ---
 
 
-class TIFFPlugin_V20(FilePlugin_V20, TIFFPlugin, version=(2, 0), version_of=TIFFPlugin):
+class TIFFPlugin_V20(FilePlugin_V20, TIFFPlugin, version=(2, 0),
+                     version_of=TIFFPlugin):
     ...
 
 
-class TIFFPlugin_V21(FilePlugin_V21, TIFFPlugin_V20, version=(2, 1), version_of=TIFFPlugin):
+class TIFFPlugin_V21(FilePlugin_V21, TIFFPlugin_V20, version=(2, 1),
+                     version_of=TIFFPlugin):
     ...
 
 
-class TIFFPlugin_V22(FilePlugin_V22, TIFFPlugin_V21, version=(2, 2), version_of=TIFFPlugin):
+class TIFFPlugin_V22(FilePlugin_V22, TIFFPlugin_V21, version=(2, 2),
+                     version_of=TIFFPlugin):
     ...
 
 
-class TIFFPlugin_V25(FilePlugin_V25, TIFFPlugin_V22, version=(2, 5), version_of=TIFFPlugin):
+class TIFFPlugin_V25(FilePlugin_V25, TIFFPlugin_V22, version=(2, 5),
+                     version_of=TIFFPlugin):
     ...
 
 
-class TIFFPlugin_V26(FilePlugin_V26, TIFFPlugin_V25, version=(2, 6), version_of=TIFFPlugin):
+class TIFFPlugin_V26(FilePlugin_V26, TIFFPlugin_V25, version=(2, 6),
+                     version_of=TIFFPlugin):
     ...
 
 
-class TIFFPlugin_V31(FilePlugin_V31, TIFFPlugin_V26, version=(3, 1), version_of=TIFFPlugin):
+class TIFFPlugin_V31(FilePlugin_V31, TIFFPlugin_V26, version=(3, 1),
+                     version_of=TIFFPlugin):
     ...
 
 
-class TIFFPlugin_V33(FilePlugin_V33, TIFFPlugin_V31, version=(3, 3), version_of=TIFFPlugin):
+class TIFFPlugin_V33(FilePlugin_V33, TIFFPlugin_V31, version=(3, 3),
+                     version_of=TIFFPlugin):
     ...
 
 
-class TIFFPlugin_V34(FilePlugin_V34, TIFFPlugin_V33, version=(3, 4), version_of=TIFFPlugin):
+class TIFFPlugin_V34(FilePlugin_V34, TIFFPlugin_V33, version=(3, 4),
+                     version_of=TIFFPlugin):
     ...
 
 
 # --- NDTransform ---
 
 
-class TransformPlugin_V20(PluginBase_V20, TransformPlugin, version=(2, 0), version_of=TransformPlugin):
+class TransformPlugin_V20(PluginBase_V20, TransformPlugin, version=(2, 0),
+                          version_of=TransformPlugin):
     array_size = DDC_SignalWithRBV(
         ("array_size0", "ArraySize0"),
         ("array_size1", "ArraySize1"),
@@ -1791,7 +1936,8 @@ class TransformPlugin_V20(PluginBase_V20, TransformPlugin, version=(2, 0), versi
     )
 
 
-class TransformPlugin_V21(TransformPlugin_V20, version=(2, 1), version_of=TransformPlugin):
+class TransformPlugin_V21(TransformPlugin_V20, version=(2, 1),
+                          version_of=TransformPlugin):
     name_ = None  # REMOVED
     origin_location = None  # REMOVED
     t1_max_size = None  # REMOVED DDC
@@ -1803,7 +1949,8 @@ class TransformPlugin_V21(TransformPlugin_V20, version=(2, 1), version_of=Transf
     height = None  # Removed array_size portions
     depth = None  # Removed array_size portions
     type_ = Cpt(EpicsSignal, 'Type', string=True,
-                doc="0=None 1=Rot90 2=Rot180 3=Rot270 4=Mirror 5=Rot90Mirror 6=Rot180Mirror 7=Rot270Mirror")
+                doc="0=None 1=Rot90 2=Rot180 3=Rot270 4=Mirror 5=Rot90Mirror"
+                    " 6=Rot180Mirror 7=Rot270Mirror")
     array_size = DDC_EpicsSignalRO(
         ("array_size0", "ArraySize0_RBV"),
         ("array_size1", "ArraySize1_RBV"),
@@ -1812,27 +1959,33 @@ class TransformPlugin_V21(TransformPlugin_V20, version=(2, 1), version_of=Transf
     )
 
 
-class TransformPlugin_V22(PluginBase_V22, TransformPlugin_V21, version=(2, 2), version_of=TransformPlugin):
+class TransformPlugin_V22(PluginBase_V22, TransformPlugin_V21,
+                          version=(2, 2), version_of=TransformPlugin):
     ...
 
 
-class TransformPlugin_V25(PluginBase_V25, TransformPlugin_V22, version=(2, 5), version_of=TransformPlugin):
+class TransformPlugin_V25(PluginBase_V25, TransformPlugin_V22,
+                          version=(2, 5), version_of=TransformPlugin):
     ...
 
 
-class TransformPlugin_V26(PluginBase_V26, TransformPlugin_V25, version=(2, 6), version_of=TransformPlugin):
+class TransformPlugin_V26(PluginBase_V26, TransformPlugin_V25,
+                          version=(2, 6), version_of=TransformPlugin):
     ...
 
 
-class TransformPlugin_V31(PluginBase_V31, TransformPlugin_V26, version=(3, 1), version_of=TransformPlugin):
+class TransformPlugin_V31(PluginBase_V31, TransformPlugin_V26,
+                          version=(3, 1), version_of=TransformPlugin):
     ...
 
 
-class TransformPlugin_V33(PluginBase_V33, TransformPlugin_V31, version=(3, 3), version_of=TransformPlugin):
+class TransformPlugin_V33(PluginBase_V33, TransformPlugin_V31,
+                          version=(3, 3), version_of=TransformPlugin):
     ...
 
 
-class TransformPlugin_V34(PluginBase_V34, TransformPlugin_V33, version=(3, 4), version_of=TransformPlugin):
+class TransformPlugin_V34(PluginBase_V34, TransformPlugin_V33,
+                          version=(3, 4), version_of=TransformPlugin):
     ...
 
 
@@ -1847,23 +2000,28 @@ class PvaPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginPva'
 
 
-class PvaPlugin_V25(PluginBase_V25, PvaPlugin, version=(2, 5), version_of=PvaPlugin):
+class PvaPlugin_V25(PluginBase_V25, PvaPlugin, version=(2, 5),
+                    version_of=PvaPlugin):
     pv_name = Cpt(EpicsSignalRO, "PvName_RBV")
 
 
-class PvaPlugin_V26(PluginBase_V26, PvaPlugin_V25, version=(2, 6), version_of=PvaPlugin):
+class PvaPlugin_V26(PluginBase_V26, PvaPlugin_V25, version=(2, 6),
+                    version_of=PvaPlugin):
     ...
 
 
-class PvaPlugin_V31(PluginBase_V31, PvaPlugin_V26, version=(3, 1), version_of=PvaPlugin):
+class PvaPlugin_V31(PluginBase_V31, PvaPlugin_V26, version=(3, 1),
+                    version_of=PvaPlugin):
     ...
 
 
-class PvaPlugin_V33(PluginBase_V33, PvaPlugin_V31, version=(3, 3), version_of=PvaPlugin):
+class PvaPlugin_V33(PluginBase_V33, PvaPlugin_V31, version=(3, 3),
+                    version_of=PvaPlugin):
     ...
 
 
-class PvaPlugin_V34(PluginBase_V34, PvaPlugin_V33, version=(3, 4), version_of=PvaPlugin):
+class PvaPlugin_V34(PluginBase_V34, PvaPlugin_V33, version=(3, 4),
+                    version_of=PvaPlugin):
     ...
 
 
@@ -1879,16 +2037,20 @@ class FFTPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginFFT'
 
 
-class FFTPlugin_V25(PluginBase_V25, FFTPlugin, version=(2, 5), version_of=FFTPlugin):
+class FFTPlugin_V25(PluginBase_V25, FFTPlugin, version=(2, 5),
+                    version_of=FFTPlugin):
     fft_abs_value = Cpt(EpicsSignal, "FFTAbsValue")
-    fft_direction = Cpt(SignalWithRBV, "FFTDirection", string=True, doc="0='Time to freq.' 1='Freq. to time'")
+    fft_direction = Cpt(SignalWithRBV, "FFTDirection", string=True,
+                        doc="0='Time to freq.' 1='Freq. to time'")
     fft_freq_axis = Cpt(EpicsSignal, "FFTFreqAxis")
     fft_imaginary = Cpt(EpicsSignal, "FFTImaginary")
     fft_num_average = Cpt(SignalWithRBV, "FFTNumAverage")
     fft_num_averaged = Cpt(EpicsSignal, "FFTNumAveraged")
     fft_real = Cpt(EpicsSignal, "FFTReal")
-    fft_reset_average = Cpt(EpicsSignal, "FFTResetAverage", string=True, doc="0='Done' 1='Reset'")
-    fft_suppress_dc = Cpt(SignalWithRBV, "FFTSuppressDC", string=True, doc="0='Disable' 1='Enable'")
+    fft_reset_average = Cpt(EpicsSignal, "FFTResetAverage", string=True,
+                            doc="0='Done' 1='Reset'")
+    fft_suppress_dc = Cpt(SignalWithRBV, "FFTSuppressDC", string=True,
+                          doc="0='Disable' 1='Enable'")
     fft_time_axis = Cpt(EpicsSignal, "FFTTimeAxis")
     fft_time_per_point = Cpt(SignalWithRBV, "FFTTimePerPoint")
     fft_time_per_point_link = Cpt(EpicsSignal, "FFTTimePerPointLink")
@@ -1896,19 +2058,23 @@ class FFTPlugin_V25(PluginBase_V25, FFTPlugin, version=(2, 5), version_of=FFTPlu
     name_ = Cpt(EpicsSignal, "Name", string=True)
 
 
-class FFTPlugin_V26(PluginBase_V26, FFTPlugin_V25, version=(2, 6), version_of=FFTPlugin):
+class FFTPlugin_V26(PluginBase_V26, FFTPlugin_V25, version=(2, 6),
+                    version_of=FFTPlugin):
     ...
 
 
-class FFTPlugin_V31(PluginBase_V31, FFTPlugin_V26, version=(3, 1), version_of=FFTPlugin):
+class FFTPlugin_V31(PluginBase_V31, FFTPlugin_V26, version=(3, 1),
+                    version_of=FFTPlugin):
     ...
 
 
-class FFTPlugin_V33(PluginBase_V33, FFTPlugin_V31, version=(3, 3), version_of=FFTPlugin):
+class FFTPlugin_V33(PluginBase_V33, FFTPlugin_V31, version=(3, 3),
+                    version_of=FFTPlugin):
     ...
 
 
-class FFTPlugin_V34(PluginBase_V34, FFTPlugin_V33, version=(3, 4), version_of=FFTPlugin):
+class FFTPlugin_V34(PluginBase_V34, FFTPlugin_V33, version=(3, 4),
+                    version_of=FFTPlugin):
     ...
 
 
@@ -1923,19 +2089,24 @@ class ScatterPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginScatter'
 
 
-class ScatterPlugin_V31(PluginBase_V31, ScatterPlugin, version=(3, 1), version_of=ScatterPlugin):
-    scatter_method = Cpt(SignalWithRBV, "ScatterMethod", string=True, doc="0='Round robin'")
+class ScatterPlugin_V31(PluginBase_V31, ScatterPlugin, version=(3, 1),
+                        version_of=ScatterPlugin):
+    scatter_method = Cpt(SignalWithRBV, "ScatterMethod", string=True,
+                         doc="0='Round robin'")
 
 
-class ScatterPlugin_V32(ScatterPlugin_V31, version=(3, 2), version_of=ScatterPlugin):
+class ScatterPlugin_V32(ScatterPlugin_V31, version=(3, 2),
+                        version_of=ScatterPlugin):
     ...
 
 
-class ScatterPlugin_V33(PluginBase_V33, ScatterPlugin_V32, version=(3, 3), version_of=ScatterPlugin):
+class ScatterPlugin_V33(PluginBase_V33, ScatterPlugin_V32, version=(3, 3),
+                        version_of=ScatterPlugin):
     ...
 
 
-class ScatterPlugin_V34(PluginBase_V34, ScatterPlugin_V33, version=(3, 4), version_of=ScatterPlugin):
+class ScatterPlugin_V34(PluginBase_V34, ScatterPlugin_V33, version=(3, 4),
+                        version_of=ScatterPlugin):
     ...
 
 
@@ -1950,11 +2121,13 @@ class PosPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPosPlugin'
 
 
-class PosPluginPlugin_V25(PluginBase_V25, PosPlugin, version=(2, 5), version_of=PosPlugin):
+class PosPluginPlugin_V25(PluginBase_V25, PosPlugin, version=(2, 5),
+                          version_of=PosPlugin):
     delete = Cpt(EpicsSignal, "Delete", string=True, doc="")
     duplicate = Cpt(SignalWithRBV, "Duplicate")
     expected_id = Cpt(EpicsSignalRO, "ExpectedID_RBV")
-    file_valid = Cpt(EpicsSignalRO, "FileValid_RBV", string=True, doc="0='No' 1='Yes'")
+    file_valid = Cpt(EpicsSignalRO, "FileValid_RBV", string=True,
+                     doc="0='No' 1='Yes'")
     filename = Cpt(SignalWithRBV, "Filename")
     id_difference = Cpt(SignalWithRBV, "IDDifference")
     id_name = Cpt(SignalWithRBV, "IDName", string=True)
@@ -1968,19 +2141,23 @@ class PosPluginPlugin_V25(PluginBase_V25, PosPlugin, version=(2, 5), version_of=
     running = Cpt(SignalWithRBV, "Running")
 
 
-class PosPluginPlugin_V26(PluginBase_V26, PosPluginPlugin_V25, version=(2, 6), version_of=PosPlugin):
+class PosPluginPlugin_V26(PluginBase_V26, PosPluginPlugin_V25, version=(2, 6),
+                          version_of=PosPlugin):
     ...
 
 
-class PosPluginPlugin_V31(PluginBase_V31, PosPluginPlugin_V26, version=(3, 1), version_of=PosPlugin):
+class PosPluginPlugin_V31(PluginBase_V31, PosPluginPlugin_V26, version=(3, 1),
+                          version_of=PosPlugin):
     ...
 
 
-class PosPluginPlugin_V33(PluginBase_V33, PosPluginPlugin_V31, version=(3, 3), version_of=PosPlugin):
+class PosPluginPlugin_V33(PluginBase_V33, PosPluginPlugin_V31, version=(3, 3),
+                          version_of=PosPlugin):
     ...
 
 
-class PosPluginPlugin_V34(PluginBase_V34, PosPluginPlugin_V33, version=(3, 4), version_of=PosPlugin):
+class PosPluginPlugin_V34(PluginBase_V34, PosPluginPlugin_V33, version=(3, 4),
+                          version_of=PosPlugin):
     ...
 
 
@@ -1995,7 +2172,8 @@ class CircularBuffPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginCircularBuff'
 
 
-class CircularBuffPlugin_V22(PluginBase_V22, CircularBuffPlugin, version=(2, 2), version_of=CircularBuffPlugin):
+class CircularBuffPlugin_V22(PluginBase_V22, CircularBuffPlugin,
+                             version=(2, 2), version_of=CircularBuffPlugin):
     actual_trigger_count = Cpt(EpicsSignalRO, "ActualTriggerCount_RBV")
     capture = Cpt(SignalWithRBV, "Capture")
     current_qty = Cpt(EpicsSignalRO, "CurrentQty_RBV")
@@ -2019,35 +2197,31 @@ class CircularBuffPlugin_V22(PluginBase_V22, CircularBuffPlugin, version=(2, 2),
     )
 
 
-class CircularBuffPlugin_V25(
-    PluginBase_V25, CircularBuffPlugin_V22, version=(2, 5), version_of=CircularBuffPlugin
-):
+class CircularBuffPlugin_V25(PluginBase_V25, CircularBuffPlugin_V22,
+                             version=(2, 5), version_of=CircularBuffPlugin):
     ...
 
 
-class CircularBuffPlugin_V26(
-    PluginBase_V26, CircularBuffPlugin_V25, version=(2, 6), version_of=CircularBuffPlugin
-):
+class CircularBuffPlugin_V26(PluginBase_V26, CircularBuffPlugin_V25,
+                             version=(2, 6), version_of=CircularBuffPlugin):
     ...
 
 
-class CircularBuffPlugin_V31(
-    PluginBase_V31, CircularBuffPlugin_V26, version=(3, 1), version_of=CircularBuffPlugin
-):
+class CircularBuffPlugin_V31(PluginBase_V31, CircularBuffPlugin_V26,
+                             version=(3, 1), version_of=CircularBuffPlugin):
     ...
 
 
-class CircularBuffPlugin_V33(
-    PluginBase_V33, CircularBuffPlugin_V31, version=(3, 3), version_of=CircularBuffPlugin
-):
+class CircularBuffPlugin_V33(PluginBase_V33, CircularBuffPlugin_V31,
+                             version=(3, 3), version_of=CircularBuffPlugin):
     ...
 
 
-class CircularBuffPlugin_V34(
-    PluginBase_V34, CircularBuffPlugin_V33, version=(3, 4), version_of=CircularBuffPlugin
-):
+class CircularBuffPlugin_V34(PluginBase_V34, CircularBuffPlugin_V33,
+                             version=(3, 4), version_of=CircularBuffPlugin):
     flush_on_soft_trigger = Cpt(
-        SignalWithRBV, "FlushOnSoftTrg", string=True, doc="0='OnNewImage' 1='Immediately'"
+        SignalWithRBV, "FlushOnSoftTrg", string=True,
+        doc="0='OnNewImage' 1='Immediately'"
     )
 
 
@@ -2059,14 +2233,16 @@ class AttributeNPlugin(Device, version_type='ADCore'):
     ...
 
 
-class AttributeNPlugin_V22(AttributeNPlugin, version=(2, 2), version_of=AttributeNPlugin):
+class AttributeNPlugin_V22(AttributeNPlugin, version=(2, 2),
+                           version_of=AttributeNPlugin):
     attribute_name = Cpt(SignalWithRBV, "AttrName")
     ts_array_value = Cpt(EpicsSignal, "TSArrayValue")
     value_sum = Cpt(EpicsSignalRO, "ValueSum_RBV")
     value = Cpt(EpicsSignalRO, "Value_RBV")
 
 
-class AttributeNPlugin_V26(AttributeNPlugin_V22, version=(2, 6), version_of=AttributeNPlugin):
+class AttributeNPlugin_V26(AttributeNPlugin_V22, version=(2, 6),
+                           version_of=AttributeNPlugin):
     ...
 
 # --- NDAttrPlot ---
@@ -2077,16 +2253,19 @@ class AttrPlotPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDAttrPlot'
 
 
-class AttrPlotPlugin_V31(PluginBase_V31, AttrPlotPlugin, version=(3, 1), version_of=AttrPlotPlugin):
+class AttrPlotPlugin_V31(PluginBase_V31, AttrPlotPlugin, version=(3, 1),
+                         version_of=AttrPlotPlugin):
     npts = Cpt(EpicsSignal, "NPts")
     reset = Cpt(EpicsSignal, "Reset")
 
 
-class AttrPlotPlugin_V33(PluginBase_V33, AttrPlotPlugin_V31, version=(3, 3), version_of=AttrPlotPlugin):
+class AttrPlotPlugin_V33(PluginBase_V33, AttrPlotPlugin_V31, version=(3, 3),
+                         version_of=AttrPlotPlugin):
     ...
 
 
-class AttrPlotPlugin_V34(PluginBase_V34, AttrPlotPlugin_V33, version=(3, 4), version_of=AttrPlotPlugin):
+class AttrPlotPlugin_V34(PluginBase_V34, AttrPlotPlugin_V33, version=(3, 4),
+                         version_of=AttrPlotPlugin):
     ...
 
 
@@ -2098,7 +2277,8 @@ class TimeSeriesNPlugin(Device, version_type='ADCore'):
     ...
 
 
-class TimeSeriesNPlugin_V25(TimeSeriesNPlugin, version=(2, 5), version_of=TimeSeriesNPlugin):
+class TimeSeriesNPlugin_V25(TimeSeriesNPlugin, version=(2, 5),
+                            version_of=TimeSeriesNPlugin):
     name_ = Cpt(EpicsSignal, "Name", string=True)
     time_series = Cpt(EpicsSignal, "TimeSeries")
 
@@ -2112,12 +2292,15 @@ class TimeSeriesPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginTimeSeries'
 
 
-class TimeSeriesPlugin_V25(PluginBase_V25, TimeSeriesPlugin, version=(2, 5), version_of=TimeSeriesPlugin):
+class TimeSeriesPlugin_V25(PluginBase_V25, TimeSeriesPlugin, version=(2, 5),
+                           version_of=TimeSeriesPlugin):
     ts_acquire = Cpt(EpicsSignal, "TSAcquire")
     ts_acquire_mode = Cpt(
-        SignalWithRBV, "TSAcquireMode", string=True, doc="0='Fixed length' 1='Circ. buffer'"
+        SignalWithRBV, "TSAcquireMode", string=True,
+        doc="0='Fixed length' 1='Circ. buffer'"
     )
-    ts_acquiring = Cpt(EpicsSignal, "TSAcquiring", string=True, doc="0='Done' 1='Acquiring'")
+    ts_acquiring = Cpt(EpicsSignal, "TSAcquiring", string=True,
+                       doc="0='Done' 1='Acquiring'")
     ts_averaging_time = Cpt(SignalWithRBV, "TSAveragingTime")
     ts_current_point = Cpt(EpicsSignal, "TSCurrentPoint")
     ts_elapsed_time = Cpt(EpicsSignal, "TSElapsedTime")
@@ -2130,19 +2313,23 @@ class TimeSeriesPlugin_V25(PluginBase_V25, TimeSeriesPlugin, version=(2, 5), ver
     ts_timestamp = Cpt(EpicsSignal, "TSTimestamp")
 
 
-class TimeSeriesPlugin_V26(PluginBase_V26, TimeSeriesPlugin_V25, version=(2, 6), version_of=TimeSeriesPlugin):
+class TimeSeriesPlugin_V26(PluginBase_V26, TimeSeriesPlugin_V25,
+                           version=(2, 6), version_of=TimeSeriesPlugin):
     ...
 
 
-class TimeSeriesPlugin_V31(PluginBase_V31, TimeSeriesPlugin_V26, version=(3, 1), version_of=TimeSeriesPlugin):
+class TimeSeriesPlugin_V31(PluginBase_V31, TimeSeriesPlugin_V26,
+                           version=(3, 1), version_of=TimeSeriesPlugin):
     ...
 
 
-class TimeSeriesPlugin_V33(PluginBase_V33, TimeSeriesPlugin_V31, version=(3, 3), version_of=TimeSeriesPlugin):
+class TimeSeriesPlugin_V33(PluginBase_V33, TimeSeriesPlugin_V31,
+                           version=(3, 3), version_of=TimeSeriesPlugin):
     ...
 
 
-class TimeSeriesPlugin_V34(PluginBase_V34, TimeSeriesPlugin_V33, version=(3, 4), version_of=TimeSeriesPlugin):
+class TimeSeriesPlugin_V34(PluginBase_V34, TimeSeriesPlugin_V33,
+                           version=(3, 4), version_of=TimeSeriesPlugin):
     ...
 
 
@@ -2155,19 +2342,25 @@ class CodecPlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginCodec'
 
 
-class CodecPlugin_V34(PluginBase_V34, CodecPlugin, version=(3, 4), version_of=CodecPlugin):
+class CodecPlugin_V34(PluginBase_V34, CodecPlugin, version=(3, 4),
+                      version_of=CodecPlugin):
     blosc_compression_level = Cpt(SignalWithRBV, "BloscCLevel")
     blosc_compressor = Cpt(
-        SignalWithRBV, "BloscCompressor", string=True, doc="0=BloscLZ 1=LZ4 2=LZ4HC 3=SNAPPY 4=ZLIB 5=ZSTD"
+        SignalWithRBV, "BloscCompressor", string=True,
+        doc="0=BloscLZ 1=LZ4 2=LZ4HC 3=SNAPPY 4=ZLIB 5=ZSTD"
     )
     blosc_num_threads = Cpt(SignalWithRBV, "BloscNumThreads")
-    blosc_shuffle = Cpt(SignalWithRBV, "BloscShuffle", string=True, doc="0=None 1=Bit 2=Byte")
+    blosc_shuffle = Cpt(SignalWithRBV, "BloscShuffle", string=True,
+                        doc="0=None 1=Bit 2=Byte")
     codec_error = Cpt(EpicsSignal, "CodecError")
-    codec_status = Cpt(EpicsSignal, "CodecStatus", string=True, doc="0=Success 1=Warning 2=Error")
+    codec_status = Cpt(EpicsSignal, "CodecStatus", string=True,
+                       doc="0=Success 1=Warning 2=Error")
     comp_factor = Cpt(EpicsSignalRO, "CompFactor_RBV")
-    compressor = Cpt(SignalWithRBV, "Compressor", string=True, doc="0=None 1=JPEG 2=Blosc")
+    compressor = Cpt(SignalWithRBV, "Compressor", string=True,
+                     doc="0=None 1=JPEG 2=Blosc")
     jpeg_quality = Cpt(SignalWithRBV, "JPEGQuality")
-    mode = Cpt(SignalWithRBV, "Mode", string=True, doc="0=Compress 1=Decompress")
+    mode = Cpt(SignalWithRBV, "Mode", string=True,
+               doc="0=Compress 1=Decompress")
 
 
 @register_plugin
@@ -2178,23 +2371,29 @@ class AttributePlugin(Device, version_type='ADCore'):
     _plugin_type = 'NDPluginAttribute'
 
 
-class AttributePlugin_V20(PluginBase_V20, AttributePlugin, version=(2, 0), version_of=AttributePlugin):
+class AttributePlugin_V20(PluginBase_V20, AttributePlugin, version=(2, 0),
+                          version_of=AttributePlugin):
     array_data = Cpt(EpicsSignalRO, 'ArrayData_RBV')
     attribute_name = Cpt(SignalWithRBV, 'AttrName')
-    reset = Cpt(EpicsSignal, 'Reset', string=True, doc="0='Done Reset' 1='Reset'")
+    reset = Cpt(EpicsSignal, 'Reset', string=True,
+                doc="0='Done Reset' 1='Reset'")
     reset_array_counter = Cpt(EpicsSignal, 'ResetArrayCounter')
-    update = Cpt(EpicsSignal, 'Update', string=True, doc="0='Done Update Array' 1='Update Array'")
+    update = Cpt(EpicsSignal, 'Update', string=True,
+                 doc="0='Done Update Array' 1='Update Array'")
     update_period = Cpt(SignalWithRBV, 'UpdatePeriod')
     value_sum = Cpt(EpicsSignalRO, 'ValueSum_RBV')
     value = Cpt(EpicsSignalRO, 'Value_RBV')
 
 
-class AttributePlugin_V22(PluginBase_V22, AttributePlugin_V20, version=(2, 2), version_of=AttributePlugin):
+class AttributePlugin_V22(PluginBase_V22, AttributePlugin_V20, version=(2, 2),
+                          version_of=AttributePlugin):
     array_data = None  # REMOVED
     attribute_name = None  # REMOVED
     reset_array_counter = None  # REMOVED
-    ts_acquiring = Cpt(EpicsSignal, 'TSAcquiring', string=True, doc="0='Done' 1='Acquiring'")
-    ts_control = Cpt(EpicsSignal, 'TSControl', string=True, doc="0=Erase/Start 1=Start 2=Stop 3=Read")
+    ts_acquiring = Cpt(EpicsSignal, 'TSAcquiring', string=True,
+                       doc="0='Done' 1='Acquiring'")
+    ts_control = Cpt(EpicsSignal, 'TSControl', string=True,
+                     doc="0=Erase/Start 1=Start 2=Stop 3=Read")
     ts_current_point = Cpt(EpicsSignal, 'TSCurrentPoint')
     ts_num_points = Cpt(EpicsSignal, 'TSNumPoints')
     ts_read = Cpt(EpicsSignal, 'TSRead')
@@ -2209,19 +2408,24 @@ class AttributePlugin_V22(PluginBase_V22, AttributePlugin_V20, version=(2, 2), v
     )
 
 
-class AttributePlugin_V25(PluginBase_V25, AttributePlugin_V22, version=(2, 5), version_of=AttributePlugin):
+class AttributePlugin_V25(PluginBase_V25, AttributePlugin_V22, version=(2, 5),
+                          version_of=AttributePlugin):
     ...
 
 
-class AttributePlugin_V26(PluginBase_V26, AttributePlugin_V25, version=(2, 6), version_of=AttributePlugin):
-    ts_acquiring = Cpt(EpicsSignal, "TSAcquiring", string=True, doc="0='Done' 1='Acquiring'")
-    ts_control = Cpt(EpicsSignal, 'TSControl', string=True, doc="0=Erase/Start 1=Start 2=Stop 3=Read")
+class AttributePlugin_V26(PluginBase_V26, AttributePlugin_V25, version=(2, 6),
+                          version_of=AttributePlugin):
+    ts_acquiring = Cpt(EpicsSignal, "TSAcquiring", string=True,
+                       doc="0='Done' 1='Acquiring'")
+    ts_control = Cpt(EpicsSignal, 'TSControl', string=True,
+                     doc="0=Erase/Start 1=Start 2=Stop 3=Read")
     ts_current_point = Cpt(EpicsSignal, 'TSCurrentPoint')
     ts_num_points = Cpt(EpicsSignal, 'TSNumPoints')
     ts_read = Cpt(EpicsSignal, 'TSRead')
 
 
-class AttributePlugin_V31(PluginBase_V31, AttributePlugin_V26, version=(3, 1), version_of=AttributePlugin):
+class AttributePlugin_V31(PluginBase_V31, AttributePlugin_V26, version=(3, 1),
+                          version_of=AttributePlugin):
     array_size_all = DDC_SignalWithRBV(
         ("size0", "ArraySize0"),
         ("size1", "ArraySize1"),
@@ -2237,11 +2441,13 @@ class AttributePlugin_V31(PluginBase_V31, AttributePlugin_V26, version=(3, 1), v
     )
 
 
-class AttributePlugin_V33(PluginBase_V33, AttributePlugin_V31, version=(3, 3), version_of=AttributePlugin):
+class AttributePlugin_V33(PluginBase_V33, AttributePlugin_V31, version=(3, 3),
+                          version_of=AttributePlugin):
     ...
 
 
-class AttributePlugin_V34(PluginBase_V34, AttributePlugin_V33, version=(3, 4), version_of=AttributePlugin):
+class AttributePlugin_V34(PluginBase_V34, AttributePlugin_V33, version=(3, 4),
+                          version_of=AttributePlugin):
     ...
 
 
@@ -2261,9 +2467,12 @@ class GatherNPlugin(Device, version_type='ADCore'):
         super().__init__(*args, **kwargs)
 
 
-class GatherNPlugin_V31(GatherNPlugin, version=(3, 1), version_of=GatherNPlugin):
-    gather_array_address = FCpt(SignalWithRBV, "{self.prefix}NDArrayAddress_{self.index}")
-    gather_array_port = FCpt(SignalWithRBV, "{self.prefix}NDArrayPort_{self.index}", string=True)
+class GatherNPlugin_V31(GatherNPlugin, version=(3, 1),
+                        version_of=GatherNPlugin):
+    gather_array_address = FCpt(
+        SignalWithRBV, "{self.prefix}NDArrayAddress_{self.index}")
+    gather_array_port = FCpt(
+        SignalWithRBV, "{self.prefix}NDArrayPort_{self.index}", string=True)
 
 
 def plugin_from_pvname(pv):

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -38,7 +38,7 @@ class ADTriggerStatus(DeviceStatus):
             try:
                 args.append(getattr(self,arg_name))
             except AttributeError:
-                setattr(self, arg_name, getattr(self.device,arg_name).position)
+                setattr(self, arg_name, getattr(self.device,arg_name).get())
                 args.append(getattr(self,arg_name))
 
         self.est_time = self.device.est_time.trigger(*args)

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -43,7 +43,7 @@ class ADTriggerStatus(DeviceStatus):
                         attr = getattr(self.device, arg_name)
                     except AttributeError:
                         print('{} attribute on {} required but not found'
-                              .format(arg_name, self.pos))
+                              .format(arg_name, self.device))
                         raise
 
                     try:

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -35,11 +35,13 @@ class ADTriggerStatus(DeviceStatus):
         arg_names = inspect.signature(self.device.est_time.trigger).parameters
         args = []
         for arg_name in arg_names:
-            try:
-                args.append(getattr(self,arg_name))
-            except AttributeError:
-                setattr(self, arg_name, getattr(self.device,arg_name).get())
-                args.append(getattr(self,arg_name))
+            if arg_name is not 'self':
+                try:
+                    args.append(getattr(self, arg_name))
+                except AttributeError:
+                    setattr(self, arg_name,
+                            getattr(self.device, arg_name).get())
+                    args.append(getattr(self, arg_name))
 
         self.est_time = self.device.est_time.trigger(*args)
 
@@ -54,7 +56,6 @@ class ADTriggerStatus(DeviceStatus):
         else:
             self.finish_ts = ttime.time()
             self.device.est_time.trigger.record(self)
-
 
     def watch(self, func):
         self._watchers.append(func)
@@ -91,14 +92,15 @@ class ADTriggerStatus(DeviceStatus):
                     time_elapsed=time_elapsed,
                     time_remaining=time_remaining)
 
-    def _finished(self, success = True, **kwargs):
+    def _finished(self, success=True, **kwargs):
         '''Informs the status object that it is done and if it succeeded. If it
         suceeded it also records the telemetry associated with the trigger.
         '''
-        super()._finished(success = success, **kwargs)
+        super()._finished(success=success, **kwargs)
         self.finish_ts = ttime.time()
         if success:
             self.device.est_time.trigger.record(self)
+
 
 class TriggerBase(BlueskyInterface):
     """Base class for trigger mixin classes

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -39,9 +39,18 @@ class ADTriggerStatus(DeviceStatus):
                 try:
                     args.append(getattr(self, arg_name))
                 except AttributeError:
-                    setattr(self, arg_name,
-                            getattr(self.device, arg_name).get())
-                    args.append(getattr(self, arg_name))
+                    try:
+                        val = getattr(self.device, arg_name).get()
+                    except AttributeError:
+                        val = getattr(self.device, arg_name)
+
+                    try:
+                        setattr(self, arg_name, val)
+                        args.append(getattr(self, arg_name))
+                    except AttributeError:
+                        print('{} attribute on {} required but not found'
+                              .format(arg_name, self.pos))
+                        raise
 
         self.est_time = self.device.est_time.trigger(*args)
 

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -40,17 +40,19 @@ class ADTriggerStatus(DeviceStatus):
                     args.append(getattr(self, arg_name))
                 except AttributeError:
                     try:
-                        val = getattr(self.device, arg_name).get()
-                    except AttributeError:
-                        val = getattr(self.device, arg_name)
-
-                    try:
-                        setattr(self, arg_name, val)
-                        args.append(getattr(self, arg_name))
+                        attr = getattr(self.device, arg_name)
                     except AttributeError:
                         print('{} attribute on {} required but not found'
                               .format(arg_name, self.pos))
                         raise
+
+                    try:
+                        val = attr.get()
+                    except AttributeError:
+                        val = attr
+
+                    setattr(self, arg_name, val)
+                    args.append(getattr(self, arg_name))
 
         self.est_time = self.device.est_time.trigger(*args)
 

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -8,6 +8,7 @@ from .utils.epics_pvs import (raise_if_disconnected, AlarmSeverity)
 from .positioner import PositionerBase
 from .device import (Device, Component as Cpt, required_for_connection)
 from .status import wait as status_wait
+from .EstTime import EpicsMotorEstTime
 from enum import Enum
 
 
@@ -40,11 +41,11 @@ class EpicsMotor(Device, PositionerBase):
     timeout : float, optional
         The default timeout to use for motion requests, in seconds.
     '''
+
     # position
     user_readback = Cpt(EpicsSignalRO, '.RBV', kind='hinted',
                         auto_monitor=True)
     user_setpoint = Cpt(EpicsSignal, '.VAL', limits=True)
-
     # calibration dial <-> user
     user_offset = Cpt(EpicsSignal, '.OFF', kind='config')
     user_offset_dir = Cpt(EpicsSignal, '.DIR', kind='config')
@@ -82,6 +83,7 @@ class EpicsMotor(Device, PositionerBase):
         # Make the default alias for the user_readback the name of the
         # motor itself.
         self.user_readback.name = self.name
+        self.est_time = EpicsMotorEstTime(self.name)
 
     @property
     def precision(self):

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -1,9 +1,8 @@
 import functools
 from itertools import count
-
+from .EstTime import DefaultEstTime
 import time
 import logging
-
 from enum import IntFlag
 
 
@@ -77,7 +76,7 @@ class OphydObject:
     _default_sub = None
 
     def __init__(self, *, name=None, attr_name='', parent=None, labels=None,
-                 kind=None):
+                 kind=None, est_time=DefaultEstTime):
         if labels is None:
             labels = set()
         self._ophyd_labels_ = set(labels)
@@ -95,6 +94,7 @@ class OphydObject:
             raise ValueError("name must be a string.")
         self._name = name
         self._parent = parent
+        self.est_time = est_time(self.name)
 
         self.subscriptions = {getattr(self, k)
                               for k in dir(type(self))
@@ -124,7 +124,7 @@ class OphydObject:
 
     def __init_subclass__(cls, version=None, version_of=None,
                           version_type=None, **kwargs):
-        'This is called automatically in Python for all subclasses of OphydObject'
+        'Called automatically in Python for all subclasses of OphydObject'
         super().__init_subclass__(**kwargs)
 
         if version is None:

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -472,8 +472,8 @@ class SynAxis(SynAxisNoHints):
             return st
         else:
             update_state()
-            return MoveStatus(positioner=self, target=value, start_pos=start_pos,
-                              done=True, success=True)
+            return MoveStatus(positioner=self, target=value,
+                              start_pos=start_pos, done=True, success=True)
 
     readback = Component(ReadbackSignal, value=None, kind=Kind.hinted)
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -398,7 +398,7 @@ class SynAxisNoHints(Device):
                            timestamp=self.sim_state['readback_ts'])
 
         if self.delay:
-            st = MoveStatus(device=self)
+            st = MoveStatus(device=self, target=value)
             if self.loop.is_running():
 
                 def update_and_finish():
@@ -417,7 +417,8 @@ class SynAxisNoHints(Device):
             return st
         else:
             update_state()
-            return MoveStatus(device=self, done=True, success=True)
+            return MoveStatus(device=self, target=value, done=True,
+                              success=True)
 
     @property
     def position(self):
@@ -451,7 +452,7 @@ class SynAxis(SynAxisNoHints):
                            timestamp=self.sim_state['readback_ts'])
 
         if self.delay:
-            st = MoveStatus(device=self)
+            st = MoveStatus(positioner=self, target=value)
             if self.loop.is_running():
 
                 def update_and_finish():
@@ -471,8 +472,8 @@ class SynAxis(SynAxisNoHints):
             return st
         else:
             update_state()
-            return MoveStatus(self, value, start_pos=start_pos, done=True,
-                              success=True)
+            return MoveStatus(positioner=self, target=value, start_pos=start_pos,
+                              done=True, success=True)
 
     readback = Component(ReadbackSignal, value=None, kind=Kind.hinted)
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -156,6 +156,10 @@ class SynAD_det(SynSignal):
     '''A SynSignal class with some additional AD related attributes.
     '''
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        est_time = ADEstTime(self.name)
+
     trigger_mode = Component(Signal, value=1, kind='config')
     num_images = Component(Signal, value=1, kind='config')
     acquire_period = Component(Signal, value=1, kind='config')
@@ -308,6 +312,7 @@ class SynAxisNoHints(Device):
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
     """
+
     readback = Component(ReadbackSignal, value=None, kind='hinted')
     setpoint = Component(SetpointSignal, value=None, kind='normal')
 
@@ -349,6 +354,8 @@ class SynAxisNoHints(Device):
         super().__init__(name=name, parent=parent, labels=labels, kind=kind,
                          **kwargs)
         self.readback.name = self.name
+        est_time = EpicsMotorEstTime(self.name)
+
 
     def set(self, value):
         old_setpoint = self.sim_state['setpoint']
@@ -713,7 +720,7 @@ class MockFlyer:
         pass
 
 
-class SynSignalWithRegistry(SynSignal):
+class SynSignalWithRegistry(SynAD_det):
     """
     A SynSignal integrated with databroker.assets
 
@@ -1290,9 +1297,6 @@ def hw(save_path=None):
     jittery_motor2 = SynAxis(name='jittery_motor2',
                              readback_func=lambda x: x + np.random.rand(),
                              labels={'motors'})
-    for axis in [motor, motor1, motor2, motor3, jittery_motor1,
-                 jittery_motor2]:
-        axis.est_time = EpicsMotorEstTime(axis.name)
 
     noisy_det = SynGauss('noisy_det', motor, 'motor', center=0, Imax=1,
                          noise='uniform', sigma=1, noise_multiplier=0.1,

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -447,7 +447,7 @@ class MoveStatus(DeviceStatus):
                 args.append(getattr(self, arg_name))
             except AttributeError:
                 try:
-                    val = getattr(self.pos, arg_name.get())
+                    val = getattr(self.pos, arg_name).get()
                 except AttributeError:
                     val = getattr(self.pos, arg_name)
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -448,7 +448,7 @@ class MoveStatus(DeviceStatus):
             except AttributeError:
                 try:
                     setattr(self, arg_name,
-                            getattr(self.pos, arg_name).position)
+                            getattr(self.pos, arg_name).get())
                     args.append(getattr(self, arg_name))
                 except AttributeError:
                     print('{} attribute on {} required but not found'

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -474,7 +474,7 @@ class MoveStatus(DeviceStatus):
             self.finish_ts = time.time()
             if self.success:
                 try:
-                    self.pos.est_time.set.record(self)
+                    self.pos.est_time.set.record(self, status_object=self)
                 except AttributeError('est_time.set.record attribute required\
                                       on {}, but not found'.format(self.pos)):
                     raise

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -447,8 +447,12 @@ class MoveStatus(DeviceStatus):
                 args.append(getattr(self, arg_name))
             except AttributeError:
                 try:
-                    setattr(self, arg_name,
-                            getattr(self.pos, arg_name).get())
+                    val = getattr(self.pos, arg_name.get())
+                except AttributeError:
+                    val = getattr(self.pos, arg_name)
+
+                try:
+                    setattr(self, arg_name, val)
                     args.append(getattr(self, arg_name))
                 except AttributeError:
                     print('{} attribute on {} required but not found'

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -447,17 +447,18 @@ class MoveStatus(DeviceStatus):
                 args.append(getattr(self, arg_name))
             except AttributeError:
                 try:
-                    val = getattr(self.pos, arg_name).get()
-                except AttributeError:
-                    val = getattr(self.pos, arg_name)
-
-                try:
-                    setattr(self, arg_name, val)
-                    args.append(getattr(self, arg_name))
+                    attr = getattr(self.pos, arg_name)
                 except AttributeError:
                     print('{} attribute on {} required but not found'
                           .format(arg_name, self.pos))
-                    raise
+
+                try:
+                    val = attr.get()
+                except AttributeError:
+                    val = attr
+
+                setattr(self, arg_name, val)
+                args.append(getattr(self, arg_name))
 
         self.est_time = self.pos.est_time.set(*args)
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -3,7 +3,7 @@ import time
 from threading import RLock
 from functools import wraps
 from warnings import warn
-
+import inspect
 import logging
 import threading
 import numpy as np
@@ -421,18 +421,41 @@ class MoveStatus(DeviceStatus):
         Motion successfully completed
     """
 
-    def __init__(self, positioner, target, *, start_ts=None,
+    def __init__(self, positioner, target, *, start_pos=None, start_ts=None,
                  **kwargs):
         self._tname = 'timeout for {}'.format(positioner.name)
+
         if start_ts is None:
             start_ts = time.time()
 
         self.pos = positioner
+        if start_pos is None:
+            start_pos = self.pos.position
+
+        self.start_pos = start_pos
         self.target = target
         self.start_ts = start_ts
-        self.start_pos = self.pos.position
         self.finish_ts = None
         self.finish_pos = None
+
+        # This section below ensures that the status object has all of the info
+        # required for storing telemetry associated with it.
+        arg_names = inspect.signature(self.pos.est_time.set).parameters
+        args = []
+        for arg_name in arg_names:
+            try:
+                args.append(getattr(self, arg_name))
+            except AttributeError:
+                try:
+                    setattr(self, arg_name,
+                            getattr(self.pos, arg_name).position)
+                    args.append(getattr(self, arg_name))
+                except AttributeError:
+                    print('{} attribute on {} required but not found'
+                          .format(arg_name, self.pos))
+                    raise
+
+        self.est_time = self.pos.est_time.set(*args)
 
         self._unit = getattr(self.pos, 'egu', None)
         self._precision = getattr(self.pos, 'precision', None)
@@ -446,6 +469,15 @@ class MoveStatus(DeviceStatus):
         if not self.done:
             self.pos.subscribe(self._notify_watchers,
                                event_type=self.pos.SUB_READBACK)
+        else:
+            self.finish_pos = self.target
+            self.finish_ts = time.time()
+            if self.success:
+                try:
+                    self.pos.est_time.set.record(self)
+                except AttributeError('est_time.set.record attribute required\
+                                      on {}, but not found'.format(self.pos)):
+                    raise
 
     def watch(self, func):
         """
@@ -535,6 +567,15 @@ class MoveStatus(DeviceStatus):
                 )
 
     __repr__ = __str__
+
+    def _finished(self, success=True, **kwargs):
+        '''Inform the status object that it is done, and if it succeeded. If
+        success is True then also record telemetry about the move.
+        '''
+
+        super()._finished(success=success, **kwargs)
+        if success:
+            self.pos.est_time.set.record(self)
 
 
 def wait(status, timeout=None, *, poll_rate=0.05):

--- a/ophyd/telemetry.py
+++ b/ophyd/telemetry.py
@@ -1,0 +1,199 @@
+import pymongo
+import yaml
+import os
+import sys
+
+
+class TelemetryClass:
+
+    def __init__(self):
+
+        self.telemetry = []
+        # This is a prototype telemetry database, it has the structure:
+        #   telemetry[ {timestamp: '', object_name: '', action: '',
+        #               time: {'start': '', 'stop': ''},
+        #       attribute_1_name{'start':'', 'stop':''}.........
+        #       attribute_n_name{'start': '', 'stop': ''} }, ............]
+
+        self.use_database = False
+        # allows for hot swapping between the dictionary (self.telemetry)
+        # and a mongo database.
+
+        self._client = None
+        self.telemetry_db = None
+
+    if os.name == 'nt':
+        _user_conf = os.path.join(os.environ['APPDATA'], 'telemetry')
+        CONFIG_SEARCH_PATH = (_user_conf,)
+    else:
+        _user_conf = os.path.join(os.path.expanduser('~'), '.config',
+                                  'telemetry')
+        _local_etc = os.path.join(os.path.dirname(os.path.dirname(
+                                  sys.executable)), 'etc', 'telemetry')
+        _system_etc = os.path.join('/', 'etc', 'telemetry')
+        CONFIG_SEARCH_PATH = (_user_conf, _local_etc, _system_etc)
+
+    def record_telemetry(self, obj_name, cmd, data):
+        '''This function records a set of value/timestamp tuples into the
+        telemetry database.
+
+        This function is used to record a value/timestamp tuple to the
+        telemetry database (currently a dictionary). It takes in the obj_name,
+        a command (or action) and a dictionary where the optional keywords are
+        the attribute names and the values are set_value/measured_value/
+        timestamp tuples. In addition it always has the unique keyword 'time'
+        with a value being a estimated_value/measured_value/timestamp tuple and
+        may contain an optional keyword 'position' with a value being a
+        start_position/stop_position/timestamp tuple (mainly for motor-like
+        'set' actions).
+
+        PARAMETERS
+        ----------
+        obj_name : string.
+            A string that contains the name of the object/device that the
+            action was performed on.
+        cmd : string.
+            The name of the action performed on the object/device (matches the
+            actions defined in a plans msg list).
+        data : dict.
+            A dictionary with a keyword 'time' and a value being an start_time
+            /stop_time tuple. It may also contain optional keywords
+            corresponding to the attributes that where set for the action and
+            values being start value/stop value tuples.
+        '''
+        event_dict = {}
+
+        event_dict['object_name'] = obj_name
+        event_dict['action'] = cmd
+
+        for attribute in data:
+            temp_dict = {}
+            for key in data[attribute]:
+                temp_dict[key] = data[attribute][key]
+            event_dict[attribute] = temp_dict
+
+        if self.use_database:
+            self.telemetry_db.posts.insert_one(event_dict)
+        else:
+            self.telemetry.append(event_dict)
+
+    def fetch_telemetry(self, obj_name, cmd):
+        '''This function returns a dictionary with value and timestamp lists
+           from the telemetry database.
+
+        This function is used to return a dictionary with value and timestamp
+        lists from the telemetry database (currently a dictionary). It takes
+        in the obj_name and a command (or action) and returns a dictionary
+        where the keywords are attributes, the values are another dictionary
+        with keywords for 'value' and 'time' and values being matched lists of
+        data. If there are no telemetry values for this object and action it
+        returns an empty dictionary.
+
+        PARAMETERS
+        ----------
+        obj_name : string.
+            A string that contains the name of the object/device that the
+            action was performed on.
+        cmd : string.
+            The name of the action performed on the object/device (matches the
+            actions defined in a plans msg list).
+
+        RETURNS
+        -------
+        data : dict.
+            A dictionary with the keyword 'time' and a value being a dictionary
+            with keywords 'estimated', 'measured' and 'timestamp' and values
+            being a matched list of each. Data may also include keywords
+            corresponding to the attributes, that where stored for the action,
+            and values being a dictionary with keywords 'input', 'measured' and
+            'timestamp' and values being a matched list of data for each. A
+            final optional keyword for data is 'position' whose value is a
+            dictionary with the keywords 'start_position','stop_position' and
+            'timestamp' with a matched list of values for each.
+        '''
+        if self.use_database:
+            out_list = list(self.telemetry_db.posts.find(
+                            {'object_name': obj_name, 'action': cmd}))
+        else:
+            out_list = []
+            for item in self.telemetry:
+                if item['object_name'] == obj_name and item['action'] == cmd:
+                    out_list.append(item)
+
+        return out_list
+
+    def lookup_config(self, name):
+        """
+        Search for a databroker configuration file with a given name.
+        For exmaple, the name 'example' will cause the function to search for:
+        * ``~/.config/databroker/example.yml``
+        * ``{python}/../etc/databroker/example.yml``
+        * ``/etc/databroker/example.yml``
+        where ``{python}`` is the location of the current Python binary, as
+        reported by ``sys.executable``. It will use the first match it finds.
+        The configuration file should have the structure:
+        >>> config = {
+        ...     'description': 'lightweight personal database',
+        ...     'telemetry': {
+        ...         'config': {
+        ...             'host' : 'some_host',
+        ...             'port' : 'some_port',
+        ...             'database' : 'some database name'}
+        ...                   },
+        ...                  }
+        ...          }
+
+        Parameters
+        ----------
+        name : string
+
+        Returns
+        -------
+        config : dict
+        """
+
+        if not name.endswith('.yml'):
+            name += '.yml'
+        tried = []
+        for path in self.CONFIG_SEARCH_PATH:
+            filename = os.path.join(path, name)
+            tried.append(filename)
+            if os.path.isfile(filename):
+                with open(filename) as f:
+                    return yaml.load(f)
+        else:
+            raise FileNotFoundError("No config file named {!r} could be found"
+                                    "in the following locations:\n{}"
+                                    "".format(name, '\n'.join(tried)))
+
+    def configure_db(self, name=None):
+        """
+        Create a new Broker instance using a dictionary of configuration.
+        Parameters
+        ----------
+        config : dict
+        name : str, optional
+            The name of the generated Broker
+        Returns
+        -------
+        db : Broker
+        Examples
+        --------
+        Create a Broker backed by sqlite databases. (This is configuration is
+        not recommended for large or important deployments. See the
+        configuration documentation for more.)
+        """
+
+        # Import component classes.
+        if self.telemetry_db is None:
+            config = self.lookup_config('name')
+
+            if self._client is None:
+                self._client = pymongo.MongoClient(self.config['host'],
+                                                   self.config.get('port',
+                                                                   None))
+
+            self.telemetry_db = self._client(config['database'])
+
+
+TelemetryUI = TelemetryClass()

--- a/ophyd/tests/test_telemetry.py
+++ b/ophyd/tests/test_telemetry.py
@@ -1,0 +1,74 @@
+from ophyd.telemetry import TelemetryUI
+
+
+# Start with a test of the generic data entry and extraction process.
+def test_telemetry_input_and_output(hw):
+    # make an input dictionary
+    input_data = {'estimation': {'time': 7.5, 'std_dev': 0.75},
+                  'time': {'start': 0, 'stop': 8},
+                  'position': {'start': 0, 'stop': 5}}
+    # make the output data
+    output_data = {'object_name': 'motor1', 'action': 'set'}
+    output_data.update(input_data)
+    # ensure the telemetry list is empty
+    TelemetryUI.telemetry = []
+    # run the insert command
+    TelemetryUI.record_telemetry('motor1', 'set', input_data)
+    # test that the only database entry equals the output data
+    assert TelemetryUI.telemetry[0] == output_data
+    # fetch the data using the builtin command and test it is as expected
+    fetch_data = TelemetryUI.fetch_telemetry('motor1', 'set')[0]
+    assert fetch_data == output_data
+
+
+# RUN SOME TESTS ON AN EpicsMotorEstTime device  `ophyd.sim hw.motor1`.
+# test motor set.
+def test_telemetry_on_motor_set(hw):
+    output_data = {'object_name': 'motor1',
+                   'action': 'set',
+                   'estimation': {'time': float('nan'),
+                                  'std_dev': float('nan')},
+                   'time': {'start': float('nan'), 'stop': float('nan')},
+                   'position': {'start': 5, 'stop': 3},
+                   'velocity': {'setpoint': 1},
+                   'settle_time': {'setpoint': 0}}
+    hw.motor1.set(5)  # move motor1 to a starting location (5)
+    TelemetryUI.telemetry = []  # empty the telemetry database
+    hw.motor1.set(3)  # move motor1 to the finishing location (3)
+    # test that the keys are the same
+    assert TelemetryUI.telemetry[0].keys() == output_data.keys()
+    # test that each of the values for all non-time related keys are the same
+    for key in ['object_name', 'action', 'position', 'velocity',
+                'settle_time']:
+        assert TelemetryUI.telemetry[0][key] == output_data[key]
+
+# In the future we will need to add some tests of 'motor.trigger',
+# 'motor.stage' and 'motor.unstage' when it is implemented
+
+
+# RUN SOME TESTS ON AN ADEstTime device `ophyd.sim hw.det1`
+# test det trigger.
+def test_telemetry_on_det_trigger(hw):
+    # In the future, once they are implemented, we will need to modify this to
+    # check the `det1.stage` and `det1.unstage` inserts.
+    output_data = {'object_name': 'det1',
+                   'action': 'trigger',
+                   'estimation': {'time': float('nan'),
+                                  'std_dev': float('nan')},
+                   'time': {'start': float('nan'), 'stop': float('nan')},
+                   'trigger_mode': {'setpoint': 1},
+                   'num_images': {'setpoint': 1},
+                   'settle_time': {'setpoint': 0},
+                   'acquire_period': {'setpoint': 1},
+                   'acquire_time': {'setpoint': 1}}
+
+    hw.det1.stage()  # stage the detector
+    TelemetryUI.telemetry = []  # empty the telemetry database
+    hw.det1.trigger()  # trigger the detector
+    hw.det1.unstage()
+    # test that the keys are the same
+    assert TelemetryUI.telemetry[0].keys() == output_data.keys()
+    # test that each of the values for all non-time related keys are the same
+    for key in ['object_name', 'action', 'trigger_mode', 'num_images',
+                'settle_time', 'acquire_period', 'acquire_time']:
+        assert TelemetryUI.telemetry[0][key] == output_data[key]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 codecov
 matplotlib
+pymongo
 pytest
 databroker
 caproto[complete]


### PR DESCRIPTION
This is part of a system that allows for time estimation for plans. It implements a telemetry and time estimation process at the ophyd object level to estimate the time to make a 'cmd' on an object. 'cmd' is the commands past in the plan messages.

An est_time('plan') function (see [NSLS-II/Bluesky PR # 1048](https://github.com/NSLS-II/bluesky/pull/1048) ), similar to summarise_plans('plan'), then steps through each message in order to estimate the time to perform each step and hence the entire plan. 
This fixes  [NSLS-II/Bluesky issue # 713](https://github.com/NSLS-II/bluesky/issues/713), in combination with [NSLS-II/Bluesky PR # 1048](https://github.com/NSLS-II/bluesky/pull/1048) 