### PR TITLE
ENH add Lambda750kCam

### DIFF
--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -18,6 +18,7 @@ __all__ = ['CamBase',
            'FirewireLinDetectorCam',
            'FirewireWinDetectorCam',
            'GreatEyesDetectorCam',
+           'Lambda750kCam',
            'LightFieldDetectorCam',
            'Mar345DetectorCam',
            'MarCCDDetectorCam',
@@ -312,6 +313,21 @@ class GreatEyesDetectorCam(CamBase):
     hot_side_temp = C(EpicsSignal, 'GreatEyesHotSideTemp')
     readout_dir = C(SignalWithRBV, 'GreatEyesReadoutDir')
     sync = C(SignalWithRBV, 'GreatEyesSync')
+
+
+class Lambda750kCam(CamBase):
+    """
+    support for X-Spectrum Lambda 750K detector
+    
+    https://x-spectrum.de/products/lambda-350k750k/
+    """
+    _html_docs = ['Lambda750kCam.html']
+
+    config_file_path = C(EpicsSignal, 'ConfigFilePath')
+    firmware_version = C(EpicsSignalRO, 'FirmwareVersion_RBV')
+    operating_mode = C(SignalWithRBV, 'OperatingMode')
+    serial_number = C(EpicsSignalRO, 'SerialNumber_RBV')
+    temperature = C(SignalWithRBV, 'Temperature')
 
 
 class LightFieldDetectorCam(CamBase):


### PR DESCRIPTION
support for [ADLambda](https://github.com/areaDetector/ADLambda) [X-Spectrum Lambda 750K](https://x-spectrum.de/products/lambda-350k750k/) area detector

We also have support for [the plugin chain we use now](https://github.com/aps-8id-trr/ipython-8idiuser/blob/master/profile_bluesky/startup/25-areadetector.py#L23-L72).  That plugin chain is likely to be redeveloped in the next year and might not be useful in ophyd, other than pedagogical value.