### PR TITLE
Fix 'shape' reported by describe().

### DIFF
--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -73,9 +73,9 @@ class CamBase(ADBase):
 
     array_callbacks = ADCpt(SignalWithRBV, 'ArrayCallbacks')
     array_size = DDC(ad_group(EpicsSignalRO,
-                              (('array_size_x', 'ArraySizeX_RBV'),
+                              (('array_size_z', 'ArraySizeZ_RBV'),
                                ('array_size_y', 'ArraySizeY_RBV'),
-                               ('array_size_z', 'ArraySizeZ_RBV'))),
+                               ('array_size_x', 'ArraySizeX_RBV'))),
                      doc='Size of the array in the XYZ dimensions')
 
     array_size_bytes = ADCpt(EpicsSignalRO, 'ArraySize_RBV')

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -73,7 +73,10 @@ class DetectorBase(ADBase):
 
     def make_data_key(self):
         source = 'PV:{}'.format(self.prefix)
-        shape = tuple(self.cam.array_size.get())
+        # This shape is expected to match arr.shape for the array.
+        shape = (self.cam.num_images.get(),
+                 self.cam.array_size.array_size_y.get(),
+                 self.cam.array_size.array_size_x.get())
         return dict(shape=shape, source=source, dtype='array',
                     external='FILESTORE:')
 

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -237,9 +237,9 @@ class PluginBase(ADBase, version=(1, 9, 1), version_type='ADCore'):
     height = Cpt(EpicsSignalRO, 'ArraySize1_RBV')
     depth = Cpt(EpicsSignalRO, 'ArraySize2_RBV')
     array_size = DDC_EpicsSignalRO(
+        ('depth', 'ArraySize2_RBV'),
         ('height', 'ArraySize1_RBV'),
         ('width', 'ArraySize0_RBV'),
-        ('depth', 'ArraySize2_RBV'),
         doc='The array size'
     )
 
@@ -314,9 +314,9 @@ class ImagePlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
 
     array_data = Cpt(EpicsSignal, 'ArrayData')
     shaped_image = Cpt(NDDerivedSignal, derived_from='array_data',
-                       shape=('array_size.height',
-                              'array_size.width',
-                              'array_size.depth'),
+                       shape=('array_size.depth',
+                              'array_size.height',
+                              'array_size.width'),
                        num_dimensions='ndimensions',
                        kind='omitted')
 
@@ -326,8 +326,8 @@ class ImagePlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
         if array_size == (0, 0, 0):
             raise RuntimeError('Invalid image; ensure array_callbacks are on')
 
-        if array_size[-1] == 0:
-            array_size = array_size[:-1]
+        if array_size[0] == 0:
+            array_size = array_size[1:]
 
         pixel_count = self.array_pixels
         image = self.array_data.get(count=pixel_count)
@@ -619,9 +619,9 @@ class ROIPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     _plugin_type = 'NDPluginROI'
 
     array_size = DDC_EpicsSignalRO(
-        ('x', 'ArraySizeX_RBV'),
-        ('y', 'ArraySizeY_RBV'),
         ('z', 'ArraySizeZ_RBV'),
+        ('y', 'ArraySizeY_RBV'),
+        ('x', 'ArraySizeX_RBV'),
         doc='Size of the ROI data in XYZ',
     )
 
@@ -732,9 +732,9 @@ class TransformPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     height = Cpt(SignalWithRBV, 'ArraySize1')
     depth = Cpt(SignalWithRBV, 'ArraySize2')
     array_size = DDC_SignalWithRBV(
+        ('depth', 'ArraySize2'),
         ('height', 'ArraySize1'),
         ('width', 'ArraySize0'),
-        ('depth', 'ArraySize2'),
         doc='Array size',
     )
 


### PR DESCRIPTION
We noticed in https://github.com/bluesky/bluesky-browser/pull/36
that area detectors have been reporting the wrong shape in
``describe()``. For a given image ``arr`` referenced by ``read()[data_key]``
we expect ``describe()[data_key]['shape']`` == ``arr.shape``.

Currently ``describe()[data_key]['shape']`` is ``(x, y, 0)``. To match
the ``arr.shape``, it should be ``(num_images, y, x)``. This PR changes
the shape to make it correct.

Downstream tooling will need to cope with both, unless/until we sort out
how to do data migrations. The addition of version metadata to the
RunStart document in bluesky 1.6.0 may help with this.