### PR TITLE
adding a note about the hdf5 fileplugin requirement to the docstring of MultiTrigger

### DIFF
--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -153,7 +153,7 @@ class MultiTrigger(TriggerBase):
     positions.
 
     NOTE: At present this trigger mixin only works in conjunction with the
-    ``ophyd/areadetector/filestore_mixin/FileStoreHDF5 mixin. Use of other
+    ``ophyd/areadetector/filestore_mixin/FileStoreHDF5`` mixin. Use of other
     ``ophyd/areadetector/filestore_mixins`` or reading the array data using
     `device.read()` after `device.trigger()` will result in only the last image
     being recognised by databroker.

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -152,6 +152,12 @@ class MultiTrigger(TriggerBase):
     acquisitions with, for example, different gain settings or shutter
     positions.
 
+    NOTE: At present this trigger mixin only works in conjunction with the
+    ``ophyd/areadetector/filestore_mixin/FileStoreHDF5 mixin. Use of other
+    ``ophyd/areadetector/filestore_mixins`` or reading the array data using
+    `device.read()` after `device.trigger()` will result in only the last image
+    being recognised by databroker.
+
     The are two levels of nesting here:
 
      - cycling through different actions on successive calls to `trigger`


### PR DESCRIPTION
This PR updates the docstring of MultiTrigger to add a note about the requirement to use it with the hdf5 fileplugin. 

## Description
This adds a note to the MultiTrigger doc string to warn that it must be used with the hdf5 plugin, failure to do this means that only the last image in each `device.trigger()` call will be found when runnign the `device.read()` afterwards.

## Motivation and Context
At the NSLS-II LIX beamline they attempted to use this without a fileplugin, and where only able to extract the last image from each trigger sequence from databroker. Investigation revealed that this is because without a fileplugin each succesive image is overwrites the previous one in memory and hence without reading the data between triggers it is not accessible. Further investigation revealed that as the `device.read()` method does not know anything about the `device.trigger()` method it will only return a reference to the final image of the `device.trigger()` call. As the hdf5 fileplugin works in streaming mode (where all files for a single run are saved to the same hdf5 file) then this by default ensures that all data is referenced in databroker.

## How Has This Been Tested?
This is a docstring change only, so no testing has been completed.