### PR TITLE
Deprecate settable done attribute.

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -46,7 +46,7 @@ class StatusBase:
         self._tname = None
         self._lock = RLock()
         self._callbacks = deque()
-        self.done = done
+        self._done = done
         self.success = success
         self.timeout = None
 
@@ -68,6 +68,32 @@ class StatusBase:
                                       daemon=True, name=self._tname)
             self._timeout_thread = thread
             self._timeout_thread.start()
+
+    @property
+    def done(self):
+        """
+        Boolean indicating whether associated operation has completed.
+
+        This be set to True at __init__ time or by calling `_finished()`. Once
+        True, it can be never become False.
+        """
+        return self._done
+
+    @done.setter
+    def done(self, value):
+        # For now, allow this setter to work only if it has no effect.
+        # In a future release, make this property not settable.
+        if bool(self._done) != bool(value):
+            raise RuntimeError(
+                "The done-ness of a status object cannot be changed by "
+                "setting its `done` attribute directly. Call `_finished()`.")
+        warn(
+            "Do not set the `done` attribute of a status object directly. "
+            "It should only be set indirectly by calling `_finished()`. "
+            "Direct setting was never intended to be supported and it will be "
+            "disallowed in a future release of ophyd, causing this code path "
+            "to fail.",
+            UserWarning)
 
     def _wait_and_cleanup(self):
         """Handle timeout"""
@@ -109,7 +135,7 @@ class StatusBase:
                 # We timed out while waiting for the settle time.
                 return
             self.success = success
-            self.done = True
+            self._done = True
             self._settled()
 
             for cb in self._callbacks:

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -74,8 +74,8 @@ class StatusBase:
         """
         Boolean indicating whether associated operation has completed.
 
-        This be set to True at __init__ time or by calling `_finished()`. Once
-        True, it can be never become False.
+        This is set to True at __init__ time or by calling `_finished()`. Once
+        True, it can never become False.
         """
         return self._done
 

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -67,6 +67,23 @@ def test_status_pre():
     assert state['done']
 
 
+def test_direct_done_setting():
+    st = StatusBase()
+    state, cb = _setup_state_and_cb()
+
+    with pytest.raises(RuntimeError):
+        st.done = True  # changing isn't allowed
+    with pytest.warns(UserWarning):
+        st.done = False  # but for now no-ops warn
+
+    st._finished()
+
+    with pytest.raises(RuntimeError):
+        st.done = False  # changing isn't allowed
+    with pytest.warns(UserWarning):
+        st.done = True  # but for now no-ops warn
+
+
 def test_subscription_status():
     # Arbitrary device
     d = Device("Tst:Prefix", name='test')


### PR DESCRIPTION
It should never have been possible to set `status.done` directly. This
PR makes doing so issue a warning. In the N+1 release we should remove
the setter entirely.