### PR TITLE
MNT: make *_lazy_wait_connection context managers more paranoid

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1634,8 +1634,10 @@ def _wait_for_connection_context(value, doc):
         '''
         orig = dev.lazy_wait_for_connection
         dev.lazy_wait_for_connection = value
-        yield
-        dev.lazy_wait_for_connection = orig
+        try:
+            yield
+        finally:
+            dev.lazy_wait_for_connection = orig
 
     return wrapped
 


### PR DESCRIPTION
Make sure we set the state back if something raises inside of the
context block.