### PR TITLE
ENH: specify for which device another set call is issued

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -253,7 +253,8 @@ class Signal(OphydObject):
                 del th
 
         if self._set_thread is not None:
-            raise RuntimeError('Another set() call is still in progress')
+            raise RuntimeError('Another set() call is still in progress '
+                               f'for {self.name}')
 
         st = Status(self)
         self._status = st


### PR DESCRIPTION
This is to be more specific which device has a second `set` call.