### PR TITLE
Kind Tests

### DIFF
--- a/ophyd/tests/test_hints.py
+++ b/ophyd/tests/test_hints.py
@@ -13,7 +13,8 @@ def test_device_hints():
 
     assert {'fields': ['dev_a']} == Dongle(name='dev').hints
     assert {'fields': ['dev_a']} == Dongle(name='dev').hints
-
+    # A signal should record its own hints
+    assert len(Dongle(name='dev').b.hints.get('fields')) > 1
 
 def test_motor_bundle_hints():
     class Bundle(MotorBundle):

--- a/ophyd/tests/test_hints.py
+++ b/ophyd/tests/test_hints.py
@@ -20,8 +20,10 @@ def test_motor_bundle_hints():
     class Bundle(MotorBundle):
         a = Component(SynAxis, kind=Kind.hinted)
         b = Component(SynAxis, kind=Kind.hinted)
+        c = Component(SynAxis, kind=Kind.normal)
 
     assert {'fields': ['dev_a', 'dev_b']} == Bundle(name='dev').hints
+    assert {'fields': ['dev_c']} == Bundle(name='dev').c.hints
 
 
 def test_pseudopos_hints(hw):

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,5 +1,6 @@
 from ophyd import (Device, Signal, Kind, Component, ALL_COMPONENTS,
                    kind_context, DynamicDeviceComponent as DDC)
+from ophyd.sim import SynAxis
 import pytest
 
 
@@ -58,14 +59,12 @@ def test_nested_devices():
     assert 'a_omitted_sig' not in a.read_configuration()
 
     # Another layer of nesting!
-
     class B(Device):
         a_default = Component(A)
         a_config = Component(A, kind=Kind.config)
         a_omitted = Component(A, kind=Kind.omitted)
 
     b = B(name='b')
-
     assert ['b_a_default_normal_sig'] == list(b.read())
 
     # Notice that a_default comes along for the ride here. If you ask
@@ -86,6 +85,13 @@ def test_nested_devices():
     assert [] == list(b.read())
     assert ['b_a_default_config_sig',
             'b_a_config_config_sig'] == list(b.read_configuration())
+    # Nested motors with name matching component name
+
+    class C(Device):
+        a = Component(SynAxis, kind=Kind.normal)
+
+    c = C(name='c')
+    assert len(c.read_attrs) == len(c.a.read_attrs)
 
 
 def test_strings():


### PR DESCRIPTION
A more explicit explanation of a few gripes that I have with how `Kind` currently works. I think the `Signal` test was an explicit feature that I disapprove of, the other I think may be unintentional.

The `read_attrs` one is probably not a huge deal if you plan on deprecating it. It is however slightly annoying if you want to introspect without calling `read` itself.