### PR TITLE
API/REF: Make simulated hw into Devices.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage
+.coverage*
 .cache
 .pytest_cache
 nosetests.xml

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -144,7 +144,7 @@ class SynSignal(Signal):
                   d: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         '''Configure the device for something during a run
         '''
-        if not d:
+        if d:
             warnings.warn('The `configure` method on `ophyd.sim.SynSignal` '
                           'devices is a no-op method, all information'
                           'included in the dictionary `d` is ignored')

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -19,7 +19,7 @@ from tempfile import mkdtemp
 from .signal import Signal, EpicsSignal, EpicsSignalRO
 from .areadetector.base import EpicsSignalWithRBV
 from .status import DeviceStatus, StatusBase
-from .device import (Device, Component, Component as C,
+from .device import (Device, Component, Component as Cpt,
                      DynamicDeviceComponent as DDC, Kind)
 from types import SimpleNamespace
 from .pseudopos import (PseudoPositioner, PseudoSingle,
@@ -857,14 +857,14 @@ class InvariantSignal(SynSignal):
 
 
 class SPseudo3x3(PseudoPositioner):
-    pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a', kind=Kind.hinted)
-    pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b', kind=Kind.hinted)
-    pseudo3 = C(PseudoSingle, limits=None, egu='c', kind=Kind.hinted)
-    real1 = C(SoftPositioner, init_pos=0)
-    real2 = C(SoftPositioner, init_pos=0)
-    real3 = C(SoftPositioner, init_pos=0)
+    pseudo1 = Cpt(PseudoSingle, limits=(-10, 10), egu='a', kind=Kind.hinted)
+    pseudo2 = Cpt(PseudoSingle, limits=(-10, 10), egu='b', kind=Kind.hinted)
+    pseudo3 = Cpt(PseudoSingle, limits=None, egu='c', kind=Kind.hinted)
+    real1 = Cpt(SoftPositioner, init_pos=0)
+    real2 = Cpt(SoftPositioner, init_pos=0)
+    real3 = Cpt(SoftPositioner, init_pos=0)
 
-    sig = C(Signal, value=0)
+    sig = Cpt(Signal, value=0)
 
     @pseudo_position_argument
     def forward(self, pseudo_pos):
@@ -884,10 +884,10 @@ class SPseudo3x3(PseudoPositioner):
 
 
 class SPseudo1x3(PseudoPositioner):
-    pseudo1 = C(PseudoSingle, limits=(-10, 10), kind=Kind.hinted)
-    real1 = C(SoftPositioner, init_pos=0)
-    real2 = C(SoftPositioner, init_pos=0)
-    real3 = C(SoftPositioner, init_pos=0)
+    pseudo1 = Cpt(PseudoSingle, limits=(-10, 10), kind=Kind.hinted)
+    real1 = Cpt(SoftPositioner, init_pos=0)
+    real2 = Cpt(SoftPositioner, init_pos=0)
+    real3 = Cpt(SoftPositioner, init_pos=0)
 
     @pseudo_position_argument
     def forward(self, pseudo_pos):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -437,7 +437,8 @@ class SynGauss(SynSignal):
 
         def func():
             m = self._motor.read()[self._motor_field]['value']
-            v = self.Imax * np.exp(-(m - self.center) ** 2 / (2 * self.sigma ** 2))
+            v = self.Imax * np.exp(-(m - self.center) ** 2 /
+                                   (2 * self.sigma ** 2))
             if self.noise == 'poisson':
                 v = int(self.random_state.poisson(np.round(v), 1))
             elif self.noise == 'uniform':
@@ -543,11 +544,12 @@ class TrivialFlyer:
 
 class NewTrivialFlyer(TrivialFlyer):
     """
-    The old-style API inserted Resource and Datum documents into a database directly.
-    The new-style API only caches the documents and provides an interface (collect_asset_docs)
-    for accessing that cache. This change was part of the "asset refactor" that changed
-    that way Resource and Datum documents flowed through ophyd, bluesky, and databroker.
-    Trivial flyer that complies to the API but returns empty data.
+    The old-style API inserted Resource and Datum documents into a database
+    directly. The new-style API only caches the documents and provides an
+    interface (collect_asset_docs for accessing that cache. This change was
+    part of the "asset refactor" that changed that way Resource and Datum
+    documents flowed through ophyd, bluesky, and databroker. Trivial flyer that
+    complies to the API but returns empty data.
     """
 
     name = 'new_trivial_flyer'
@@ -998,7 +1000,7 @@ def clear_fake_device(dev, *, default_value=0, default_string_value='',
                      if string
                      else default_value)
             sig.sim_put(value)
-        except Exception as ex:
+        except Exception:
             if not ignore_exceptions:
                 raise
         else:
@@ -1202,7 +1204,8 @@ class FakeEpicsSignalRO(SynSignalRO, FakeEpicsSignal):
 
 class FakeEpicsSignalWithRBV(FakeEpicsSignal):
     """
-    FakeEpicsSignal with PV and PV_RBV; used in the AreaDetector PV naming scheme
+    FakeEpicsSignal with PV and PV_RBV; used in the AreaDetector PV naming
+    scheme
     """
     def __init__(self, prefix, **kwargs):
         super().__init__(prefix + '_RBV', write_pv=prefix, **kwargs)

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -8,6 +8,7 @@ import os
 import random
 import threading
 import time as ttime
+from typing import Dict, Any, Tuple
 import uuid
 import warnings
 import weakref
@@ -139,6 +140,13 @@ class SynSignal(Signal):
         # example.
         return super().get()
 
+    def configure(self,
+                  d: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        '''Configure the device for something during a run
+        '''
+        old = self.read_configuration()
+        new = self.read_configuration()
+        return old, new
 
 class SignalRO(Signal):
     def __init__(self, *args, **kwargs):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1257,6 +1257,10 @@ def hw(save_path=None):
     # area detector that directly stores image data in Event
     direct_img = SynSignal(func=lambda: np.array(np.ones((10, 10))),
                            name='img', labels={'detectors'})
+
+    direct_img_list = SynSignal(func=lambda: [[1] * 10] * 10,
+                                name='img', labels={'detectors'})
+
     # area detector that stores data in a file
     img = SynSignalWithRegistry(func=lambda: np.array(np.ones((10, 10))),
                                 name='img', labels={'detectors'},
@@ -1298,6 +1302,7 @@ def hw(save_path=None):
         new_trivial_flyer=new_trivial_flyer,
         ab_det=ab_det,
         direct_img=direct_img,
+        direct_img_list=direct_img_list,
         img=img,
         invariant1=invariant1,
         invariant2=invariant2,

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -144,6 +144,11 @@ class SynSignal(Signal):
                   d: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         '''Configure the device for something during a run
         '''
+        if not d:
+            warnings.warn('The `configure` method on `ophyd.sim.SynSignal` '
+                          'devices is a no-op method, all information'
+                          'included in the dictionary `d` is ignored')
+
         old = self.read_configuration()
         new = self.read_configuration()
         return old, new

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -140,6 +140,12 @@ class SynSignal(Signal):
         # example.
         return super().get()
 
+    def sim_set_func(self, func):
+        """
+        Update the SynSignal function to set a new value on trigger.
+        """
+        self._func = func
+
 
 class SignalRO(Signal):
     def __init__(self, *args, **kwargs):
@@ -1079,12 +1085,6 @@ class FakeEpicsSignal(SynSignal):
         if self._enum_strs is not None:
             desc[self.name]['enum_strs'] = self.enum_strs
         return desc
-
-    def sim_set_func(self, func):
-        """
-        Update the SynSignal function to set a new value on trigger.
-        """
-        self._func = func
 
     def sim_set_putter(self, putter):
         """

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -19,7 +19,7 @@ from tempfile import mkdtemp
 from .signal import Signal, EpicsSignal, EpicsSignalRO
 from .areadetector.base import EpicsSignalWithRBV
 from .status import DeviceStatus, StatusBase
-from .device import (Device, Component, Component as Cpt,
+from .device import (Device, Component as Cpt,
                      DynamicDeviceComponent as DDC, Kind)
 from types import SimpleNamespace
 from .pseudopos import (PseudoPositioner, PseudoSingle,
@@ -296,13 +296,13 @@ class SynAxisNoHints(Device):
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
     """
-    readback = Component(ReadbackSignal, value=None, kind='hinted')
-    setpoint = Component(SetpointSignal, value=None, kind='normal')
+    readback = Cpt(ReadbackSignal, value=None, kind='hinted')
+    setpoint = Cpt(SetpointSignal, value=None, kind='normal')
 
-    velocity = Component(Signal, value=1, kind='config')
-    acceleration = Component(Signal, value=1, kind='config')
+    velocity = Cpt(Signal, value=1, kind='config')
+    acceleration = Cpt(Signal, value=1, kind='config')
 
-    unused = Component(Signal, value=1, kind='omitted')
+    unused = Cpt(Signal, value=1, kind='omitted')
 
     SUB_READBACK = 'readback'
     _default_sub = SUB_READBACK
@@ -387,7 +387,7 @@ class SynAxisNoHints(Device):
 
 
 class SynAxis(SynAxisNoHints):
-    readback = Component(ReadbackSignal, value=None, kind=Kind.hinted)
+    readback = Cpt(ReadbackSignal, value=None, kind='hinted')
 
 
 class SynGauss(SynSignal):
@@ -814,23 +814,23 @@ class NumpySeqHandler:
 
 
 class ABDetector(Device):
-    a = Component(SynSignal, func=random.random, kind=Kind.hinted)
-    b = Component(SynSignal, func=random.random)
+    a = Cpt(SynSignal, func=random.random, kind=Kind.hinted)
+    b = Cpt(SynSignal, func=random.random)
 
     def trigger(self):
         return self.a.trigger() & self.b.trigger()
 
 
 class DetWithCountTime(Device):
-    intensity = Component(SynSignal, func=lambda: 0, kind=Kind.hinted)
-    count_time = Component(Signal)
+    intensity = Cpt(SynSignal, func=lambda: 0, kind=Kind.hinted)
+    count_time = Cpt(Signal)
 
 
 class DetWithConf(Device):
-    a = Component(SynSignal, func=lambda: 1, kind=Kind.hinted)
-    b = Component(SynSignal, func=lambda: 2, kind=Kind.hinted)
-    c = Component(SynSignal, func=lambda: 3)
-    d = Component(SynSignal, func=lambda: 4)
+    a = Cpt(SynSignal, func=lambda: 1, kind=Kind.hinted)
+    b = Cpt(SynSignal, func=lambda: 2, kind=Kind.hinted)
+    c = Cpt(SynSignal, func=lambda: 3)
+    d = Cpt(SynSignal, func=lambda: 4)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -942,14 +942,14 @@ def make_fake_device(cls):
         for cpt_name in cls.component_names:
             cpt = getattr(cls, cpt_name)
             if isinstance(cpt, DDC):
-                # Make a regular Component out of the DDC, as it already has
+                # Make a regular Cpt out of the DDC, as it already has
                 # been generated
-                fake_cpt = Component(cls=cpt.cls, suffix=cpt.suffix,
-                                     lazy=cpt.lazy,
-                                     trigger_value=cpt.trigger_value,
-                                     kind=cpt.kind, add_prefix=cpt.add_prefix,
-                                     doc=cpt.doc, **cpt.kwargs,
-                                     )
+                fake_cpt = Cpt(cls=cpt.cls, suffix=cpt.suffix,
+                               lazy=cpt.lazy,
+                               trigger_value=cpt.trigger_value,
+                               kind=cpt.kind, add_prefix=cpt.add_prefix,
+                               doc=cpt.doc, **cpt.kwargs,
+                )
             else:
                 fake_cpt = copy.copy(cpt)
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1256,10 +1256,10 @@ def hw(save_path=None):
     ab_det = ABDetector(name='det', labels={'detectors'})
     # area detector that directly stores image data in Event
     direct_img = SynSignal(func=lambda: np.array(np.ones((10, 10))),
-                           name='img', labels={'detectors'})
+                           name='direct_img', labels={'detectors'})
 
     direct_img_list = SynSignal(func=lambda: [[1] * 10] * 10,
-                                name='img', labels={'detectors'})
+                                name='direct_img_list', labels={'detectors'})
 
     # area detector that stores data in a file
     img = SynSignalWithRegistry(func=lambda: np.array(np.ones((10, 10))),

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -142,23 +142,17 @@ class SynSignal(Signal):
         self._func = func
 
 
-class SignalRO(Signal):
+class SynSignalRO(SynSignal):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._metadata.update(
-            connected=True,
-            write_access=False,
-        )
+            connected=True,)
 
     def put(self, value, *, timestamp=None, force=False):
         raise ReadOnlyError("The signal {} is readonly.".format(self.name))
 
     def set(self, value, *, timestamp=None, force=False):
         raise ReadOnlyError("The signal {} is readonly.".format(self.name))
-
-
-class SynSignalRO(SignalRO, SynSignal):
-    pass
 
 
 def periodic_update(ref, period, period_jitter):
@@ -224,13 +218,21 @@ class SynPeriodicSignal(SynSignal):
         self.__thread.start()
 
 
-class ReadbackSignal(SignalRO):
+class ReadbackSignal(Signal):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._metadata.update(
+            connected=True,
+            write_access=False,
+        )
+
     def get(self):
         return self.parent.sim_state['readback']
 
     def describe(self):
         res = super().describe()
-        # There should be only one key here, but for the sake of generality....
+        # There should be only one key here, but for the sake of
+        # generality....
         for k in res:
             res[k]['precision'] = self.parent.precision
         return res
@@ -239,6 +241,12 @@ class ReadbackSignal(SignalRO):
     def timestamp(self):
         '''Timestamp of the readback value'''
         return self.parent.sim_state['readback_ts']
+
+    def put(self, value, *, timestamp=None, force=False):
+        raise ReadOnlyError("The signal {} is readonly.".format(self.name))
+
+    def set(self, value, *, timestamp=None, force=False):
+        raise ReadOnlyError("The signal {} is readonly.".format(self.name))
 
 
 class SetpointSignal(Signal):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -219,7 +219,7 @@ class SynPeriodicSignal(SynSignal):
         self.__thread.start()
 
 
-class ReadbackSignal(Signal):
+class _ReadbackSignal(Signal):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._metadata.update(
@@ -250,7 +250,7 @@ class ReadbackSignal(Signal):
         raise ReadOnlyError("The signal {} is readonly.".format(self.name))
 
 
-class SetpointSignal(Signal):
+class _SetpointSignal(Signal):
     def put(self, value, *, timestamp=None, force=False):
         self.parent.set(float(value))
 
@@ -296,8 +296,8 @@ class SynAxisNoHints(Device):
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
     """
-    readback = Cpt(ReadbackSignal, value=None, kind='hinted')
-    setpoint = Cpt(SetpointSignal, value=None, kind='normal')
+    readback = Cpt(_ReadbackSignal, value=None, kind='hinted')
+    setpoint = Cpt(_SetpointSignal, value=None, kind='normal')
 
     velocity = Cpt(Signal, value=1, kind='config')
     acceleration = Cpt(Signal, value=1, kind='config')
@@ -387,7 +387,7 @@ class SynAxisNoHints(Device):
 
 
 class SynAxis(SynAxisNoHints):
-    readback = Cpt(ReadbackSignal, value=None, kind='hinted')
+    readback = Cpt(_ReadbackSignal, value=None, kind='hinted')
 
 
 class SynGauss(SynSignal):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -148,6 +148,7 @@ class SynSignal(Signal):
         new = self.read_configuration()
         return old, new
 
+
 class SignalRO(Signal):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -140,19 +140,6 @@ class SynSignal(Signal):
         # example.
         return super().get()
 
-    def configure(self,
-                  d: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        '''Configure the device for something during a run
-        '''
-        if d:
-            warnings.warn('The `configure` method on `ophyd.sim.SynSignal` '
-                          'devices is a no-op method, all information'
-                          'included in the dictionary `d` is ignored')
-
-        old = self.read_configuration()
-        new = self.read_configuration()
-        return old, new
-
 
 class SignalRO(Signal):
     def __init__(self, *args, **kwargs):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -135,11 +135,6 @@ class SynSignal(Signal):
             self.put(self._func())
             return NullStatus()
 
-    def get(self):
-        # Get a new value, which allows us to synthesize noisy data, for
-        # example.
-        return super().get()
-
     def sim_set_func(self, func):
         """
         Update the SynSignal function to set a new value on trigger.

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -424,7 +424,7 @@ class SynAxis(SynAxisNoHints):
     readback = Cpt(_ReadbackSignal, value=None, kind='hinted')
 
 
-class SynGauss(SynSignal):
+class SynGauss(Device):
     """
     Evaluate a point on a Gaussian based on the value of a motor.
 
@@ -452,31 +452,56 @@ class SynGauss(SynSignal):
     motor = SynAxis(name='motor')
     det = SynGauss('det', motor, 'motor', center=0, Imax=1, sigma=1)
     """
+    def _compute(self):
+        m = self._motor.read()[self._motor_field]['value']
+        # we need to do this one at a time because
+        #   - self.read() may be screwed with by the user
+        #   - self.get would cause infinite recursion
+        Imax = self.Imax.get()
+        center = self.center.get()
+        sigma = self.sigma.get()
+        noise = self.noise.get()
+        noise_multiplier = self.noise_multiplier.get()
+        v = Imax * np.exp(-(m - center) ** 2 /
+                          (2 * sigma ** 2))
+        if noise == 'poisson':
+            v = int(self.random_state.poisson(np.round(v), 1))
+        elif noise == 'uniform':
+            v += self.random_state.uniform(-1, 1) * noise_multiplier
+        return v
 
-    def __init__(self, name, motor, motor_field, center, Imax, sigma=1,
-                 noise=None, noise_multiplier=1, random_state=None, **kwargs):
-        if noise not in ('poisson', 'uniform', None):
-            raise ValueError("noise must be one of 'poisson', 'uniform', None")
+    val = Cpt(SynSignal, kind='hinted')
+    Imax = Cpt(Signal, value=10, kind='config')
+    center = Cpt(Signal, value=0, kind='config')
+    sigma = Cpt(Signal, value=1, kind='config')
+    noise = Cpt(EnumSignal, value='none', kind='config',
+                enum_strings=('none', 'poisson', 'uniform'))
+    noise_multiplier = Cpt(Signal, value=1, kind='config')
+
+    def __init__(self, name, motor, motor_field, center, Imax,
+                 *, random_state=None,
+
+                 **kwargs):
+        set_later = {}
+        for k in ('Imax', 'center', 'sigma',
+                  'noise', 'noise_multiplier'):
+            v = kwargs.pop(k, None)
+            if v is not None:
+                set_later[k] = v
+        super().__init__(name=name, **kwargs)
         self._motor = motor
         self._motor_field = motor_field
-        self.center = center
-        self.sigma = sigma
-        self.Imax = Imax
-        self.noise = noise
-        self.noise_multiplier = noise_multiplier
+        self.center.put(center)
+        self.Imax.put(Imax)
+
         self.random_state = random_state or np.random
+        self.val.name = self.name
+        self.val.sim_set_func(self._compute)
+        for k, v in set_later.items():
+            getattr(self, k).put(v)
 
-        def func():
-            m = self._motor.read()[self._motor_field]['value']
-            v = self.Imax * np.exp(-(m - self.center) ** 2 /
-                                   (2 * self.sigma ** 2))
-            if self.noise == 'poisson':
-                v = int(self.random_state.poisson(np.round(v), 1))
-            elif self.noise == 'uniform':
-                v += self.random_state.uniform(-1, 1) * self.noise_multiplier
-            return v
-
-        super().__init__(func=func, name=name, **kwargs)
+    def trigger(self, *args, **kwargs):
+        return self.val.trigger(*args, **kwargs)
 
 
 class Syn2DGauss(SynSignal):


### PR DESCRIPTION
I have added the `configure` method to SynSignal, so that each of the simulated detectors in `hw` have this method. 

This method is required so that we can deploy a 'plan' that includes ` yield from bluesky.plan_stubs.configure`. This allows for the testing of callbacks (like the suitcase Serializers) with plans that have mulitple descriptors per stream.