### PR TITLE
ENH: add EpicsPathSignal

### DIFF
--- a/ophyd/areadetector/__init__.py
+++ b/ophyd/areadetector/__init__.py
@@ -19,3 +19,4 @@ from .plugins import (ColorConvPlugin, FilePlugin, HDF5Plugin, ImagePlugin,  # n
 
 from .common_plugins import *  # noqa: F401, F402, E402, F403
 from .trigger_mixins import *  # noqa: F401, F402, E402, F403
+from .paths import EpicsPathSignal  # noqa: F401, F402, E402, F403

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -258,7 +258,7 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
 
     @read_path_template.setter
     def read_path_template(self, val):
-        self._read_path_template = val
+        self._read_path_template = os.path.join(val, "")
 
     @property
     def write_path_template(self):

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -253,12 +253,14 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
                 raise ValueError(
                     ('root: {!r} in not consistent with '
                      'read_path_template: {!r}').format(rootp, ret))
-
+        ret = os.path.join(ret, "")
         return str(ret)
 
     @read_path_template.setter
     def read_path_template(self, val):
-        self._read_path_template = os.path.join(val, "")
+        if val is not None:
+            val = os.path.join(val, "")
+        self._read_path_template = val
 
     @property
     def write_path_template(self):

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -427,7 +427,7 @@ class FileStorePluginBase(FileStoreBase):
         # These must be set before parent is staged (specifically
         # before capture mode is turned on. They will not be reset
         # on 'unstage' anyway.
-        set_and_wait(self.file_path, write_path)
+        self.file_path.set(write_path).wait()
         set_and_wait(self.file_name, filename)
         set_and_wait(self.file_number, 0)
         super().stage()

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -46,27 +46,6 @@ def new_short_uid():
     return '-'.join(new_uid().split('-')[:-1])
 
 
-def _ensure_trailing_slash(path, path_semantics=None):
-    """
-    'a/b/c' -> 'a/b/c/'
-
-    EPICS adds the trailing slash itself if we do not, so in order for the
-    setpoint filepath to match the readback filepath, we need to add the
-    trailing slash ourselves.
-    """
-    if path_semantics == 'posix':
-        return f'{PurePosixPath(path)}/'
-    elif path_semantics == 'windows':
-        return f'{PureWindowsPath(path)}\\'
-    elif path_semantics is None:
-        # We are forced to guess which path semantics to use.
-        # Guess that the AD driver is running on the same OS as this client.
-        return f'{PurePath(path)}{os.path.sep}'
-    else:
-        # This should never happen, but just for the sake of future-proofing...
-        raise ValueError(f"Cannot handle path_semantics={path_semantics}")
-
-
 def resource_factory(spec, root, resource_path, resource_kwargs,
                      path_semantics):
     """Helper to create resource document and datum factory.
@@ -275,12 +254,10 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
                     ('root: {!r} in not consistent with '
                      'read_path_template: {!r}').format(rootp, ret))
 
-        return _ensure_trailing_slash(str(ret))
+        return str(ret)
 
     @read_path_template.setter
     def read_path_template(self, val):
-        if val is not None:
-            val = _ensure_trailing_slash(val)
         self._read_path_template = val
 
     @property
@@ -306,11 +283,11 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
                     ('root: {!r} in not consistent with '
                      'read_path_template: {!r}').format(rootp, ret))
 
-        return _ensure_trailing_slash(str(ret), path_semantics=self.path_semantics)
+        return str(ret)
 
     @write_path_template.setter
     def write_path_template(self, val):
-        self._write_path_template = _ensure_trailing_slash(val, path_semantics=self.path_semantics)
+        self._write_path_template = val
 
     def stage(self):
         self._locked_key_list = False

--- a/ophyd/areadetector/paths.py
+++ b/ophyd/areadetector/paths.py
@@ -95,14 +95,22 @@ class EpicsPathSignal(EpicsSignal):
         if string is not True:
             raise ValueError('Specifying an EpicsPathSignal with string=False'
                              ' does not make sense')
-        if path_semantics not in OS_NAME_TO_PATH_CLASS:
-            raise ValueError(f'Unknown path semantics: {path_semantics}. '
-                             f'Options: {OS_NAME_TO_PATH_CLASS}')
 
         super().__init__(write_pv=write_pv,
                          read_pv=f'{write_pv}_RBV',
                          string=True,
                          **kwargs)
+
+    @property
+    def path_semantics(self):
+        return self.path_semantics
+
+    @path_semantics.setter
+    def path_semantics(self, value):
+        if value not in OS_NAME_TO_PATH_CLASS:
+            raise ValueError(f'Unknown path semantics: {value}. '
+                             f'Options: {OS_NAME_TO_PATH_CLASS}')
+        self.path_semantics = value
 
     def _repr_info(self):
         yield from super()._repr_info()

--- a/ophyd/areadetector/paths.py
+++ b/ophyd/areadetector/paths.py
@@ -10,6 +10,11 @@ OS_NAME_TO_PATH_CLASS = {
     'posix': pathlib.PurePosixPath,
 }
 
+OS_SEPARATORS = {
+    'nt': '\\',
+    'posix': '/'
+}
+
 
 def path_compare(path_a, path_b, semantics):
     '''
@@ -59,6 +64,9 @@ def set_and_wait_path(signal, val, *, path_semantics, poll_time=0.01,
     ------
     TimeoutError if timeout is exceeded
     """
+    # Make sure val has trailing separator before it's set
+    if not any(str(val).endswith(sep) for sep in OS_SEPARATORS.values()):
+        val = str(val) + OS_SEPARATORS[path_semantics]
     signal.put(val)
     deadline = ttime.time() + timeout if timeout is not None else None
     current_value = signal.get()

--- a/ophyd/areadetector/paths.py
+++ b/ophyd/areadetector/paths.py
@@ -103,14 +103,14 @@ class EpicsPathSignal(EpicsSignal):
 
     @property
     def path_semantics(self):
-        return self.path_semantics
+        return self._path_semantics
 
     @path_semantics.setter
     def path_semantics(self, value):
         if value not in OS_NAME_TO_PATH_CLASS:
             raise ValueError(f'Unknown path semantics: {value}. '
                              f'Options: {OS_NAME_TO_PATH_CLASS}')
-        self.path_semantics = value
+        self._path_semantics = value
 
     def _repr_info(self):
         yield from super()._repr_info()

--- a/ophyd/areadetector/paths.py
+++ b/ophyd/areadetector/paths.py
@@ -1,0 +1,122 @@
+import os
+import pathlib
+import time as ttime
+
+from .. import EpicsSignal
+from ..status import Status
+
+
+OS_NAME_TO_PATH_CLASS = {
+    'nt': pathlib.PureWindowsPath,
+    'posix': pathlib.PurePosixPath,
+}
+
+
+def path_compare(path_a, path_b, semantics):
+    path_class = OS_NAME_TO_PATH_CLASS[semantics]
+    return path_class(path_a) == path_class(path_b)
+
+
+def set_and_wait_path(signal, val, *, path_semantics, poll_time=0.01,
+                      timeout=10):
+    """
+    Set a signal to a value and wait until it reads correctly.
+    For floating point values, it is strongly recommended to set a tolerance.
+    If tolerances are unset, the values will be compared exactly.
+
+    Parameters
+    ----------
+    signal : EpicsPathSignal (or any object with `get` and `put`)
+    val : object
+        value to set signal to
+    poll_time : float, optional
+        how soon to check whether the value has been successfully set
+    timeout : float, optional
+        maximum time to wait for value to be successfully set
+
+    Raises
+    ------
+    TimeoutError if timeout is exceeded
+    """
+    signal.put(val)
+    expiration_time = ttime.time() + timeout if timeout is not None else None
+    current_value = signal.get()
+
+    while not path_compare(current_value, val, semantics=path_semantics):
+        logger.debug("Waiting for %s to be set from %r to %r...",
+                     signal.name, current_value, val)
+        ttime.sleep(poll_time)
+        if poll_time < 0.1:
+            poll_time *= 2  # logarithmic back-off
+        current_value = signal.get()
+        if expiration_time is not None and ttime.time() > expiration_time:
+            raise TimeoutError("Attempted to set %r to value %r and timed "
+                               "out after %r seconds. Current value is %r." %
+                               (signal, val, timeout, current_value))
+
+
+class EpicsPathSignal(EpicsSignal):
+    def __init__(self, write_pv, *, path_semantics, **kwargs):
+        self.path_semantics = path_semantics
+        if kwargs.get('string', True) is not True:
+            raise ValueError('Specifying an EpicsPathSignal with string=False'
+                             ' does not make sense')
+        if path_semantics not in OS_NAME_TO_PATH_CLASS:
+            raise ValueError(f'Unknown path semantics: {path_semantics}. '
+                             f'Options: {OS_NAME_TO_PATH_CLASS}')
+
+        super().__init__(write_pv=write_pv,
+                         read_pv=f'{write_pv}_RBV',
+                         string=True,
+                         **kwargs)
+
+    def _repr_info(self):
+        yield from super()._repr_info()
+        yield ('path_semantics', self.path_semantics)
+
+    def set(self, value, *, timeout=None, settle_time=None):
+        '''
+        Set is like `put`, but is here for bluesky compatibility
+
+        Returns
+        -------
+        st : Status
+            This status object will be finished upon return in the
+            case of basic soft Signals
+        '''
+        def set_thread():
+            try:
+                set_and_wait_path(self, value, timeout=timeout,
+                                  path_semantics=self.path_semantics,
+                                  )
+            except TimeoutError:
+                self.log.debug('set_and_wait_path(%r, %s) timed out',
+                               self.name, value)
+                success = False
+            except Exception as ex:
+                self.log.exception('set_and_wait_path(%r, %s) failed',
+                                   self.name, value)
+                success = False
+            else:
+                self.log.debug('set_and_wait_path(%r, %s) succeeded => %s',
+                               self.name, value, self.value)
+                success = True
+                if settle_time is not None:
+                    time.sleep(settle_time)
+            finally:
+                # keep a local reference to avoid any GC shenanigans
+                th = self._set_thread
+                # these two must be in this order to avoid a race condition
+                self._set_thread = None
+                st._finished(success=success)
+                del th
+
+        if self._set_thread is not None:
+            raise RuntimeError('Another set() call is still in progress')
+
+        st = Status(self)
+        self._status = st
+        self._set_thread = self.cl.thread_class(target=set_thread)
+        self._set_thread.daemon = True
+        self._set_thread.start()
+        return self._status

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -37,7 +37,7 @@ from ..signal import (EpicsSignalRO, EpicsSignal, ArrayAttributeSignal)
 from ..device import GenerateDatumInterface
 from ..utils import enum, set_and_wait
 from ..utils.errors import (PluginMisconfigurationError, DestroyedError, UnprimedPlugin)
-
+from .paths import EpicsPathSignal
 
 logger = logging.getLogger(__name__)
 
@@ -787,7 +787,7 @@ class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_
     capture = Cpt(SignalWithRBV, 'Capture')
     delete_driver_file = Cpt(SignalWithRBV, 'DeleteDriverFile', kind='config')
     file_format = Cpt(SignalWithRBV, 'FileFormat', kind='config')
-    file_name = Cpt(SignalWithRBV, 'FileName', string=True, kind='config')
+    file_name = Cpt(EpicsPathSignal, 'FileName', string=True, kind='config')
     file_number = Cpt(SignalWithRBV, 'FileNumber')
     file_number_sync = Cpt(EpicsSignal, 'FileNumber_Sync')
     file_number_write = Cpt(EpicsSignal, 'FileNumber_write')

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -787,7 +787,8 @@ class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_
     capture = Cpt(SignalWithRBV, 'Capture')
     delete_driver_file = Cpt(SignalWithRBV, 'DeleteDriverFile', kind='config')
     file_format = Cpt(SignalWithRBV, 'FileFormat', kind='config')
-    file_name = Cpt(EpicsPathSignal, 'FileName', string=True, kind='config')
+    file_name = Cpt(EpicsPathSignal, 'FileName', string=True, kind='config',
+                    path_semantics='posix')
     file_number = Cpt(SignalWithRBV, 'FileNumber')
     file_number_sync = Cpt(EpicsSignal, 'FileNumber_Sync')
     file_number_write = Cpt(EpicsSignal, 'FileNumber_write')

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -787,12 +787,12 @@ class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_
     capture = Cpt(SignalWithRBV, 'Capture')
     delete_driver_file = Cpt(SignalWithRBV, 'DeleteDriverFile', kind='config')
     file_format = Cpt(SignalWithRBV, 'FileFormat', kind='config')
-    file_name = Cpt(EpicsPathSignal, 'FileName', string=True, kind='config',
-                    path_semantics='posix')
+    file_name = Cpt(SignalWithRBV, 'FileName', string=True, kind='config')
     file_number = Cpt(SignalWithRBV, 'FileNumber')
     file_number_sync = Cpt(EpicsSignal, 'FileNumber_Sync')
     file_number_write = Cpt(EpicsSignal, 'FileNumber_write')
-    file_path = Cpt(SignalWithRBV, 'FilePath', string=True, kind='config')
+    file_path = Cpt(EpicsPathSignal, 'FilePath', string=True, kind='config',
+                    path_semantics='posix')
     file_path_exists = Cpt(EpicsSignalRO, 'FilePathExists_RBV', kind='config')
     file_template = Cpt(SignalWithRBV, 'FileTemplate', string=True, kind='config')
     file_write_mode = Cpt(SignalWithRBV, 'FileWriteMode', kind='config')

--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -126,6 +126,7 @@ def signal_test_ioc(prefix, request):
                bool_enum=f'{prefix}bool_enum',
                alarm_status=f'{prefix}alarm_status',
                set_severity=f'{prefix}set_severity',
+               path=f'{prefix}path',
                )
 
     pytest.importorskip('caproto.tests.conftest')

--- a/ophyd/tests/signal_ioc.py
+++ b/ophyd/tests/signal_ioc.py
@@ -30,6 +30,8 @@ class SignalTestIOC(PVGroup):
         await self.read_only.alarm.write(
             severity=severity, status=self.alarm_status.value)
 
+    path = pvproperty(value='/path/here')
+
 
 if __name__ == '__main__':
     ioc_options, run_options = ioc_arg_parser(

--- a/ophyd/tests/signal_ioc.py
+++ b/ophyd/tests/signal_ioc.py
@@ -30,7 +30,13 @@ class SignalTestIOC(PVGroup):
         await self.read_only.alarm.write(
             severity=severity, status=self.alarm_status.value)
 
-    path = pvproperty(value='/path/here')
+    INITIAL_PATH = '/path/here'
+    path = pvproperty(value=INITIAL_PATH, max_length=255)
+    path_RBV = pvproperty(value=INITIAL_PATH, max_length=255)
+
+    @path.putter
+    async def path(self, instance, value):
+        await self.path_RBV.write(value=value)
 
 
 if __name__ == '__main__':

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -625,10 +625,10 @@ def test_ndderivedsignal_with_parent():
                           ])
 def test_posix_path(paths, cleanup, ad_prefix):
     class MyDetector(SingleTrigger, SimDetector):
-        fp1 = Cpt(FilePlugin, '')
+        tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
 
     det = MyDetector(ad_prefix, name='test')
-    print(det.fp1.plugin_type)
+    print(det.tiff1.plugin_type)
     cleanup.add(det)
 
     det.wait_for_connection()

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -633,9 +633,10 @@ def test_posix_path(paths, cleanup, ad_prefix):
 
     det.wait_for_connection()
 
-    # det.cam.path_semantics = 'posix'
-    print(det.cam.path_semantics)
-    det.cam.file_path.put(paths)
+    # det.tiff1.file_semantics = 'posix'
+    print(det.tiff1.path_semantics)
+    det.tiff1.file_path.put(paths)
+    # det.cam.file_path.put(paths)
     det.stage()
     st = det.trigger()
     wait(st, timeout=5)

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -18,7 +18,8 @@ from ophyd.areadetector.plugins import (ImagePlugin, StatsPlugin,
                                         OverlayPlugin, ROIPlugin,
                                         TransformPlugin, NetCDFPlugin,
                                         TIFFPlugin, JPEGPlugin, HDF5Plugin,
-                                        FilePlugin)
+                                        # FilePlugin
+                                        )
 from ophyd.areadetector.base import NDDerivedSignal
 from ophyd.areadetector.filestore_mixins import (
     FileStoreTIFF, FileStoreIterativeWrite,
@@ -633,8 +634,6 @@ def test_posix_path(paths, cleanup, ad_prefix):
 
     det.wait_for_connection()
 
-    # det.tiff1.file_semantics = 'posix'
-    print(det.tiff1.path_semantics)
     det.tiff1.file_path.put(paths)
     # det.cam.file_path.put(paths)
     det.stage()

--- a/ophyd/tests/test_epicspath.py
+++ b/ophyd/tests/test_epicspath.py
@@ -1,9 +1,9 @@
 import pytest
 
 from ..areadetector.paths import EpicsPathSignal
-from ..areadetector.plugins import FilePlugin
-from .. import wait, SingleTrigger, SimDetector
-from ..device import (Component as Cpt,)
+# from ..areadetector.plugins import FilePlugin
+# from .. import wait, SingleTrigger, SimDetector
+# from ..device import (Component as Cpt,)
 
 
 def test_path_semantics_exception():

--- a/ophyd/tests/test_epicspath.py
+++ b/ophyd/tests/test_epicspath.py
@@ -1,8 +1,0 @@
-import pytest
-
-from ..areadetector.paths import EpicsPathSignal
-
-
-def test_path_semantics_exception():
-    with pytest.raises(ValueError):
-        EpicsPathSignal('TEST', path_semantics='not_a_thing')

--- a/ophyd/tests/test_epicspath.py
+++ b/ophyd/tests/test_epicspath.py
@@ -1,0 +1,36 @@
+import pytest
+
+from ..areadetector.paths import EpicsPathSignal
+from ..areadetector.plugins import FilePlugin
+from .. import wait, SingleTrigger, SimDetector
+from ..device import (Component as Cpt,)
+
+
+def test_path_semantics_exception():
+    with pytest.raises(ValueError):
+        EpicsPathSignal('TEST', path_semantics='not_a_thing')
+
+
+# @pytest.mark.adsim
+# @pytest.mark.parametrize()
+# def test_epicspath(cleanup, ad_prefix):
+#     class MyDetector(SingleTrigger, SimDetector):
+#         fp1 = Cpt(FilePlugin, '')
+#
+#     det = MyDetector(ad_prefix, name='test')
+#     print(det.fp1.plugin_type)
+#     cleanup.add(det)
+#
+#     det.wait_for_connection()
+#
+#     # try passing in a bunch of unix/windows paths
+#     # and make sure they are fine or break?
+#     windows_path_list = ['']
+#     unix_path_list = ['/path/to/a/thing']
+#
+#     det.cam.path_semantics = 'posix'
+#     det.cam.file_path.put('/path/to/a/thing')
+#     det.stage()
+#     st = det.trigger()
+#     wait(st, timeout=5)
+#     det.unstage()

--- a/ophyd/tests/test_epicspath.py
+++ b/ophyd/tests/test_epicspath.py
@@ -1,36 +1,8 @@
 import pytest
 
 from ..areadetector.paths import EpicsPathSignal
-# from ..areadetector.plugins import FilePlugin
-# from .. import wait, SingleTrigger, SimDetector
-# from ..device import (Component as Cpt,)
 
 
 def test_path_semantics_exception():
     with pytest.raises(ValueError):
         EpicsPathSignal('TEST', path_semantics='not_a_thing')
-
-
-# @pytest.mark.adsim
-# @pytest.mark.parametrize()
-# def test_epicspath(cleanup, ad_prefix):
-#     class MyDetector(SingleTrigger, SimDetector):
-#         fp1 = Cpt(FilePlugin, '')
-#
-#     det = MyDetector(ad_prefix, name='test')
-#     print(det.fp1.plugin_type)
-#     cleanup.add(det)
-#
-#     det.wait_for_connection()
-#
-#     # try passing in a bunch of unix/windows paths
-#     # and make sure they are fine or break?
-#     windows_path_list = ['']
-#     unix_path_list = ['/path/to/a/thing']
-#
-#     det.cam.path_semantics = 'posix'
-#     det.cam.file_path.put('/path/to/a/thing')
-#     det.stage()
-#     st = det.trigger()
-#     wait(st, timeout=5)
-#     det.unstage()

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -576,19 +576,14 @@ def path_signal(cleanup, signal_test_ioc):
                           ('C:/yet/another/path'),
                           ('D:/more/paths/here/')
                           ])
-def test_windows_paths(paths, cleanup, signal_test_ioc):
-    sig = EpicsPathSignal(signal_test_ioc.pvs['path'], name='path',
-                          path_semantics='nt')
-    cleanup.add(sig)
-    sig.set(paths).wait(3)
+def test_windows_paths(paths, path_signal):
+    path_signal.path_semantics = 'nt'
+    path_signal.set(paths).wait(3)
 
 
 @pytest.mark.parametrize('paths',
                          [('/some/path/here'),
                           ('/here/is/another/')
                           ])
-def test_posix_paths(paths, cleanup, signal_test_ioc):
-    sig = EpicsPathSignal(signal_test_ioc.pvs['path'], name='path',
-                          path_semantics='posix')
-    cleanup.add(sig)
-    sig.set(paths).wait(3)
+def test_posix_paths(paths, path_signal):
+    path_signal.set(paths).wait(3)

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -8,6 +8,7 @@ from ophyd import get_cl
 from ophyd.signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)
 from ophyd.utils import (ReadOnlyError, AlarmStatus, AlarmSeverity)
 from ophyd.status import wait
+from ophyd.areadetector.paths import EpicsPathSignal
 
 logger = logging.getLogger(__name__)
 
@@ -558,3 +559,21 @@ def test_epicssignal_pv_reuse(cleanup, pvname, count):
 
     if get_cl().name == 'pyepics':
         assert len(set(id(sig._read_pv) for sig in signals)) == 1
+
+
+@pytest.mark.parametrize('path',
+                         [('C:\\some\\path\\here'),
+                          ('D:\\here\\is\\another\\')
+                          ])
+def test_windows_paths(path):
+    signal_nt = EpicsPathSignal('TEST', path_semantics='nt')
+    signal_nt.set(path).wait(3)
+
+
+@pytest.mark.parametrize('path',
+                         [('/some/path/here'),
+                          ('/here/is/another/')
+                          ])
+def test_posix_paths(path):
+    signal_nt = EpicsPathSignal('TEST', path_semantics='posix')
+    signal_nt.set(path).wait(3)

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -587,3 +587,8 @@ def test_windows_paths(paths, path_signal):
                           ])
 def test_posix_paths(paths, path_signal):
     path_signal.set(paths).wait(3)
+
+
+def test_path_semantics_exception():
+    with pytest.raises(ValueError):
+        EpicsPathSignal('TEST', path_semantics='not_a_thing')

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -561,19 +561,34 @@ def test_epicssignal_pv_reuse(cleanup, pvname, count):
         assert len(set(id(sig._read_pv) for sig in signals)) == 1
 
 
-@pytest.mark.parametrize('path',
+@pytest.fixture(scope='function')
+def path_signal(cleanup, signal_test_ioc):
+    sig = EpicsPathSignal(signal_test_ioc.pvs['path'], name='path',
+                          path_semantics='posix')
+    cleanup.add(sig)
+    sig.wait_for_connection()
+    return sig
+
+
+@pytest.mark.parametrize('paths',
                          [('C:\\some\\path\\here'),
-                          ('D:\\here\\is\\another\\')
+                          ('D:\\here\\is\\another\\'),
+                          ('C:/yet/another/path'),
+                          ('D:/more/paths/here/')
                           ])
-def test_windows_paths(path):
-    signal_nt = EpicsPathSignal('TEST', path_semantics='nt')
-    signal_nt.set(path).wait(3)
+def test_windows_paths(paths, cleanup, signal_test_ioc):
+    sig = EpicsPathSignal(signal_test_ioc.pvs['path'], name='path',
+                          path_semantics='nt')
+    cleanup.add(sig)
+    sig.set(paths).wait(3)
 
 
-@pytest.mark.parametrize('path',
+@pytest.mark.parametrize('paths',
                          [('/some/path/here'),
                           ('/here/is/another/')
                           ])
-def test_posix_paths(path):
-    signal_nt = EpicsPathSignal('TEST', path_semantics='posix')
-    signal_nt.set(path).wait(3)
+def test_posix_paths(paths, cleanup, signal_test_ioc):
+    sig = EpicsPathSignal(signal_test_ioc.pvs['path'], name='path',
+                          path_semantics='posix')
+    cleanup.add(sig)
+    sig.set(paths).wait(3)


### PR DESCRIPTION
Docstrings and cleanups would follow if this is deemed reasonable.

Basic idea is that on a `Device` level (specifically `FilePlugin`) we should be specifying a `Cpt(EpicsPathSignal, 'FilePath', path_semantics='nt')` instead of a regular `EpicsSignal`. This would then take care of `set_and_wait_path` for us.

I believe the base `EpicsSignal` should be more easily customizable to allow such things without massive copy/pasting, but opted to keep changes minimal for this proof-of-concept.

Notes
* Alternative to https://github.com/bluesky/ophyd/pull/703
* `_ensure_trailing_slash` could then be removed, and classes would be modified to use this.
* This would need changing as well: https://github.com/bluesky/ophyd/blob/master/ophyd/areadetector/filestore_mixins.py#L432 (not sure why we aren't calling `.set()` and then `wait(status)` there instead?)