### PR TITLE
Pre defined positions not device

### DIFF
--- a/ophyd/PreDefinedPositions.py
+++ b/ophyd/PreDefinedPositions.py
@@ -2,7 +2,6 @@ from bluesky.planstubs import mv
 import collections
 import time
 import networkx as nx
-from matplotlib import pyplot as plt
 import functools
 import operator
 
@@ -320,6 +319,8 @@ class PreDefinedPositions():
             function from the networkx module.
 
         '''
+        # Importing matplotlib here to avoid making it a dependency of ohpyd.
+        from matplotlib import pyplot as plt
 
         if self.locations is None:
             print('No locations to visualize')

--- a/ophyd/PreDefinedPositions.py
+++ b/ophyd/PreDefinedPositions.py
@@ -1,86 +1,101 @@
-from ophyd import EpicsMotor,Device
+from bluesky.planstubs import mv
 import collections
 import time
 import networkx as nx
-from matplotlib.patches import ArrowStyle
-
+from matplotlib import pyplot as plt
+import functools
+import operator
 
 
 class PreDefinedPositions():
     '''
-    A class that is used to create a 'collection' of components, and allow a series of pre-defined 
-    'locations' to be designated. It allows motion between these locations via calculated 'paths'.
-    These 'paths' are calcualted based on the optional 'neighbours' dictionary, which for each 
-    'location' defines a list of other locations that it is 'safe' to move directly to. The 
-    'components' in the instance can be any 'component' in ophyd: such as motor axes, detectors, 
-    gate valves, their configuration attributes and or even another PreDefinedPositions instance.
-    The 'locations' do not need to have a value specifed for every component in the collection, and 
-    the collection can be in more than one 'location' at any given time. A further optional 
-    dictionary allows the user to define a 'volume' for all or some 'locations', within which the 
-    device is considered 'in the location'. Moves to/from a location always end at the 'location' 
-    defined in the 'locations' dictionary. If a 'volume' is not defined for any of the 'locations'
-    then it is assumed to be in that location if all listed component values are with 1% of the 
-    'location'.   
-     
+    A class that is used to create a 'collection' of components, and allow a
+    series of pre-defined 'locations' to be designated. It allows motion
+    between these locations via calculated 'paths'. These 'paths' are
+    calculated based on the optional 'neighbours' dictionary, which for each
+    'location' defines a list of other locations that it is 'safe' to move
+    directly to. The 'components' in the instance can be any 'component' in
+    ophyd: such as motor axes, detectors, gate valves, their configuration
+    attributes and or even another PreDefinedPositions instance. The
+    'locations' do not need to have a value specifed for every component in the
+    collection, and the collection can be in more than one 'location' at any
+    given time. A further optional dictionary allows the user to define a
+    'volume' for all or some 'locations', within which the device is considered
+    'in the location'. Moves to/from a location always end at the 'location'
+    defined in the 'locations' dictionary. If a 'volume' is not defined for any
+    of the 'locations' then it is assumed to be in that location if all listed
+    component values are with 1% of the 'location'.
+
     Parameters
     ----------
     components : Dictionary.
-        A dictionary of components associated with this collection, with keywords being the name to 
-        use in this collection and the value being the component. A reference to each component will 
-        be created so that they can be accessed using 'collection.name' for each component. Components         can be any components including but not limited too: motor axes, detectors, gate valves (and
-        thier configuration attributes) or even another PreDefinedPositions 'collection'.
+        A dictionary of components associated with this collection, with
+        keywords being the name to use in this collection and the value being
+        the component. A reference to each component will be created so that
+        they can be accessed using 'collection.name' for each component.
+        Components can be any components including but not limited too:
+        motor axes, detectors, gate valves (and thier configuration attributes)
+        or even another PreDefinedPositions 'collection'.
     locations : dictionary, optional.
-        A keyword:Value dictionary that lists all of the predefined positions (keyword) and a 
-        list of axis-value pairs to be set in this location in the form: 
-        {location1:[axis1,value1,axis2,value2,...], 
-            location2:[axis1,value1,axis2,value2,...],.....}.
-            NOTE: 
-            1. Not all axes need to have a specifed value for each device location, only 
-            those with a specifed value are moved/checked for a given location.
-            2. All axes specifed in this dictionary must be specifed as components in 'components'.
+        A keyword:Value dictionary that lists all of the predefined positions
+        (keyword) and a list of axis-value pairs to be set in this location in
+        the form: {location1:[axis1,value1,axis2,value2,...],
+                   location2:[axis1,value1,axis2,value2,...],.....}.
+            .. note::
+                #. Not all axes need to have a specifed value for each device
+                   location, only those with a specifed value are moved/checked
+                   for a given location.
+                #. All axes specifed in this dictionary must be specifed as
+                   components in 'components'.
     neighbours : Dictionary, optional.
-        A keyword:value dictionary where each keyword is a location defined in 'locations' and 
-        each value is a list of 'neighbours' for that location. Motion can only occur between 
-        neighbours, for non-neighbours a path through various locations will be used, if 
-        it is found using self.find_path. Optionally if the list contains 'All' this indicates 
-        that evey location is accesible from this one. If no neighbours are defined for this 
-        location then it is assumed that no direct motion is allowed from this location.
+        A keyword:value dictionary where each keyword is a location defined in
+        'locations' and each value is a list of 'neighbours' for that location.
+        Motion can only occur between neighbours, for non-neighbours a path
+        through various locations will be used, if it is found using
+        self.find_path. Optionally if the list contains 'All' this indicates
+        that evey location is accesible from this one. If no neighbours are
+        defined for this location then it is assumed that no direct motion is
+        allowed from this location.
     regions : Dictionary, optional.
-        The optional keyword:value dictionary that has location keywords and 'region' values 
-        'region' is a dictionary that has axis_name keywords and [min_val, max_val] values 
-        denoting the range of values for this location and axis. This dictionary has the form: 
+        The optional keyword:value dictionary that has location keywords and
+        'region' values 'region' is a dictionary that has axis_name keywords
+        and [min_val, max_val] values denoting the range of values for this
+        location and axis. This dictionary has the form:
             {location1:{'axis1_name':[axis1_min_val,axis1_max_val],
-                                                   'axis2_name':[axis2_min_val,axis2_max_val],...}, 
-            location2:{'axis1_name':[axis1_min_val,axis1_max_val],
-                                                   'axis2_name':[axis2_min_val,axis2_max_val],...},
+                        'axis2_name':[axis2_min_val,axis2_max_val],...},
+             location2:{'axis1_name':[axis1_min_val,axis1_max_val],
+                        'axis2_name':[axis2_min_val,axis2_max_val],...},
                                           ....}.
-            NOTE: Not all locations in the 'locations' require an entry in this dictionary and not 
-            all axes defined with a value in 'locations', for a given location, must have a 
-            range in this dictionary for the given location. For any axis that a 'range' is not 
-            provided a default range of =/- 1% is used.
+            .. note::
+                Not all locations in the 'locations' require an entry in this
+                dictionary and not all axes defined with a value in 'locations'
+                , for a given location, must have a range in this dictionary
+                for the given location. For any axis that a 'range' is not
+                provided a default range of +/- 1% is used.
 
-
-    NOTES ON PREDEFINED MOTION WITH NEIGHBOURS:
-    1. To ensure the motion to a predefined location always occurs when using neighbours to define
-        motion 'paths' it is best to ensure that the device is always in a 'location' by making sure
-        that motion can not move the device outside of all 'locations'.
-    2. To ensure that motion occurs always via a path then each 'point' in the path should be a 
-        location, and it should only have the neighbours that are before or after it in the required
-        path.
+    .. note::
+        NOTES ON PREDEFINED MOTION WITH NEIGHBOURS:
+        #. To ensure the motion to a predefined location always occurs when
+           using neighbours to define motion 'paths' it is best to ensure that
+           the device is always in a 'location' by making sure that motion can
+           not move the device outside of all 'locations'.
+        #. To ensure that motion occurs always via a path then each 'point' in
+           the path should be a location, and it should only have the
+           neighbours that are before or after it in the required path.
     '''
-    def __init__(self, components, *,locations={}, neighbours={}, regions={}):
+    def __init__(self, components, *, locations={}, neighbours={}, regions={}):
 
-        #define inputs as attributes
+        # Define inputs as attributes
         self.components = components
         self.locations = locations
         self.neighbours = neighbours
         self.regions = regions
 
-        #define components as attributes
-        for attribute in list(components.keys())
-            self.attribute = components[keys]
+        # Define components as attributes
+        for attribute in list(components.keys()):
+            self.attribute = components[attribute]
 
-        self.nxGraph=nx.DiGraph(directed=True)
+        self.nxGraph = nx.DiGraph(directed=True)
         self.nxGraph.add_nodes_from(list(self.locations.keys()))
 
         for location in list(neighbours.keys()):
@@ -91,42 +106,45 @@ class PreDefinedPositions():
                 for neighbour in neighbours[location]:
                     self.nxGraph.add_edge(location, neighbour)
 
-
         def mv_plan(to_location):
-            '''
-            A function that returns a plan that can move the collection  to the location defined by 
-            'value'
-    
+            '''Returns a plan to move to 'to_location'.
+
+            A function that returns a plan that can move the collection  to the
+            location defined by 'to_location'
+
             Parameters
             ----------
             to_location: string
                 The name of the location that it is required to move too.
             '''
-            
-            setattr(self,to_location,mv_axis(to_location))#this resolves an issue with the definition
-                                                          #being set to None after a call 
-            
-            path_list = self.find_path(from_location='current_location',to_location=to_location)
-            if value not in list(self.locations.keys()):
-                raise ValueError(f'{location} is not a pre defined position')  
+
+            setattr(self, to_location, mv_plan(to_location))
+            # This resolves an issue with the definition being set to None
+            # after a call
+            path_list = self.find_path(from_location='current_location',
+                                       to_location=to_location)
+            if to_location not in list(self.locations.keys()):
+                raise ValueError(f'{to_location} is not a pre defined\
+                                 position')
             else:
                 for location in path_list:
-                    print ('Move {} to "{}"'.format(self.name,location))
-                    yield from mv(*self.locations['location'])     
+                    print('Move {} to "{}"'.format(self.name, location))
+                    yield from mv(*self.locations['location'])
 
-        for location in self.locations:#define the position attributes
-            setattr(self,location,mv_axis(location))
-
+        for location in self.locations:  # Define the position attributes
+            setattr(self, location, mv_plan(location))
 
     def set(self, value):
-        '''Moves the collection to the location defined by 'value' and returns a status object.
+        '''Moves the collection to the location defined by 'value' and returns
+        a status object.
 
-        This function mimics the 'set' function of an ophyd 'device', it is primarily used to allow
-        instances of this class to be added as 'components' of another instance.
+        This function mimics the 'set' function of an ophyd 'device', it is
+        primarily used to allow instances of this class to be added as
+        'components' of another instance.
 
         Parameters
         ----------
-        value, string: 
+        value, string:
             The pre defined location that the object is to move to.
 
         Returns
@@ -137,82 +155,89 @@ class PreDefinedPositions():
         Raises:
         -------
         ValueError:
-            On invalid locations.  
+            On invalid locations.
 
         '''
 
         if value not in list(self.locations.keys()):
-            raise ValueError(f'{location} is not a pre defined position')  
+            raise ValueError(f'{value} is not a pre defined position')
         else:
             status = []
-            path_list = self.find_path(from_location='current_location',to_location=to_location)
+            path_list = self.find_path(from_location='current_location',
+                                       to_location=value)
 
             for location in path_list:
-                axis_list=self.locations[location]
-                for i in range(0,len(axis_list),2):
-                    status.append(getattr(self,axis_list[i]).set(axis_list[i+1])
+                axis_list = self.locations[location]
+                for i in range(0, len(axis_list), 2):
+                    status.append(getattr(self, axis_list[i]).
+                                  set(axis_list[i+1]))
 
         return functools.reduce(operator.and_, status)
-        
 
     def read(self):
         '''
-        An attribute that returns the current 'location' of the unit as an ordered dictionary. This
-        is used identically to the read attribute function for a standard device and therefore can 
-        be used in the baseline.
-        
+        An attribute that returns the current 'location' of the unit as an
+        ordered dictionary. This is used identically to the read attribute
+        function for a standard device and therefore can be used in the
+        baseline.
+
         Parameters
         ----------
         read_dict: ordered dictionary, ouput
-            The output dictionary that matches the standard output for a Device.
+            The output dictionary that matches the standard output for a
+            Device.
         '''
 
         out_dict = collections.OrderedDict()
-        out_dict[self.name+'_location'] = {'timestamp':time.time(),'value':self.status }
+        out_dict[self.name+'_location'] = {'timestamp': time.time(),
+                                           'value': self.status}
 
         read_dict = super().read()
         read_dict.update(out_dict)
-        
+
         return read_dict
 
-    
-    
     def describe(self):
         '''
-        An attribute that returns the current 'location' description of the output data as an 
-        ordered dictionary. This is used identically to the describe attribute function for a 
-        standard device and therefore can be used in the baseline.
-        
+        An attribute that returns the current 'location' description of the
+        output data as an ordered dictionary. This is used identically to the
+        describe attribute function for a standard device and therefore can be
+        used in the baseline.
+
         Parameters
         ----------
         describe_dict: ordered dictionary, ouput
-            The output dictionary that matches the standard output for a Device.
+            The output dictionary that matches the standard output for a
+            Device.
         '''
 
         out_dict = collections.OrderedDict()
         out_dict[self.name+'_location'] = {'dtype': 'string',
-               'lower_ctrl_limit': None,
-               'precision': None,
-               'shape': [],
-               'source': 'None',
-               'units': None,
-               'upper_ctrl_limit': None}
-              
+                                           'lower_ctrl_limit': None,
+                                           'precision': None,
+                                           'shape': [],
+                                           'source': 'None',
+                                           'units': None,
+                                           'upper_ctrl_limit': None}
+
         describe_dict = super().describe()
         describe_dict.update(out_dict)
-        
+
         return describe_dict
 
+    def find_path(self, from_location=None, to_location=None):
+        '''Find the shortest path from 'from_location' to 'to_location'.
+        Find the shortest path from 'from_location' to 'to_location' passing
+        only thorugh the neighbours for each location defiend by the dictionary
+        'neighbours'. Returns an empty list if no path found otherwise returns
+        a list of 'locations' that define the path. If to_location is None then
+        it returns a dictionary showing the shortest path to all possible
+        locations. If from_location is None it returns a dictionary showing the
+        shortest path from all locations to the current location. If both are
+        None it returns a dictioanry of dictionaries. If from_location is
+        'current_location' the starting point is changed to the current
+        location.
 
-    def find_path(self,from_location=None,to_location=None):
-        '''
-        Find the shortest path from 'from_location' to 'to_location' passing only thorugh the 
-        neighbours for each location defiend by the dictionary 'neighbours'. Returns an empty list 
-        if no path found otherwise returns a list of 'locations' that define the path. If to_location 
-        is None then it returns a dictionary showing the shortest path to all possible locations. If
-        from_location is None it returns a dictionary showing the shortest path from all locations to
-        the current location. If both are None it returns a dictioanry of dictionaries. If 
-        from_location is 'current_location' the starting point is changed to the current location.
         Parameters
         ---------
         from_location: string
@@ -220,112 +245,129 @@ class PreDefinedPositions():
         to_location: string
             The name of the ending location required for the path.
         path_list: list, output
-            A list locations indicating the path to take to reach the required position.
+            A list locations indicating the path to take to reach the required
+            position.
         '''
 
-
         if from_location is not 'current_location':
-            path_list = nx.shortest_path(self.nxGraph,source=from_location,target=to_location)
-        elif isinstance(self.status_list,str) and self.neighbours is not None:
-            path_list=(self.status_list)
+            path_list = nx.shortest_path(self.nxGraph, source=from_location,
+                                         target=to_location)
+        elif isinstance(self.status_list, str) and self.neighbours is not None:
+            path_list = (self.status_list)
         else:
             if self.neighbours is None:
-                path_list=[to_location]
+                path_list = [to_location]
             else:
-                path_list=[]
+                path_list = []
                 for location in self.status_list:
-                    prev_path_list=path_list
-                    path_list=nx.shortest_path(self.nxGraph,source=location,target=to_location)
+                    prev_path_list = path_list
+                    path_list = nx.shortest_path(self.nxGraph, source=location,
+                                                 target=to_location)
 
-                    if len(prev_path_list)>1 and len(prev_path_len)<len(path_list):
-                        path_list=prev_path_list
+                    if len(prev_path_list) > 1 and\
+                       len(prev_path_list) < len(path_list):
+                        path_list = prev_path_list
 
         return path_list
 
-
-    def visualize_paths(self, fig_size = [10,10], axis_labels = ['arb. axis', 'arb. axis'] ,
-                        options = {}):
-        ''' Creates a plot of the possible paths between the predefined locations.
+    def visualize_paths(self, fig_size=[10, 10],
+                        axis_labels=['arb. axis', 'arb. axis'],
+                        options={}):
+        ''' Creates a plot of the possible paths between the predefined
+        locations.
 
         PARAMETERS
         ----------
         fig_size: list, optional
-            A list containing the horizontal and vertical size to make the figure.
-        axis_labels: list, optional 
+            A list containing the horizontal and vertical size to make the
+            figure.
+        axis_labels: list, optional
             A list of horizontal and vertical axis names for the figure.
         options: dict, optional
-            An optional dictionary that contains kwargs for the draw_networkx function from the
-            networkx module.
+            An optional dictionary that contains kwargs for the draw_networkx
+            function from the networkx module.
 
         '''
 
         if self.locations is None:
-            print ('No locations to visualize')
+            print('No locations to visualize')
         else:
-            
-            default_options={'pos':nx.circular_layout(self.nxGraph),'node_color':'darkturquoise',
-                    'edge_color':'grey','node_size':6000, 'width':3,'arrowstyle':'-|>',
-                    'arrow_size':12}
+
+            default_options = {'pos': nx.circular_layout(self.nxGraph),
+                               'node_color': 'darkturquoise',
+                               'edge_color': 'grey', 'node_size': 6000,
+                               'width': 3, 'arrowstyle': '-|>',
+                               'arrow_size': 12}
             default_options.update(options)
 
-            plt.figure('visualize {} paths'.format(self.name),figsize=(fig_size[0],fig_size[1]))
+            plt.figure('visualize {} paths'.format(self.name),
+                       figsize=(fig_size[0], fig_size[1]))
             plt.xlabel(axis_labels[0])
             plt.ylabel(axis_labels[1])
-            nx.draw_networkx(self.nxGraph,arrows=True,**default_options)
-
-
+            nx.draw_networkx(self.nxGraph, arrows=True, **default_options)
 
     @property
     def position(self):
         '''Lists the current locations the collection is in.
 
-        This returns a list containing the names of the current locations that the collection is in.
-        
+        This returns a list containing the names of the current locations that
+        the collection is in.
+
         Returns
         -------
         location_list : list
         '''
-   
+
         if self.locations is not None:
-            location_list='unknown location'
+            location_list = 'unknown location'
             for location in self.locations:
-                in_position=True
-                for i in range(0,len(self.locations[location]),2):
+                in_position = True
+                for i in range(0, len(self.locations[location]), 2):
                     axis = self.locations[location][i]
                     value = self.locations[location][i+1]
 
-                    if hasattr(getattr(self,axis),'position'):
+                    if hasattr(getattr(self, axis), 'position'):
                         if isinstance(self.in_band, float):
-                            if getattr(self,axis).position < value - self.in_band or \
-                                getattr(self,axis).position > value + self.in_band:
-                                in_position=False
-                        else:
-                            if getattr(self,axis).position < self.in_band[location][axis][0] or \
-                                getattr(self,axis).position > self.in_band[location][axis][1] :
-                                in_position=False
+                            if getattr(self, axis).position <\
+                               value - self.in_band or\
+                               getattr(self, axis).position >\
+                               value + self.in_band:
 
-                    elif hasattr(getattr(self,axis),'get'):
+                                in_position = False
+                        else:
+                            if getattr(self, axis).position <\
+                               self.in_band[location][axis][0] or\
+                               getattr(self, axis).position >\
+                               self.in_band[location][axis][1]:
+
+                                in_position = False
+
+                    elif hasattr(getattr(self, axis), 'get'):
                         if isinstance(self.in_band, float):
-                            if getattr(self,axis).get() < value - self.in_band or \
-                                getattr(self,axis).get() > value + self.in_band:
-                                in_position=False
+                            if getattr(self, axis).get() <\
+                               value - self.in_band or\
+                               getattr(self, axis).get() >\
+                               value + self.in_band:
+
+                                in_position = False
                         else:
-                            if getattr(self,axis).get() < self.in_band[location][axis][0] or \
-                                getattr(self,axis).get() > self.in_band[location][axis][1] :
-                                in_position=False
+                            if getattr(self, axis).get() <\
+                               self.in_band[location][axis][0] or\
+                               getattr(self, axis).get() >\
+                               self.in_band[location][axis][1]:
 
-                    elif hasattr(getattr(self,axis),'status'):
-                        if getattr(self,axis).status is not value:
-                            in_position=False
+                                in_position = False
 
-                if in_position: 
+                    elif hasattr(getattr(self, axis), 'status'):
+                        if getattr(self, axis).status is not value:
+                            in_position = False
+
+                if in_position:
                     if location_list == 'unknown location':
                         location_list = [location]
                     else:
                         location_list.append(location)
         else:
-            location_list=['no locations']
+            location_list = ['no locations']
 
         return location_list
-   
-            

--- a/ophyd/PreDefinedPositions.py
+++ b/ophyd/PreDefinedPositions.py
@@ -1,0 +1,362 @@
+from ophyd import EpicsMotor,Device
+import collections
+import time
+import networkx as nx
+from matplotlib.patches import ArrowStyle
+
+
+
+class PreDefinedPositions(Device):
+    '''
+    A class that is used to create a diagnostic unit and/or a single axis mask units. The
+    class has the axis as an attribute as well as a series of pre-defined 'locations'. It also 
+    allows motion between these locations via 'paths' defined by the optional keyword dictionary
+    neighbours. If neighbours is not none it will define the shortest path between the current 
+    location and the requested location moving only from a location to it's 'neighbours'.
+    
+    Parameters
+    ----------
+    self : numerous paramters
+        All of the parameters associated with the parent class 'Device'
+    locations : dictionary, optional
+        A keyword:Value dictionary that lists all of the predefined locations (keyword) and a 
+        list of axis-value pairs to be set in this location in the form: 
+        {location1:['axis1_name',value1,axis2_name',value2,...], 
+            location2:['axis1_name',value1,axis2_name',value2,...],.....}.
+            NOTE: Not all axes need to have a specifed value for each device location, only 
+            those with a specifed value are moved/checked for a given location. 
+    neighbours : Dictionary, optional
+        A keyword:value dictionary where each keyword is a location defined in 'locations' and 
+        each value is a list of 'neighbours' for that location. When defined motion occurs only 
+        between neighbours, for non-neighbours a path through various locations will be used, if 
+        it is found using self.find_path. 
+    in_band : float or dictionary, optional
+        A float that gives the in-band range for all axes when deciding if the device is 'in' the 
+        correct location or not. The default value is 0.1. The optional keyword:value dictionary 
+        that lists all of the predefined locations (keyword) and a sub-dictionary that has axis_name
+        keywords and [min_val,max_val] values denoting the range of values for this location and 
+        axis. This dictionary has the form: 
+            {location1:{'axis1_name':[axis1_min_val,axis1_max_val],
+                                                   'axis2_name':[axis2_min_val,axis2_max_val],...}, 
+            location2:{'axis1_name':[axis1_min_val,axis1_max_val],
+                                                   'axis2_name':[axis2_min_val,axis2_max_val],...},
+                                          ....}.
+            NOTE: All axes defined with a value in 'locations', for a given location, must have a 
+            range in this dictionary for the given location, unless the 'value' in location is a 
+            string.
+    cam_list : list, optional
+        A list of cameras associated with this device, they will be accesible via the attribute
+        cam or cam1,cam2 etc.
+    qem_list : list, optional
+        A list of qem's associated with this device, they will be accesible via the attribute
+        qem or qem1,qem2 etc.
+    gv_list : list, optional
+        A list of gv's associated with this device, they will be accesible via the attribute
+        gv or gv1,gv2 etc.
+    vis_path_options : dict, optional
+        A dictionary that allows for different path visulatiztion options, the parameters and values
+        are those defined for drawing in the python networkX Module. A set of defaults is used if this 
+        parameter is None. May also contain the optional 'axis_labels':['x_label','y_label'] and 
+        'fig_size':[x_size,y_size] values.
+    NOTES ON PREDEFINED MOTION WITH NEIGHBOURS:
+    1. The locations dictionary can include gate valves and/or parameter sets as axes with the 
+        value being 'string'.
+    2. To ensure the motion to a predefined location always occurs when using neighbours to define
+        motion 'paths' it is best to ensure that the device is always in a 'location' by making sure
+        that motion can not move the device outside of all 'locations'.
+    3. Devices can be in more than one location at a time.
+    4. To ensure that motion occurs always via a path then each 'point' in the path should be a 
+        location, and it should only have the neighbours that are before or after it in the required
+        path.
+    '''
+    def __init__(self, *args, locations=None, neighbours=None,in_band=0.1, cam_list=None, 
+            qem_list=None, gv_list=None, vis_path_options=None,**kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.locations = locations
+        self.in_band = in_band
+        self.neighbours = neighbours
+        self.vis_path_options=vis_path_options
+
+        self.nxGraph=nx.DiGraph(directed=True)
+        
+        if locations is not None: self.nxGraph.add_nodes_from(list(locations.keys()))
+
+        if neighbours is not None:
+            for key in neighbours.keys():
+                for neighbour in neighbours[key]:
+                    self.nxGraph.add_edge(str(key),neighbour)
+        elif locations is not None:
+            for location in locations.keys():
+                for location2 in locations.keys():
+                    if location is not location2:
+                        self.nxGraph.add_edge(str(location),str(location2))
+
+
+        if isinstance(cam_list,list): 
+            if len(cam_list)==1:
+                self.cam=cam_list[0]
+            else:
+                for i,cam in enumerate(cam_list):
+                    setattr(self,'cam{}'.format(i+1),cam_list[i])                
+
+        if isinstance(qem_list,list): 
+            if len(qem_list)==1:
+                self.qem=qem_list[0]
+            else:
+                for i,qem in enumerate(qem_list):
+                    setattr(self,'qem{}'.format(i+1),qem_list[i])  
+
+        if isinstance(gv_list,list): 
+            if len(gv_list)==1:
+                self.gv=gv_list[0]
+            else:
+                for i,gv in enumerate(gv_list):
+                    setattr(self,'qem{}'.format(i+1),gv_list[i])  
+
+
+
+        def mv_axis(to_location):
+            '''
+            A function that moves the diagnostic or single axis slit to the location defined by 
+            'value'
+    
+            Parameters
+            ----------
+            to_location: string
+                The name of the location that it is required to move too.
+            '''
+            
+            setattr(self,to_location,mv_axis(to_location))#this resolves an issue with the definition
+                                                          #being set to None after a call 
+            
+            path_list = self.find_path(from_location='current_location',to_location=to_location)
+            if path_list == 'unknown location':#if the current location is unknown
+                print ('current location is not pre-defined, move to predefined position first')
+                print ('a list of locations and axis values can be found using the "locations"')
+                print ('attribute, e.g. device.locations')
+            else:
+                for location in path_list:
+                    print ('Move {} to "{}"'.format(self.name,location))
+                    axis_value_list=self.get_axis_value_list(location)
+                    yield from mv(*axis_value_list)
+                    
+
+        if locations is not None:
+            for location in self.locations:#define the position attributes
+                setattr(self,location,mv_axis(location))
+
+        
+        
+    def read(self):
+        '''
+        An attribute that returns the current 'location' of the unit as an ordered dictionary. This
+        is used identically to the read attribute function for a standard device and therefore can 
+        be used in the baseline.
+        
+        Parameters
+        ----------
+        read_dict: ordered dictionary, ouput
+            The output dictionary that matches the standard output for a Device.
+        '''
+
+        out_dict = collections.OrderedDict()
+        out_dict[self.name+'_location'] = {'timestamp':time.time(),'value':self.status }
+
+        read_dict = super().read()
+        read_dict.update(out_dict)
+        
+        return read_dict
+
+    
+    
+    def describe(self):
+        '''
+        An attribute that returns the current 'location'description of the output data as an 
+        ordered dictionary. This is used identically to the describe attribute function for a 
+        standard device and therefore can be used in the baseline.
+        
+        Parameters
+        ----------
+        describe_dict: ordered dictionary, ouput
+            The output dictionary that matches the standard output for a Device.
+        '''
+
+        out_dict = collections.OrderedDict()
+        out_dict[self.name+'_location'] = {'dtype': 'string',
+               'lower_ctrl_limit': None,
+               'precision': None,
+               'shape': [],
+               'source': 'None',
+               'units': None,
+               'upper_ctrl_limit': None}
+              
+        describe_dict = super().describe()
+        describe_dict.update(out_dict)
+        
+        return describe_dict
+
+
+
+    def get_axis_value_list(self,location):
+        '''
+        Returns the axis-value list for a defined location
+        
+        Returns
+        -------
+        axis_value_list : list, output
+            the axis-value list for the inputted location that is returned
+        '''
+        axis_value_list=[]
+        for item in self.locations[location]:
+                if isinstance(item,str):
+                    axis_value_list.append(getattr(self,item))
+                else:
+                    axis_value_list.append(item)
+                    
+        return axis_value_list
+        
+
+    def find_path(self,from_location=None,to_location=None):
+        '''
+        Find the shortest path from the 'from_location' to 'to_location' passing only thorugh the 
+        neighbours for each location defiend by the dictionary 'neighbours'. Returns an empty list 
+        if no path found otherwise returns a list of 'locations' that define the path. If to_location 
+        is None then it returns a dictionary showing the shortest path to all possible locations. If
+        from_location is None it returns a dictionary showing the shortest path from all locations to
+        the current location. If both are None it returns a dictioanry of dictionaries. If 
+        from_location is 'current_location' the starting point is changed to the current location.
+        Parameters
+        ---------
+        from_location: string
+            The name of the starting location required for the path.
+        to_location: string
+            The name of the ending location required for the path.
+        path_list: list, output
+            A list locations indicating the path to take to reach the required position.
+        '''
+
+
+        if from_location is not 'current_location':
+            path_list = nx.shortest_path(self.nxGraph,source=from_location,target=to_location)
+        elif isinstance(self.status_list,str) and self.neighbours is not None:
+            path_list=(self.status_list)
+        else:
+            if self.neighbours is None:
+                path_list=[to_location]
+            else:
+                path_list=[]
+                for location in self.status_list:
+                    prev_path_list=path_list
+                    path_list=nx.shortest_path(self.nxGraph,source=location,target=to_location)
+
+                    if len(prev_path_list)>1 and len(prev_path_len)<len(path_list):
+                        path_list=prev_path_list
+
+        return path_list
+
+    @property
+    def visualize_paths(self):
+        ''' Creates a plot of the possible paths between the predefined locations.
+        '''
+        if self.locations is None:
+            print ('No locations to visualize')
+        else:
+            
+            options={'pos':nx.circular_layout(self.nxGraph),'node_color':'darkturquoise','edge_color':'grey','node_size':6000,
+                     'width':3,'arrowstyle':'-|>','arrow_size':12}
+            if self.vis_path_options is not None:
+                options.update(self.vis_path_options)
+
+            if 'fig_size' in options.keys():
+                fig_size=[options['fig_size'][0],options['fig_size'][1]]
+                del options['fig_size']
+            else:
+                fig_size=[10,10]
+
+            if 'axis_labels' in options.keys():
+                axis_labels=[options['axis_labels'][0],options['axis_labels'][1]]
+                del options['axis_labels']
+            else:
+                axis_labels=['arbitrary axis','arbitrary axis']
+
+
+            plt.figure('visualize {} paths'.format(self.name),figsize=(fig_size[0],fig_size[1]))
+            plt.xlabel(axis_labels[0])
+            plt.ylabel(axis_labels[1])
+            nx.draw_networkx(self.nxGraph,arrows=True,**options)
+
+
+
+    @property
+    def status_list(self):
+        '''The current location of the device
+        
+        Returns
+        -------
+        position : list
+        '''
+   
+        if self.locations is not None:
+            loc_list='unknown location'
+            for location in self.locations:
+                in_position=True
+                for i in range(0,len(self.locations[location]),2):
+                    axis = self.locations[location][i]
+                    value = self.locations[location][i+1]
+
+                    if hasattr(getattr(self,axis),'position'):
+                        if isinstance(self.in_band, float):
+                            if getattr(self,axis).position < value - self.in_band or \
+                                getattr(self,axis).position > value + self.in_band:
+                                in_position=False
+                        else:
+                            if getattr(self,axis).position < self.in_band[location][axis][0] or \
+                                getattr(self,axis).position > self.in_band[location][axis][1] :
+                                in_position=False
+
+                    elif hasattr(getattr(self,axis),'get'):
+                        if isinstance(self.in_band, float):
+                            if getattr(self,axis).get() < value - self.in_band or \
+                                getattr(self,axis).get() > value + self.in_band:
+                                in_position=False
+                        else:
+                            if getattr(self,axis).get() < self.in_band[location][axis][0] or \
+                                getattr(self,axis).get() > self.in_band[location][axis][1] :
+                                in_position=False
+
+                    elif hasattr(getattr(self,axis),'status'):
+                        if getattr(self,axis).status is not value:
+                            in_position=False
+
+                if in_position: 
+                    if loc_list == 'unknown location':
+                        loc_list = [location]
+                    else:
+                        loc_list.append(location)
+        else:
+            loc_list=['no locations']
+
+        return loc_list
+   
+    @property  
+    def status(self):
+        '''The current location of the device
+        
+        Returns
+        -------
+        position : string
+        '''
+
+        if isinstance(self.status_list,list):
+            position=''
+            for location in self.status_list:
+                if len(position)>1:
+                    position+=' , '
+
+                position+= location
+        else:
+            position = self.status_list
+
+        return position
+        

--- a/ophyd/PreDefinedPositions.py
+++ b/ophyd/PreDefinedPositions.py
@@ -6,119 +6,95 @@ from matplotlib.patches import ArrowStyle
 
 
 
-class PreDefinedPositions(Device):
+class PreDefinedPositions():
     '''
-    A class that is used to create a diagnostic unit and/or a single axis mask units. The
-    class has the axis as an attribute as well as a series of pre-defined 'locations'. It also 
-    allows motion between these locations via 'paths' defined by the optional keyword dictionary
-    neighbours. If neighbours is not none it will define the shortest path between the current 
-    location and the requested location moving only from a location to it's 'neighbours'.
-    
+    A class that is used to create a 'collection' of components, and allow a series of pre-defined 
+    'locations' to be designated. It allows motion between these locations via calculated 'paths'.
+    These 'paths' are calcualted based on the optional 'neighbours' dictionary, which for each 
+    'location' defines a list of other locations that it is 'safe' to move directly to. The 
+    'components' in the instance can be any 'component' in ophyd: such as motor axes, detectors, 
+    gate valves, their configuration attributes and or even another PreDefinedPositions instance.
+    The 'locations' do not need to have a value specifed for every component in the collection, and 
+    the collection can be in more than one 'location' at any given time. A further optional 
+    dictionary allows the user to define a 'volume' for all or some 'locations', within which the 
+    device is considered 'in the location'. Moves to/from a location always end at the 'location' 
+    defined in the 'locations' dictionary. If a 'volume' is not defined for any of the 'locations'
+    then it is assumed to be in that location if all listed component values are with 1% of the 
+    'location'.   
+     
     Parameters
     ----------
-    self : numerous paramters
-        All of the parameters associated with the parent class 'Device'
-    locations : dictionary, optional
-        A keyword:Value dictionary that lists all of the predefined locations (keyword) and a 
+    components : Dictionary.
+        A dictionary of components associated with this collection, with keywords being the name to 
+        use in this collection and the value being the component. A reference to each component will 
+        be created so that they can be accessed using 'collection.name' for each component. Components         can be any components including but not limited too: motor axes, detectors, gate valves (and
+        thier configuration attributes) or even another PreDefinedPositions 'collection'.
+    locations : dictionary, optional.
+        A keyword:Value dictionary that lists all of the predefined positions (keyword) and a 
         list of axis-value pairs to be set in this location in the form: 
-        {location1:['axis1_name',value1,axis2_name',value2,...], 
-            location2:['axis1_name',value1,axis2_name',value2,...],.....}.
-            NOTE: Not all axes need to have a specifed value for each device location, only 
-            those with a specifed value are moved/checked for a given location. 
-    neighbours : Dictionary, optional
+        {location1:[axis1,value1,axis2,value2,...], 
+            location2:[axis1,value1,axis2,value2,...],.....}.
+            NOTE: 
+            1. Not all axes need to have a specifed value for each device location, only 
+            those with a specifed value are moved/checked for a given location.
+            2. All axes specifed in this dictionary must be specifed as components in 'components'.
+    neighbours : Dictionary, optional.
         A keyword:value dictionary where each keyword is a location defined in 'locations' and 
-        each value is a list of 'neighbours' for that location. When defined motion occurs only 
-        between neighbours, for non-neighbours a path through various locations will be used, if 
-        it is found using self.find_path. 
-    in_band : float or dictionary, optional
-        A float that gives the in-band range for all axes when deciding if the device is 'in' the 
-        correct location or not. The default value is 0.1. The optional keyword:value dictionary 
-        that lists all of the predefined locations (keyword) and a sub-dictionary that has axis_name
-        keywords and [min_val,max_val] values denoting the range of values for this location and 
-        axis. This dictionary has the form: 
+        each value is a list of 'neighbours' for that location. Motion can only occur between 
+        neighbours, for non-neighbours a path through various locations will be used, if 
+        it is found using self.find_path. Optionally if the list contains 'All' this indicates 
+        that evey location is accesible from this one. If no neighbours are defined for this 
+        location then it is assumed that no direct motion is allowed from this location.
+    regions : Dictionary, optional.
+        The optional keyword:value dictionary that has location keywords and 'region' values 
+        'region' is a dictionary that has axis_name keywords and [min_val, max_val] values 
+        denoting the range of values for this location and axis. This dictionary has the form: 
             {location1:{'axis1_name':[axis1_min_val,axis1_max_val],
                                                    'axis2_name':[axis2_min_val,axis2_max_val],...}, 
             location2:{'axis1_name':[axis1_min_val,axis1_max_val],
                                                    'axis2_name':[axis2_min_val,axis2_max_val],...},
                                           ....}.
-            NOTE: All axes defined with a value in 'locations', for a given location, must have a 
-            range in this dictionary for the given location, unless the 'value' in location is a 
-            string.
-    cam_list : list, optional
-        A list of cameras associated with this device, they will be accesible via the attribute
-        cam or cam1,cam2 etc.
-    qem_list : list, optional
-        A list of qem's associated with this device, they will be accesible via the attribute
-        qem or qem1,qem2 etc.
-    gv_list : list, optional
-        A list of gv's associated with this device, they will be accesible via the attribute
-        gv or gv1,gv2 etc.
-    vis_path_options : dict, optional
-        A dictionary that allows for different path visulatiztion options, the parameters and values
-        are those defined for drawing in the python networkX Module. A set of defaults is used if this 
-        parameter is None. May also contain the optional 'axis_labels':['x_label','y_label'] and 
-        'fig_size':[x_size,y_size] values.
+            NOTE: Not all locations in the 'locations' require an entry in this dictionary and not 
+            all axes defined with a value in 'locations', for a given location, must have a 
+            range in this dictionary for the given location. For any axis that a 'range' is not 
+            provided a default range of =/- 1% is used.
+
+
     NOTES ON PREDEFINED MOTION WITH NEIGHBOURS:
-    1. The locations dictionary can include gate valves and/or parameter sets as axes with the 
-        value being 'string'.
-    2. To ensure the motion to a predefined location always occurs when using neighbours to define
+    1. To ensure the motion to a predefined location always occurs when using neighbours to define
         motion 'paths' it is best to ensure that the device is always in a 'location' by making sure
         that motion can not move the device outside of all 'locations'.
-    3. Devices can be in more than one location at a time.
-    4. To ensure that motion occurs always via a path then each 'point' in the path should be a 
+    2. To ensure that motion occurs always via a path then each 'point' in the path should be a 
         location, and it should only have the neighbours that are before or after it in the required
         path.
     '''
-    def __init__(self, *args, locations=None, neighbours=None,in_band=0.1, cam_list=None, 
-            qem_list=None, gv_list=None, vis_path_options=None,**kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, components, *,locations={}, neighbours={}, regions={}):
 
+        #define inputs as attributes
+        self.components = components
         self.locations = locations
-        self.in_band = in_band
         self.neighbours = neighbours
-        self.vis_path_options=vis_path_options
+        self.regions = regions
+
+        #define components as attributes
+        for attribute in list(components.keys())
+            self.attribute = components[keys]
 
         self.nxGraph=nx.DiGraph(directed=True)
-        
-        if locations is not None: self.nxGraph.add_nodes_from(list(locations.keys()))
+        self.nxGraph.add_nodes_from(list(self.locations.keys()))
 
-        if neighbours is not None:
-            for key in neighbours.keys():
-                for neighbour in neighbours[key]:
-                    self.nxGraph.add_edge(str(key),neighbour)
-        elif locations is not None:
-            for location in locations.keys():
-                for location2 in locations.keys():
-                    if location is not location2:
-                        self.nxGraph.add_edge(str(location),str(location2))
-
-
-        if isinstance(cam_list,list): 
-            if len(cam_list)==1:
-                self.cam=cam_list[0]
+        for location in list(neighbours.keys()):
+            if 'All' in neighbours[location]:
+                for neighbour, location in list(self.locations.keys()):
+                    self.nxGraph.add_edge(location, neighbour)
             else:
-                for i,cam in enumerate(cam_list):
-                    setattr(self,'cam{}'.format(i+1),cam_list[i])                
-
-        if isinstance(qem_list,list): 
-            if len(qem_list)==1:
-                self.qem=qem_list[0]
-            else:
-                for i,qem in enumerate(qem_list):
-                    setattr(self,'qem{}'.format(i+1),qem_list[i])  
-
-        if isinstance(gv_list,list): 
-            if len(gv_list)==1:
-                self.gv=gv_list[0]
-            else:
-                for i,gv in enumerate(gv_list):
-                    setattr(self,'qem{}'.format(i+1),gv_list[i])  
+                for neighbour in neighbours[location]:
+                    self.nxGraph.add_edge(location, neighbour)
 
 
-
-        def mv_axis(to_location):
+        def mv_plan(to_location):
             '''
-            A function that moves the diagnostic or single axis slit to the location defined by 
+            A function that returns a plan that can move the collection  to the location defined by 
             'value'
     
             Parameters
@@ -131,23 +107,54 @@ class PreDefinedPositions(Device):
                                                           #being set to None after a call 
             
             path_list = self.find_path(from_location='current_location',to_location=to_location)
-            if path_list == 'unknown location':#if the current location is unknown
-                print ('current location is not pre-defined, move to predefined position first')
-                print ('a list of locations and axis values can be found using the "locations"')
-                print ('attribute, e.g. device.locations')
+            if value not in list(self.locations.keys()):
+                raise ValueError(f'{location} is not a pre defined position')  
             else:
                 for location in path_list:
                     print ('Move {} to "{}"'.format(self.name,location))
-                    axis_value_list=self.get_axis_value_list(location)
-                    yield from mv(*axis_value_list)
-                    
+                    yield from mv(*self.locations['location'])     
 
-        if locations is not None:
-            for location in self.locations:#define the position attributes
-                setattr(self,location,mv_axis(location))
+        for location in self.locations:#define the position attributes
+            setattr(self,location,mv_axis(location))
 
+
+    def set(self, value):
+        '''Moves the collection to the location defined by 'value' and returns a status object.
+
+        This function mimics the 'set' function of an ophyd 'device', it is primarily used to allow
+        instances of this class to be added as 'components' of another instance.
+
+        Parameters
+        ----------
+        value, string: 
+            The pre defined location that the object is to move to.
+
+        Returns
+        -------
+        status, MoveStatus object:
+            Returns a MoveStatus object.
+
+        Raises:
+        -------
+        ValueError:
+            On invalid locations.  
+
+        '''
+
+        if value not in list(self.locations.keys()):
+            raise ValueError(f'{location} is not a pre defined position')  
+        else:
+            status = []
+            path_list = self.find_path(from_location='current_location',to_location=to_location)
+
+            for location in path_list:
+                axis_list=self.locations[location]
+                for i in range(0,len(axis_list),2):
+                    status.append(getattr(self,axis_list[i]).set(axis_list[i+1])
+
+        return functools.reduce(operator.and_, status)
         
-        
+
     def read(self):
         '''
         An attribute that returns the current 'location' of the unit as an ordered dictionary. This
@@ -172,7 +179,7 @@ class PreDefinedPositions(Device):
     
     def describe(self):
         '''
-        An attribute that returns the current 'location'description of the output data as an 
+        An attribute that returns the current 'location' description of the output data as an 
         ordered dictionary. This is used identically to the describe attribute function for a 
         standard device and therefore can be used in the baseline.
         
@@ -197,29 +204,9 @@ class PreDefinedPositions(Device):
         return describe_dict
 
 
-
-    def get_axis_value_list(self,location):
-        '''
-        Returns the axis-value list for a defined location
-        
-        Returns
-        -------
-        axis_value_list : list, output
-            the axis-value list for the inputted location that is returned
-        '''
-        axis_value_list=[]
-        for item in self.locations[location]:
-                if isinstance(item,str):
-                    axis_value_list.append(getattr(self,item))
-                else:
-                    axis_value_list.append(item)
-                    
-        return axis_value_list
-        
-
     def find_path(self,from_location=None,to_location=None):
         '''
-        Find the shortest path from the 'from_location' to 'to_location' passing only thorugh the 
+        Find the shortest path from 'from_location' to 'to_location' passing only thorugh the 
         neighbours for each location defiend by the dictionary 'neighbours'. Returns an empty list 
         if no path found otherwise returns a list of 'locations' that define the path. If to_location 
         is None then it returns a dictionary showing the shortest path to all possible locations. If
@@ -255,50 +242,52 @@ class PreDefinedPositions(Device):
 
         return path_list
 
-    @property
-    def visualize_paths(self):
+
+    def visualize_paths(self, fig_size = [10,10], axis_labels = ['arb. axis', 'arb. axis'] ,
+                        options = {}):
         ''' Creates a plot of the possible paths between the predefined locations.
+
+        PARAMETERS
+        ----------
+        fig_size: list, optional
+            A list containing the horizontal and vertical size to make the figure.
+        axis_labels: list, optional 
+            A list of horizontal and vertical axis names for the figure.
+        options: dict, optional
+            An optional dictionary that contains kwargs for the draw_networkx function from the
+            networkx module.
+
         '''
+
         if self.locations is None:
             print ('No locations to visualize')
         else:
             
-            options={'pos':nx.circular_layout(self.nxGraph),'node_color':'darkturquoise','edge_color':'grey','node_size':6000,
-                     'width':3,'arrowstyle':'-|>','arrow_size':12}
-            if self.vis_path_options is not None:
-                options.update(self.vis_path_options)
-
-            if 'fig_size' in options.keys():
-                fig_size=[options['fig_size'][0],options['fig_size'][1]]
-                del options['fig_size']
-            else:
-                fig_size=[10,10]
-
-            if 'axis_labels' in options.keys():
-                axis_labels=[options['axis_labels'][0],options['axis_labels'][1]]
-                del options['axis_labels']
-            else:
-                axis_labels=['arbitrary axis','arbitrary axis']
-
+            default_options={'pos':nx.circular_layout(self.nxGraph),'node_color':'darkturquoise',
+                    'edge_color':'grey','node_size':6000, 'width':3,'arrowstyle':'-|>',
+                    'arrow_size':12}
+            default_options.update(options)
 
             plt.figure('visualize {} paths'.format(self.name),figsize=(fig_size[0],fig_size[1]))
             plt.xlabel(axis_labels[0])
             plt.ylabel(axis_labels[1])
-            nx.draw_networkx(self.nxGraph,arrows=True,**options)
+            nx.draw_networkx(self.nxGraph,arrows=True,**default_options)
 
 
 
     @property
-    def status_list(self):
-        '''The current location of the device
+    def position(self):
+        '''Lists the current locations the collection is in.
+
+        This returns a list containing the names of the current locations that the collection is in.
         
         Returns
         -------
-        position : list
+        location_list : list
         '''
    
         if self.locations is not None:
-            loc_list='unknown location'
+            location_list='unknown location'
             for location in self.locations:
                 in_position=True
                 for i in range(0,len(self.locations[location]),2):
@@ -330,33 +319,13 @@ class PreDefinedPositions(Device):
                             in_position=False
 
                 if in_position: 
-                    if loc_list == 'unknown location':
-                        loc_list = [location]
+                    if location_list == 'unknown location':
+                        location_list = [location]
                     else:
-                        loc_list.append(location)
+                        location_list.append(location)
         else:
-            loc_list=['no locations']
+            location_list=['no locations']
 
-        return loc_list
+        return location_list
    
-    @property  
-    def status(self):
-        '''The current location of the device
-        
-        Returns
-        -------
-        position : string
-        '''
-
-        if isinstance(self.status_list,list):
-            position=''
-            for location in self.status_list:
-                if len(position)>1:
-                    position+=' , '
-
-                position+= location
-        else:
-            position = self.status_list
-
-        return position
-        
+            


### PR DESCRIPTION
This is an in-progress work. It creates a PreDefinedPositionsClass which is not a child of Device. Instead it takes in a list of 'components' and attribute references to them.

The aims of this new class are:

1. To provide a common interface for a collection of components that are experimentally connected but are not the same physical hardware.
2. To allow for a series of 'pre defined positions' to be specified so that the device can be used as a 'multi-state' positioner. This is useful when there are a series of 'locations' which are regularly accessed, and hence a quick interface to move to these locations is required.
3. To provide a method for moving between states through semi-complicated 'paths' .