### PR TITLE
 My suggestion for reporting missing self.value

### DIFF
--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -269,7 +269,7 @@ def _check_pyepics_version(version):
         warnings.warn('Unrecognized PyEpics version; assuming it is '
                       'compatible', ImportWarning)
     elif version < parse_version('3.3.2'):
-        raise RuntimeError(f'The installed version of pyepics={version} is not'
+        raise RuntimeError(f'The installed version of pyepics={version} is not '
                            f'compatible with ophyd.  Please upgrade to the '
                            f'latest version.')
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -301,6 +301,12 @@ class Signal(OphydObject):
             with the ``event_model.event_descriptor.data_key`` schema.
         """
         val = self.value
+        if val is None:
+            raise AssertionError(
+                f'Description can not yet been made for {self.name} as '
+                f'self.value == None. This typically means, that the '
+                f'value was never set.'
+                )
         return {self.name: {'source': 'SIM:{}'.format(self.name),
                             'dtype': data_type(val),
                             'shape': data_shape(val)}}

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -303,7 +303,7 @@ class Signal(OphydObject):
         val = self.value
         if val is None:
             raise NonPVValue(
-                f'Description can not yet been made for "{self.name}" as '
+                f'Description can not yet been made for {self.name!r} as '
                 f'self.value = None. This typically means, that the '
                 f'value was never set.'
                 )
@@ -311,7 +311,7 @@ class Signal(OphydObject):
         try:
             dtype = data_type(val)
         except Exception as ex:
-            msg = f'Conversion error for self.value for variable "{self.name}".'
+            msg = f'Type inference failed for {self.value!r} for {self.name!r}.'
             raise ex.__class__(msg) from ex
 
         return {self.name: {'source': 'SIM:{}'.format(self.name),

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -302,14 +302,21 @@ class Signal(OphydObject):
         """
         val = self.value
         try:
-            dtype =  data_type(val)
-        except NonPVValue as npv:
-            if val is None:
+            dtype = data_type(val)
+        except Exception as npv:
+            if isinstance(npv, NonPVValue) and val is None:
+                msg, = npv.args
                 raise NonPVValue(
                     f'Description can not yet been made for "{self.name}" as '
                     f'self.value = None. This typically means, that the '
                     f'value was never set.'
                 )
+
+            # val was not None so lets give all the knowledge to the user
+            txt = f'Conversion error for self.value for variable "{self.name}":'
+            args = (txt,) + npv.args
+            npv.args = args
+            raise npv
 
         return {self.name: {'source': 'SIM:{}'.format(self.name),
                             'dtype': dtype,

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -301,22 +301,18 @@ class Signal(OphydObject):
             with the ``event_model.event_descriptor.data_key`` schema.
         """
         val = self.value
-        try:
-            dtype = data_type(val)
-        except Exception as npv:
-            if isinstance(npv, NonPVValue) and val is None:
-                msg, = npv.args
-                raise NonPVValue(
-                    f'Description can not yet been made for "{self.name}" as '
-                    f'self.value = None. This typically means, that the '
-                    f'value was never set.'
+        if val is None:
+            raise NonPVValue(
+                f'Description can not yet been made for "{self.name}" as '
+                f'self.value = None. This typically means, that the '
+                f'value was never set.'
                 )
 
-            # val was not None so lets give all the knowledge to the user
-            txt = f'Conversion error for self.value for variable "{self.name}":'
-            args = (txt,) + npv.args
-            npv.args = args
-            raise npv
+        try:
+            dtype = data_type(val)
+        except Exception as ex:
+            msg = f'Conversion error for self.value for variable "{self.name}".'
+            raise ex.__class__(msg) from ex
 
         return {self.name: {'source': 'SIM:{}'.format(self.name),
                             'dtype': dtype,

--- a/ophyd/tests/test_missing_readback.py
+++ b/ophyd/tests/test_missing_readback.py
@@ -27,7 +27,7 @@ def test_describe_fail():
 
     # check if the variable name is given as quoted string in the description
     msg, =  des.value.args
-    assert(f'"{pvs_varname}_signal"' in msg)
+    assert(f"'{pvs_varname}_signal'" in msg)
 
 def test_describe_after_set():
     """If readback was set does descirbe fail?
@@ -52,4 +52,4 @@ def test_describe_after_set_invalid_value():
 
     # check if the variable name is given as quoted string in the description
     msg_signal, =  des.value.args
-    assert(f'"{pvs_varname}_signal"' in msg_signal)
+    assert(f"'{pvs_varname}_signal'" in msg_signal)

--- a/ophyd/tests/test_missing_readback.py
+++ b/ophyd/tests/test_missing_readback.py
@@ -51,5 +51,5 @@ def test_describe_after_set_invalid_value():
         fs.describe()
 
     # check if the variable name is given as quoted string in the description
-    msg_signal, msg_data_type =  des.value.args
+    msg_signal, =  des.value.args
     assert(f'"{pvs_varname}_signal"' in msg_signal)

--- a/ophyd/tests/test_missing_readback.py
+++ b/ophyd/tests/test_missing_readback.py
@@ -1,0 +1,33 @@
+"""Check if a missing value stops program
+"""
+import unittest
+
+from ophyd import sim, Device, Component as Cpt
+
+
+class TestDevice(Device):
+    """Just to create a device
+    """
+    signal = Cpt(sim.FakeEpicsSignalRO, 'a_fake_signal')
+
+
+class TestMissingReadBack(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_signal = TestDevice(name = "fake_device")
+
+    def testDescribeFail(self):
+        """If readback was never set does descirbe fail?
+
+        I guess that's a bug
+        """
+        self.assertRaises(ValueError, self.fake_signal.describe)
+
+    def testDescribeAfterSet(self):
+        """If the value is once set it does not fail any longer
+        """
+        fs = self.fake_signal
+        fs.signal.sim_put(42)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ophyd/tests/test_missing_readback.py
+++ b/ophyd/tests/test_missing_readback.py
@@ -1,31 +1,38 @@
 """Check if a missing value stops program
 """
 import pytest
-from ophyd import sim, Device, Component as Cpt
+import logging
 
+from ophyd import sim, Device, Component as Cpt
+from ophyd.utils.errors import NonPVValue
+
+pvs_varname = 'fake_device'
 class ADevice(Device):
     """Just to create a device
     """
-    signal = Cpt(sim.FakeEpicsSignalRO, 'a_fake_signal')
+    signal = Cpt(sim.FakeEpicsSignalRO, pvs_varname)
 
 
 def _get_fake_signal():
-    return ADevice(name = "fake_device")
+    return ADevice(name = pvs_varname)
 
 def test_describe_fail():
-    """If readback was never set, does descirbe fail?
+    """If readback was never set, does describe fail?
 
-    I guess that's a bug
+    The variable name shall be reported in the exception description
     """
-    # self.assertRaises(ValueError, self.fake_signal.describe)
     fs = _get_fake_signal()
-    with pytest.raises(AssertionError):
+    with pytest.raises(NonPVValue) as des:
         fs.describe()
+
+    # check if the variable name is given as quoted string in the description
+    msg, =  des.value.args
+    assert(f'"{pvs_varname}_signal"' in msg)
 
 def test_describe_after_set():
     """If readback was set does descirbe fail?
 
-    SHould work
+    Should work
     """
     fs = _get_fake_signal()
     fs.signal.sim_put(42)

--- a/ophyd/tests/test_missing_readback.py
+++ b/ophyd/tests/test_missing_readback.py
@@ -37,3 +37,19 @@ def test_describe_after_set():
     fs = _get_fake_signal()
     fs.signal.sim_put(42)
     fs.describe()
+
+
+def test_describe_after_set_invalid_value():
+    """Is error message appropriate if
+
+    lets see
+    """
+    fs = _get_fake_signal()
+    fs.signal.sim_put(ValueError)
+
+    with pytest.raises(NonPVValue) as des:
+        fs.describe()
+
+    # check if the variable name is given as quoted string in the description
+    msg_signal, msg_data_type =  des.value.args
+    assert(f'"{pvs_varname}_signal"' in msg_signal)

--- a/ophyd/tests/test_missing_readback.py
+++ b/ophyd/tests/test_missing_readback.py
@@ -21,7 +21,8 @@ class TestMissingReadBack(unittest.TestCase):
 
         I guess that's a bug
         """
-        self.assertRaises(ValueError, self.fake_signal.describe)
+        # self.assertRaises(ValueError, self.fake_signal.describe)
+        self.assertRaises(AssertionError, self.fake_signal.describe)
 
     def testDescribeAfterSet(self):
         """If the value is once set it does not fail any longer
@@ -30,4 +31,5 @@ class TestMissingReadBack(unittest.TestCase):
         fs.signal.sim_put(42)
 
 if __name__ == '__main__':
+    #TestDevice(name = "fake_device").describe()
     unittest.main()

--- a/ophyd/tests/test_missing_readback.py
+++ b/ophyd/tests/test_missing_readback.py
@@ -1,35 +1,32 @@
 """Check if a missing value stops program
 """
-import unittest
-
+import pytest
 from ophyd import sim, Device, Component as Cpt
 
-
-class TestDevice(Device):
+class ADevice(Device):
     """Just to create a device
     """
     signal = Cpt(sim.FakeEpicsSignalRO, 'a_fake_signal')
 
 
-class TestMissingReadBack(unittest.TestCase):
+def _get_fake_signal():
+    return ADevice(name = "fake_device")
 
-    def setUp(self):
-        self.fake_signal = TestDevice(name = "fake_device")
+def test_describe_fail():
+    """If readback was never set, does descirbe fail?
 
-    def testDescribeFail(self):
-        """If readback was never set does descirbe fail?
+    I guess that's a bug
+    """
+    # self.assertRaises(ValueError, self.fake_signal.describe)
+    fs = _get_fake_signal()
+    with pytest.raises(AssertionError):
+        fs.describe()
 
-        I guess that's a bug
-        """
-        # self.assertRaises(ValueError, self.fake_signal.describe)
-        self.assertRaises(AssertionError, self.fake_signal.describe)
+def test_describe_after_set():
+    """If readback was set does descirbe fail?
 
-    def testDescribeAfterSet(self):
-        """If the value is once set it does not fail any longer
-        """
-        fs = self.fake_signal
-        fs.signal.sim_put(42)
-
-if __name__ == '__main__':
-    #TestDevice(name = "fake_device").describe()
-    unittest.main()
+    SHould work
+    """
+    fs = _get_fake_signal()
+    fs.signal.sim_put(42)
+    fs.describe()

--- a/ophyd/tests/test_var_sim.py
+++ b/ophyd/tests/test_var_sim.py
@@ -1,0 +1,22 @@
+import pytest
+import logging
+
+from ophyd.sim import FakeEpicsSignalRO, FakeEpicsSignal
+import numpy
+
+def test_trigger_fake_signal():
+    """Test that reading a simulated signal works
+    """
+    a_signal = FakeEpicsSignal("a_test_var", name = "a_test_signal")
+    a_signal.sim_put(0.0)
+    a_signal.trigger()
+
+def test_reading_ro_signal():
+    """Test that reading a simulated read only signal works
+
+    Warning:
+        Warning: that currently fails
+    """
+    a_signal = FakeEpicsSignalRO("a_test_var_ro", name = "a_ro_test_signal")
+    a_signal.sim_put(0.0)
+    a_signal.trigger()

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -6,7 +6,7 @@ import functools
 import numpy as np
 import typing
 
-from .errors import DisconnectedError, OpException
+from .errors import DisconnectedError, OpException, NonPVValue
 
 
 __all__ = ['split_record_field',
@@ -319,7 +319,7 @@ def data_type(val):
         if isinstance(val, py_types):
             return json_type
 
-    raise ValueError(
+    raise NonPVValue(
         f'Cannot determine the appropriate bluesky-friendly data type for '
         f'value {val} of Python type {type(val)}. '
         f'Supported types include: int, float, str, and iterables such as '

--- a/ophyd/utils/errors.py
+++ b/ophyd/utils/errors.py
@@ -37,3 +37,6 @@ class RedundantStaging(OpException):
 class PluginMisconfigurationError(TypeError, OpException):
     # Keeping TypeError for backward-compatibility
     pass
+
+class NonPVValue(ValueError, OpException):
+    '''Value can not be converted to an epics.PV value'''


### PR DESCRIPTION
If the member 'value' of :class:`ophyd.signal.Signal` has never been set, 
its value is None. This value can thus not be turned to a JSON representation.
The user is presented with a message informing that None can not be converted
to value useful in bluesky.

I propose to add a check in the describe method if value is not None. Then the
user can be informed  which variable is the culprit.

