### PR TITLE
BLD: Add python_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='ophyd',
       long_description=long_description,
       long_description_content_type='text/markdown',
       license='BSD',
+      python_requires='>=3.6',
       install_requires=requirements,
       packages=find_packages(),
       classifiers=[


### PR DESCRIPTION
This is now part of our standard configuration for new projects, but it was
never added to ophyd.