### PR TITLE
CI: Silence codecov comments.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+# show coverage in CI status, not as a comment. 
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
This adds a configuration file that we have had in bluesky and other
repos for awhile now. It silences codecov giant comments, while still
leaving codecov's X's or checkmarks in the block "checks" above the
Merge button.