### PR TITLE
ENH: Add register_instance.

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -71,7 +71,9 @@ def get_cl():
 
 set_cl()
 
-from .ophydobj import Kind, select_version
+from .ophydobj import (Kind, select_version,
+                       register_instances_in_weakset,
+                       register_instances_keyed_on_name)
 
 # Signals
 from .signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -135,7 +135,7 @@ class OphydObject:
     # This is set to True when the first OphydObj is instiated. This may be of
     # interest to code that adds something to instantiation_callbacks, which
     # may want to know whether it has already "missed" any instances.
-    __instantiated = False
+    __any_instantiated = False
 
     def __init__(self, *, name=None, attr_name='', parent=None, labels=None,
                  kind=None):
@@ -183,7 +183,7 @@ class OphydObject:
         # Instantiate logger
         self.log = logging.getLogger(base_log + '.' + name)
 
-        if not self.__instantiated:
+        if not self.__any_instantiated:
             self.log.debug("This is the first instance of OphydObject. "
                            "name={self.name}, id={id(self)}")
             self.__mark_as_instantiated()
@@ -191,7 +191,7 @@ class OphydObject:
 
     @classmethod
     def __mark_as_instantiated(cls):
-        cls.__instantiated = True
+        cls.__any_instantiated = True
 
     @classmethod
     def add_instantiation_callback(cls, callback, fail_if_late=False):
@@ -207,7 +207,7 @@ class OphydObject:
             ``RuntimeError`` if it has, as a way of verify that no instances will
             be "missed" by this registry. False by default.
         """
-        if fail_if_late and OphydObject.__instantiated:
+        if fail_if_late and OphydObject.__any_instantiated:
             raise RuntimeError(
                 "OphydObject has already been instantiated at least once, and "
                 "this callback will not be notified of those instances that "

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -1,5 +1,6 @@
 import functools
 from itertools import count
+import weakref
 
 import time
 import logging
@@ -49,6 +50,57 @@ class UnknownSubscription(KeyError):
     ...
 
 
+def register_instances_keyed_on_name(fail_if_late=False):
+    """Register OphydObj instances in a WeakValueDictionary keyed on name.
+
+    Be advised that ophyd does not require 'name' to be unique so this should
+    not be relied on unless name uniqueness is enforced by other means.
+
+    Parameters
+    ----------
+    fail_if_late : boolean
+        If True, verify that OphydObj has not yet been instantiated and raise
+        ``RuntimeError`` if it has, as a way of verify that no instances will
+        be "missed" by this registry. False by default.
+
+    Returns
+    -------
+    WeakValueDictionary
+    """
+    weak_dict = weakref.WeakValueDictionary()
+
+    def register(instance):
+        weak_dict[instance.name] = instance
+
+    OphydObject.add_instantiation_callback(register, fail_if_late)
+    return weak_dict
+
+
+def register_instances_in_weakset(fail_if_late=False):
+    """Register OphydObj instances in a WeakSet.
+
+    Be advised that OphydObj may not always be hashable.
+
+    Parameters
+    ----------
+    fail_if_late : boolean
+        If True, verify that OphydObj has not yet been instantiated and raise
+        ``RuntimeError`` if it has, as a way of verify that no instances will
+        be "missed" by this registry. False by default.
+
+    Returns
+    -------
+    WeakSet
+    """
+    weak_set = weakref.WeakSet()
+
+    def register(instance):
+        weak_set.add(instance)
+
+    OphydObject.add_instantiation_callback(register, fail_if_late)
+    return weak_set
+
+
 class OphydObject:
     '''The base class for all objects in Ophyd
 
@@ -74,7 +126,15 @@ class OphydObject:
     name
     '''
 
+    # Any callables appended to this mutable class variable will be notified
+    # one time when a new instance of OphydObj is instantiated. See
+    # OphydObject.add_instantiation_callback().
+    __instantiation_callbacks = []
     _default_sub = None
+    # This is set to True when the first OphydObj is instiated. This may be of
+    # interest to code that adds something to instantiation_callbacks, which
+    # may want to know whether it has already "missed" any instances.
+    __instantiated = False
 
     def __init__(self, *, name=None, attr_name='', parent=None, labels=None,
                  kind=None):
@@ -121,6 +181,47 @@ class OphydObject:
             name = self.name
         # Instantiate logger
         self.log = logging.getLogger(base_log + '.' + name)
+
+        if not self.__instantiated:
+            self.log.debug("This is the first instance of OphydObject. "
+                           "name={self.name}, id={id(self)}")
+            self.__mark_as_instantiated()
+        self.__register_instance(self)
+
+    @classmethod
+    def __mark_as_instantiated(cls):
+        cls.__instantiated = True
+
+    @classmethod
+    def add_instantiation_callback(cls, callback, fail_if_late=False):
+        """
+        Register a callback which will receive each OphydObject instance.
+
+        Parameters
+        ----------
+        callback : callable
+            Expected signature: ``f(ophydobj_instance)``
+        fail_if_late : boolean
+            If True, verify that OphydObj has not yet been instantiated and raise
+            ``RuntimeError`` if it has, as a way of verify that no instances will
+            be "missed" by this registry. False by default.
+        """
+        if fail_if_late and OphydObject.__instantiated:
+            raise RuntimeError(
+                "OphydObject has already been instantiated at least once, and "
+                "this callback will not be notified of those instances that "
+                "have already been created. If that is acceptable for this "
+                "application, set fail_if_false=False.")
+        # This is a class variable.
+        cls.__instantiation_callbacks.append(callback)
+
+    @classmethod
+    def __register_instance(cls, instance):
+        """
+        Notify the callbacks in OphydObject.instantiation_callbacks of an instance.
+        """
+        for callback in cls.__instantiation_callbacks:
+            callback(instance)
 
     def __init_subclass__(cls, version=None, version_of=None,
                           version_type=None, **kwargs):

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -53,7 +53,8 @@ class UnknownSubscription(KeyError):
 def register_instances_keyed_on_name(fail_if_late=False):
     """Register OphydObj instances in a WeakValueDictionary keyed on name.
 
-    Be advised that ophyd does not require 'name' to be unique so this should
+    Be advised that ophyd does not require 'name' to be unique and is
+    configurable by the user at run-time so this should
     not be relied on unless name uniqueness is enforced by other means.
 
     Parameters

--- a/ophyd/tests/test_ophydobj.py
+++ b/ophyd/tests/test_ophydobj.py
@@ -171,7 +171,7 @@ def test_register_instance():
     test2 = OphydObject(name='test2')
     assert weakdict['test2'] == test2
 
-    assert OphydObject._OphydObject__instantiated == True
+    assert OphydObject._OphydObject__any_instantiated == True
     with pytest.raises(RuntimeError):
         register_instances_in_weakset(fail_if_late=True)
     with pytest.raises(RuntimeError):

--- a/ophyd/tests/test_ophydobj.py
+++ b/ophyd/tests/test_ophydobj.py
@@ -2,7 +2,9 @@ import logging
 import pytest
 
 from unittest.mock import Mock
-from ophyd.ophydobj import OphydObject
+from ophyd.ophydobj import (OphydObject,
+                            register_instances_keyed_on_name,
+                            register_instances_in_weakset)
 from ophyd.status import (StatusBase, DeviceStatus, wait)
 
 logger = logging.getLogger(__name__)
@@ -154,3 +156,23 @@ def test_subscribe_no_default():
 
     with pytest.raises(ValueError):
         o.subscribe(lambda *a, **k: None)
+
+
+def test_register_instance():
+    weakset = register_instances_in_weakset()
+    test1 = OphydObject(name='test1')
+    assert test1 in weakset
+    test2 = OphydObject(name='test1')
+    assert test2 in weakset
+
+    weakdict = register_instances_keyed_on_name()
+    test1 = OphydObject(name='test1')
+    assert weakdict['test1'] == test1
+    test2 = OphydObject(name='test2')
+    assert weakdict['test2'] == test2
+
+    assert OphydObject._OphydObject__instantiated == True
+    with pytest.raises(RuntimeError):
+        register_instances_in_weakset(fail_if_late=True)
+    with pytest.raises(RuntimeError):
+        register_instances_keyed_on_name(fail_if_late=True)


### PR DESCRIPTION
At various times it has been proposed to "auto-register" ophyd objects
in order to maintain a global registery of devices. We have avoided
making OphydObj aware of all its own instances because this could have
weird implications and generally feels like an unusual design in Python.
But we could allow downstream code to sign up to be notified each time
an OphydObj is instantiated. Each subscriber will get one notification,
and they can keep a strong or weak reference if they like, as needed.

<hr />

This suggestion is fully due to @tacaswell and I may or may not have
implemented it exactly as he envisioned. I need to refer to it in
another discussion so I have sketched it here.