### PR TITLE
Do not depend on caproto's experimental dependencies.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ codecov
 matplotlib
 pytest
 databroker>=1.0.0b1
-caproto[standard]
+caproto[standard] >=0.4.2rc1
 h5py
 pytest-faulthandler
 pyepics>=3.4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ codecov
 matplotlib
 pytest
 databroker>=1.0.0b1
-caproto[complete]
+caproto[standard]
 h5py
 pytest-faulthandler
 pyepics>=3.4.0


### PR DESCRIPTION
Some of caproto's *optional* dependencies are very experimental:
in particular, ``curio``, ``trio``, and ``asks``. They sometimes
introduce dependencies on bleeding-edge versions of things (most
recently, ``attrs``) that can cause packaging headaches in our other
downstream libraries. These optional requirements should not propagate
into ophyd.