### PR TITLE
Support for AD file writer CreateDirectory PV

### DIFF
--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -785,6 +785,7 @@ class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_
     auto_increment = Cpt(SignalWithRBV, 'AutoIncrement', kind='config')
     auto_save = Cpt(SignalWithRBV, 'AutoSave', kind='config')
     capture = Cpt(SignalWithRBV, 'Capture')
+    create_directory_depth = Cpt(SignalWithRBV, suffix="CreateDirectory")
     delete_driver_file = Cpt(SignalWithRBV, 'DeleteDriverFile', kind='config')
     file_format = Cpt(SignalWithRBV, 'FileFormat', kind='config')
     file_name = Cpt(SignalWithRBV, 'FileName', string=True, kind='config')


### PR DESCRIPTION
AreaDetector file writer plugins (TIFF, HDF5, ...) are intended to write the image buffer to a directory and file.  The plugin can create the directory path, given certain parameters.  One parameter that is not yet interfaced in ophyd is the `CreateDirectory` PV which can, if set to a negative value, create up to that many subdirectory levels.  It's default setting is zero (no directories created).  This PV will fix #728.