### PR TITLE
add logging to Signal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ script:
   - echo "Checking if the areaDetector IOC is running:"
   - caproto-get -v 13SIM1:cam1:Acquire
 
-  - coverage run --concurrency=thread --parallel-mode run_tests.py -v -k "${TEST_CL}"
+  - coverage run --concurrency=thread --parallel-mode run_tests.py -x -v -k "${TEST_CL}"
   - coverage combine
   - coverage report
   # Make sure only the primary build uploads to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ script:
   - echo "Checking if the areaDetector IOC is running:"
   - caproto-get -v 13SIM1:cam1:Acquire
 
-  - coverage run --concurrency=thread --parallel-mode run_tests.py -x -v -k "${TEST_CL}"
+  - coverage run --concurrency=thread --parallel-mode run_tests.py -v -k "${TEST_CL}"
   - coverage combine
   - coverage report
   # Make sure only the primary build uploads to codecov

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -151,11 +151,16 @@ logger = logging.getLogger('ophyd')
 current_handler = None  # overwritten below
 
 
-def config_ophyd_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, level='WARNING'):
+def config_ophyd_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, level='INFO', backupCount=4):
     """
     Set a new handler on the ``logging.getLogger('ophyd')`` logger.
     If this is called more than once, the handler from the previous invocation
     is removed (if still present) and replaced.
+
+    If a file path is specified a TimedRotatingLogHandler will be used. It will be
+    configured so that a new log file starts every Monday and 4 log files are kept.
+    Log files older than 4 weeks will be deleted.
+
     Parameters
     ----------
     file : object with ``write`` method or filename string
@@ -166,7 +171,9 @@ def config_ophyd_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, level=
         Use ANSI color codes. True by default.
     level : str or int
         Python logging level, given as string or corresponding integer.
-        Default is 'WARNING'.
+        Default is 'INFO'.
+    backupCount : int
+        Number of historical log files to keep. Default is 4.
     Returns
     -------
     handler : logging.Handler
@@ -180,8 +187,8 @@ def config_ophyd_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, level=
     >>> config_ophyd_logging(datefmt="%Y-%m-%d %H:%M:%S")
     Turn off ANSI color codes.
     >>> config_ophyd_logging(color=False)
-    Increase verbosity: show level INFO or higher.
-    >>> config_ophyd_logging(level='INFO')
+    Increase verbosity: show level DEBUG or higher.
+    >>> config_ophyd_logging(level='DEBUG')
     """
     global current_handler
     if isinstance(file, str):
@@ -208,9 +215,11 @@ def config_ophyd_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, level=
         logger.setLevel(levelno)
     return handler
 
+
 # Add a handler with the default parameters at import time.
 config_ophyd_logging()
 set_handler = config_ophyd_logging  # for back-compat
+
 
 def get_handler():
     """

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -2,6 +2,7 @@
 # Apache 2.0. See other_licenses/ in the repository directory.
 
 import logging
+import logging.handlers
 import sys
 try:
     import colorama
@@ -184,7 +185,11 @@ def config_ophyd_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, level=
     """
     global current_handler
     if isinstance(file, str):
-        handler = logging.FileHandler(file)
+        handler = logging.handlers.TimedRotatingFileHandler(
+            filename=file,
+            when="W0",                 # rollover every Monday
+            backupCount=backupCount,   # keep the most recent 4 log files
+        )
     else:
         handler = logging.StreamHandler(file)
     levelno = validate_level(level)

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -261,8 +261,6 @@ def config_ophyd_logging(
     return handler
 
 
-# Add a handler with the default parameters at import time.
-config_ophyd_logging()
 set_handler = config_ophyd_logging  # for back-compat
 
 

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -191,9 +191,9 @@ def config_ophyd_logging(
     If this is called more than once, the handler from the previous invocation
     is removed (if still present) and replaced.
 
-    If a file path is specified a TimedRotatingLogHandler will be used. It will be
-    configured so that a new log file starts every Monday and 4 log files are kept.
-    Log files older than 4 weeks will be deleted.
+    If a file path is specified a TimedRotatingLogHandler will be used. By default
+    it will be configured so that a new log file starts every Monday and 4 log files
+    are kept. Log files older than 4 weeks will be deleted.
 
     Parameters
     ----------
@@ -207,7 +207,9 @@ def config_ophyd_logging(
         Python logging level, given as string or corresponding integer.
         Default is 'WARNING'.
     backupCount : int
-        Number of historical log files to keep. Default is 4.
+        Number of historical log files to keep. Default is 4. Use 0 to
+        keep all historical log files. The argument name is chosen to match
+        TimedRotatingFileHandler's backupCount.
     Returns
     -------
     handler : logging.Handler

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -183,16 +183,12 @@ current_handler = None  # overwritten below
 
 
 def config_ophyd_logging(
-    file=sys.stdout, datefmt="%H:%M:%S", color=True, level="WARNING", backupCount=4
+    file=sys.stdout, datefmt="%H:%M:%S", color=True, level="WARNING"
 ):
     """
     Set a new handler on the ``logging.getLogger('ophyd')`` logger.
     If this is called more than once, the handler from the previous invocation
     is removed (if still present) and replaced.
-
-    If a file path is specified a TimedRotatingLogHandler will be used. By default
-    it will be configured so that a new log file starts every Monday and 4 log files
-    are kept. Log files older than 4 weeks will be deleted.
 
     Parameters
     ----------
@@ -205,10 +201,6 @@ def config_ophyd_logging(
     level : str or int
         Python logging level, given as string or corresponding integer.
         Default is 'WARNING'.
-    backupCount : int
-        Number of historical log files to keep. Default is 4. Use 0 to
-        keep all historical log files. The argument name is chosen to match
-        TimedRotatingFileHandler's backupCount.
     Returns
     -------
     handler : logging.Handler
@@ -227,11 +219,7 @@ def config_ophyd_logging(
     """
     global current_handler
     if isinstance(file, str):
-        handler = logging.handlers.TimedRotatingFileHandler(
-            filename=file,
-            when="W0",  # roll over every Monday
-            backupCount=backupCount,  # keep the most recent "backupCount" log files
-        )
+        handler = logging.FileHandler(file)
     else:
         handler = logging.StreamHandler(file)
     levelno = validate_level(level)

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -132,7 +132,7 @@ color_log_format = ("%(color)s[%(levelname)1.1s %(asctime)s.%(msecs)03d "
 
 def validate_level(level) -> int:
     """
-    Return aN int for level comparison
+    Return an int for level comparison
     """
     if isinstance(level, int):
         levelno = level

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -2,7 +2,6 @@
 # Apache 2.0. See other_licenses/ in the repository directory.
 
 import logging
-import logging.handlers
 import sys
 
 try:
@@ -247,16 +246,10 @@ def config_ophyd_logging(
         logger.removeHandler(current_handler)
     logger.addHandler(handler)
 
-    if current_handler in control_layer_logger.handlers:
-        control_layer_logger.removeHandler(current_handler)
-    control_layer_logger.addHandler(handler)
     current_handler = handler
 
     if logger.getEffectiveLevel() > levelno:
         logger.setLevel(levelno)
-
-    if control_layer_logger.getEffectiveLevel() > levelno:
-        control_layer_logger.setLevel(levelno)
 
     return handler
 

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -203,6 +203,13 @@ def config_ophyd_logging(file=sys.stdout, datefmt='%H:%M:%S', color=True, level=
         logger.setLevel(levelno)
     return handler
 
-
 # Add a handler with the default parameters at import time.
-current_handler = set_handler()
+config_ophyd_logging()
+set_handler = config_ophyd_logging  # for back-compat
+
+def get_handler():
+    """
+    Return the handler configured by the most recent call to :func:`config_ophyd_logging`.
+    If :func:`config_ophyd_logging` has not yet been called, this returns ``None``.
+    """
+    return current_handler

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     curses = None
 
-__all__ = ('config_ophyd_logging', 'get_handler', 'set_handler',)
+__all__ = ('config_ophyd_logging', 'get_handler', 'logger', 'set_handler',)
 
 
 def _stderr_supports_color():

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -184,7 +184,7 @@ current_handler = None  # overwritten below
 
 
 def config_ophyd_logging(
-    file=sys.stdout, datefmt="%H:%M:%S", color=True, level="INFO", backupCount=4
+    file=sys.stdout, datefmt="%H:%M:%S", color=True, level="WARNING", backupCount=4
 ):
     """
     Set a new handler on the ``logging.getLogger('ophyd')`` logger.
@@ -205,7 +205,7 @@ def config_ophyd_logging(
         Use ANSI color codes. True by default.
     level : str or int
         Python logging level, given as string or corresponding integer.
-        Default is 'INFO'.
+        Default is 'WARNING'.
     backupCount : int
         Number of historical log files to keep. Default is 4.
     Returns

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -121,7 +121,16 @@ class LogFormatter(logging.Formatter):
             self._normal = ""
 
     def format(self, record):
-        record.message = record.getMessage()
+        message = []
+        if hasattr(record, "ophyd_object_name"):
+            message.append(f"[{record.ophyd_object_name}]")
+        elif hasattr(record, "status"):
+            message.append(f"[{record.status}]")
+        else:
+            ...
+
+        message.append(record.getMessage())
+        record.message = " ".join(message)
         record.asctime = self.formatTime(record, self.datefmt)
 
         try:

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -172,7 +172,7 @@ def validate_level(level) -> int:
     else:
         raise ValueError(
             "Your level is illegal, please use "
-            "'ERROR', 'WARNING', 'INFO', 'DEBUG', OR 'TRACE'."
+            "'CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'INFO', or 'DEBUG'."
         )
 
 

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -177,7 +177,7 @@ def validate_level(level) -> int:
 
 
 logger = logging.getLogger("ophyd")
-control_layer_logger = logging.getLogger("ophyd_control_layer")
+control_layer_logger = logging.getLogger("ophyd.control_layer")
 
 
 current_handler = None  # overwritten below

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -5,7 +5,7 @@ from logging import LoggerAdapter
 import time
 import weakref
 
-from .log import logger
+from .log import control_layer_logger, logger
 
 
 def select_version(cls, version):
@@ -186,6 +186,7 @@ class OphydObject:
             base_log = self.__class__.__module__
             name = self.name
         self.log = OphydObjectLoggerAdapter(logger, {'base_log': base_log, 'name': name})
+        self.control_layer_log = OphydObjectLoggerAdapter(control_layer_logger, {'name': name})
 
         if not self.__any_instantiated:
             self.log.info("first instance of OphydObject: id=%s", id(self))

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -272,8 +272,10 @@ class OphydObject:
                 )
 
         if versions is not None and version in versions:
-            module_logger.warning('Redefining %r version %s: old=%r new=%r',
-                                  version_of, version, versions[version], cls)
+            logger.warning(
+                'Redefining %r version %s: old=%r new=%r',
+                version_of, version, versions[version], cls
+            )
 
         versions[version] = cls
 

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -99,14 +99,6 @@ def register_instances_in_weakset(fail_if_late=False):
     return weak_set
 
 
-class OphydObjectLoggerAdapter(LoggerAdapter):
-    """
-    A LoggerAdapter for use by OphydObject.
-    """
-    def process(self, msg, kwargs):
-        return f"[{self.extra['name']}] {msg}", kwargs
-
-
 class OphydObject:
     '''The base class for all objects in Ophyd
 
@@ -185,8 +177,8 @@ class OphydObject:
         else:
             base_log = self.__class__.__module__
             name = self.name
-        self.log = OphydObjectLoggerAdapter(logger, {'base_log': base_log, 'name': name})
-        self.control_layer_log = OphydObjectLoggerAdapter(control_layer_logger, {'name': name})
+        self.log = LoggerAdapter(logger, {'base_log': base_log, 'ophyd_object_name': name})
+        self.control_layer_log = LoggerAdapter(control_layer_logger, {'ophyd_object_name': name})
 
         if not self.__any_instantiated:
             self.log.info("first instance of OphydObject: id=%s", id(self))

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -927,12 +927,12 @@ class EpicsSignalBase(Signal):
                 f"within {connection_timeout:.2} sec") from err
         # Pyepics returns None when a read request times out.  Raise a
         # TimeoutError on its behalf.
-        self.log.info(
+        self.control_layer_log.info(
             'pv[%s].get_with_metadata(as_string=%s, form=%s, timeout=%s)',
             pv.pvname, as_string, form, timeout
         )
         info = pv.get_with_metadata(as_string=as_string, form=form, timeout=timeout)
-        self.log.info('pv[%s].get_with_metadata(...) returned', pv.name)
+        self.control_layer_log.info('pv[%s].get_with_metadata(...) returned', pv.name)
 
         if info is None:
             raise ReadTimeoutError(
@@ -1445,7 +1445,7 @@ class EpicsSignal(EpicsSignalBase):
         if not self.write_access:
             raise ReadOnlyError('No write access to underlying EPICS PV')
 
-        self.log.info(
+        self.control_layer_log.info(
             '_write_pv.put(value=%s, use_complete=%s, callback=%s, kwargs=%s)',
             value, use_complete, callback, kwargs
         )

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -13,7 +13,6 @@ from .utils.epics_pvs import (waveform_to_string,
 from .ophydobj import OphydObject, Kind
 from .status import Status
 from . import get_cl
-from .log import logger
 
 
 # Sentinels used for default values
@@ -76,6 +75,7 @@ class Signal(OphydObject):
 
         super().__init__(name=name, parent=parent, kind=kind, labels=labels,
                          attr_name=attr_name)
+
         if cl is None:
             cl = get_cl()
         self.cl = cl
@@ -169,7 +169,6 @@ class Signal(OphydObject):
 
     def get(self, **kwargs):
         '''The readback value'''
-        logger.info('%s get() returning ', self, self._readback)
         return self._readback
 
     def put(self, value, *, timestamp=None, force=False, metadata=None,
@@ -195,6 +194,11 @@ class Signal(OphydObject):
             Check the value prior to setting it, defaults to False
 
         '''
+        self.log.info(
+            'put(value=%s, timestamp=%s, force=%s, metadata=%s)',
+            value, timestamp, force, metadata
+        )
+
         # TODO: consider adding set_and_wait here as a kwarg
         if kwargs:
             warnings.warn('Signal.put no longer takes keyword arguments; '
@@ -226,7 +230,6 @@ class Signal(OphydObject):
         if 'timestamp' not in self._metadata_keys:
             md_for_callback['timestamp'] = timestamp
 
-        logger.info('%s put(value=%s, timestamp=%s, force=%s, metadata=%s)', self, value, timestamp, force, metadata)
         self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value,
                        value=value, **md_for_callback)
 
@@ -239,25 +242,34 @@ class Signal(OphydObject):
             This status object will be finished upon return in the
             case of basic soft Signals
         '''
-        logger.info('%s set(value=%s, timeout=%s, settle_time=%s)', self, value, timeout, settle_time)
+        self.log.info(
+            'set(value=%s, timeout=%s, settle_time=%s)',
+            value, timeout, settle_time
+        )
 
         def set_thread():
             try:
                 set_and_wait(self, value, timeout=timeout, atol=self.tolerance,
                              rtol=self.rtolerance)
             except TimeoutError:
-                self.log.debug('set_and_wait(%r, %s) timed out', self.name,
-                               value)
+                self.log.warning(
+                    'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
+                    value, timeout, self.tolerance, self.rtolerance
+                )
                 success = False
             except Exception as ex:
-                self.log.exception('set_and_wait(%r, %s) failed',
-                                   self.name, value)
+                self.log.exception(
+                    'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
+                    value, timeout, self.tolerance, self.rtolerance
+                )
                 success = False
             else:
-                self.log.debug('set_and_wait(%r, %s) succeeded => %s',
-                               self.name, value, self.value)
+                self.log.info(
+                    'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
+                    value, timeout, self.tolerance, self.rtolerance, self.value)
                 success = True
                 if settle_time is not None:
+                    self.log.info('settling for %d seconds', settle_time)
                     time.sleep(settle_time)
             finally:
                 # keep a local reference to avoid any GC shenanigans
@@ -276,7 +288,6 @@ class Signal(OphydObject):
         self._set_thread = self.cl.thread_class(target=set_thread)
         self._set_thread.daemon = True
         self._set_thread.start()
-        logger.debug('%s set() returning %s', self, self._status)
         return self._status
 
     @property
@@ -286,12 +297,10 @@ class Signal(OphydObject):
             val = self._readback
         else:
             val = self.get()
-        logger.info('%s value returning %s', self, val)
         return val
 
     @value.setter
     def value(self, value):
-        logger.info('setting %s value to %s', self, value)
         self.put(value)
 
     @raise_if_disconnected
@@ -399,7 +408,6 @@ class Signal(OphydObject):
         Clears all subscriptions on this Signal.  Once destroyed, the signal
         may no longer be used.
         '''
-        logger.info('%s destroy()', self)
         self._destroyed = True
         super().destroy()
 
@@ -860,9 +868,8 @@ class EpicsSignalBase(Signal):
         # Ensure callbacks are run prior to returning, as
         # @raise_if_disconnected can cause issues otherwise.
         if not self._signal_is_ready.wait(timeout):
-            raise TimeoutError('Control layer {} failed to send connection and '
-                               'access rights information within {:.1f} sec'
-                               ''.format(self.cl.name, float(timeout)))
+            raise TimeoutError(f'Control layer {self.cl.name} failed to send connection and '
+                               f'access rights information within {float(timeout):.1f} sec')
 
     def wait_for_connection(self, timeout=1.0):
         '''Wait for the underlying signals to initialize or connect'''
@@ -920,7 +927,12 @@ class EpicsSignalBase(Signal):
                 f"within {connection_timeout:.2} sec") from err
         # Pyepics returns None when a read request times out.  Raise a
         # TimeoutError on its behalf.
+        self.log.info(
+            'pv[%s].get_with_metadata(as_string=%s, form=%s, timeout=%s)',
+            pv.pvname, as_string, form, timeout
+        )
         info = pv.get_with_metadata(as_string=as_string, form=form, timeout=timeout)
+        self.log.info('pv[%s].get_with_metadata(...) returned', pv.name)
 
         if info is None:
             raise ReadTimeoutError(
@@ -1433,6 +1445,10 @@ class EpicsSignal(EpicsSignalBase):
         if not self.write_access:
             raise ReadOnlyError('No write access to underlying EPICS PV')
 
+        self.log.info(
+            '_write_pv.put(value=%s, use_complete=%s, callback=%s, kwargs=%s)',
+            value, use_complete, callback, kwargs
+        )
         self._write_pv.put(value, use_complete=use_complete, callback=callback,
                            **kwargs)
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -932,7 +932,7 @@ class EpicsSignalBase(Signal):
             pv.pvname, as_string, form, timeout
         )
         info = pv.get_with_metadata(as_string=as_string, form=form, timeout=timeout)
-        self.control_layer_log.info('pv[%s].get_with_metadata(...) returned', pv.name)
+        self.control_layer_log.info('pv[%s].get_with_metadata(...) returned', pv.pvname)
 
         if info is None:
             raise ReadTimeoutError(

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -189,12 +189,12 @@ class SynSignalRO(SynSignal):
             connected=True,)
 
     def put(self, value, *, timestamp=None, force=False):
-        msg = "put(value={}) called on {}.".format(self)
+        msg = f"{self}.put(value={value}, timestamp={timestamp}, force={force})"
         logger.error(msg)
         raise ReadOnlyError(msg)
 
     def set(self, value, *, timestamp=None, force=False):
-        msg = "{} is readonly.".format(self)
+        msg = f"{self} is readonly"
         logger.error(msg)
         raise ReadOnlyError(msg)
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -26,8 +26,7 @@ from .pseudopos import (PseudoPositioner, PseudoSingle,
                         real_position_argument, pseudo_position_argument)
 from .positioner import SoftPositioner
 from .utils import ReadOnlyError, LimitError
-
-logger = logging.getLogger(__name__)
+from .log import logger
 
 
 # two convenience functions 'vendored' from bluesky.utils
@@ -138,6 +137,8 @@ class SynSignal(Signal):
             connected=True,
         )
 
+        logger.info(self)
+
     def describe(self):
         res = super().describe()
         # There should be only one key here, but for the sake of generality....
@@ -146,12 +147,16 @@ class SynSignal(Signal):
         return res
 
     def trigger(self):
+        logger.info('trigger %s', self)
+
         delay_time = self.exposure_time
         if delay_time:
+            logger.info('%s delay_time is %d', self, delay_time)
             st = DeviceStatus(device=self)
             if self.loop.is_running():
 
                 def update_and_finish():
+                    logger.info('update_and_finish %s', self)
                     self.put(self._func())
                     st._finished()
 
@@ -159,6 +164,7 @@ class SynSignal(Signal):
             else:
 
                 def sleep_and_finish():
+                    logger.info('sleep_and_finish %s', self)
                     ttime.sleep(delay_time)
                     self.put(self._func())
                     st._finished()
@@ -183,10 +189,14 @@ class SynSignalRO(SynSignal):
             connected=True,)
 
     def put(self, value, *, timestamp=None, force=False):
-        raise ReadOnlyError("The signal {} is readonly.".format(self.name))
+        msg = "put(value={}) called on {}.".format(self)
+        logger.error(msg)
+        raise ReadOnlyError(msg)
 
     def set(self, value, *, timestamp=None, force=False):
-        raise ReadOnlyError("The signal {} is readonly.".format(self.name))
+        msg = "{} is readonly.".format(self)
+        logger.error(msg)
+        raise ReadOnlyError(msg)
 
 
 class SynPeriodicSignal(SynSignal):

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -168,7 +168,7 @@ class StatusBase:
         success : bool, optional
            if the action succeeded.
         """
-        self.log.info('finished', success)
+        self.log.info('finished')
         if self.done:
             return
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -117,7 +117,7 @@ class StatusBase:
                 if self.done:
                     # Avoid race condition with settling.
                     return
-                self.log.warning('timeout after %d seconds', timeout)
+                self.log.warning('timeout after %.2f seconds', timeout)
                 try:
                     self._handle_failure()
                 finally:

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -57,6 +57,8 @@ class StatusBase:
         self.success = success
         self.timeout = None
 
+        self.log = StatusBaseLoggerAdapter(logger=logger, extra={'status': self})
+
         if settle_time is None:
             settle_time = 0.0
 
@@ -75,8 +77,6 @@ class StatusBase:
                                       daemon=True, name=self._tname)
             self._timeout_thread = thread
             self._timeout_thread.start()
-
-        self.log = StatusBaseLoggerAdapter(logger=logger, extra={'status': self})
 
     @property
     def done(self):

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -25,14 +25,6 @@ def _locked(func):
     return f
 
 
-class StatusBaseLoggerAdapter(LoggerAdapter):
-    """
-    A LoggerAdapter for use by StatusBase and derived classes.
-    """
-    def process(self, msg, kwargs):
-        return f"[{str(self.extra['status'])}] {msg}", kwargs
-
-
 class StatusBase:
     """
     This is a base class that provides a single-slot callback for when the
@@ -57,7 +49,7 @@ class StatusBase:
         self.success = success
         self.timeout = None
 
-        self.log = StatusBaseLoggerAdapter(logger=logger, extra={'status': self})
+        self.log = LoggerAdapter(logger=logger, extra={'status': self})
 
         if settle_time is None:
             settle_time = 0.0

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -168,8 +168,8 @@ class StatusBase:
         success : bool, optional
            if the action succeeded.
         """
-        self.log.info('finished')
         if self.done:
+            self.log.info('finished')
             return
 
         if success and self.settle_time > 0:

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -71,7 +71,6 @@ def test_logger_adapter_status():
     status.log.info("here is some info")
     assert log_buffer.getvalue().endswith(f"[{str(status)}] here is some info\n")
 
-    status.done = True
-    status.success = True
+    status._finished(success=True)
     status.log.info("here is more info")
     assert log_buffer.getvalue().endswith(f"[{str(status)}] here is more info\n")

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -1,0 +1,15 @@
+import pytest
+
+import ophyd.log as log
+
+
+def test_validate_level():
+    log.validate_level("CRITICAL")
+    log.validate_level("ERROR")
+    log.validate_level("WARNING")
+    log.validate_level("INFO")
+    log.validate_level("DEBUG")
+    log.validate_level("NOTSET")
+
+    with pytest.raises(ValueError):
+        log.validate_level("TRACE")

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -25,8 +25,8 @@ def test_default_config_ophyd_logging():
     log.config_ophyd_logging()
 
     assert isinstance(log.current_handler, logging.StreamHandler)
-    assert log.logger.getEffectiveLevel() <= logging.INFO
-    assert log.control_layer_logger.getEffectiveLevel() <= logging.INFO
+    assert log.logger.getEffectiveLevel() <= logging.WARNING
+    assert log.control_layer_logger.getEffectiveLevel() <= logging.WARNING
 
 
 def test_config_ophyd_logging():

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -1,3 +1,6 @@
+import logging
+import logging.handlers
+
 import pytest
 
 import ophyd.log as log
@@ -13,3 +16,30 @@ def test_validate_level():
 
     with pytest.raises(ValueError):
         log.validate_level("TRACE")
+
+
+def test_default_config_ophyd_logging():
+    log.config_ophyd_logging()
+
+    assert isinstance(log.current_handler, logging.StreamHandler)
+    assert log.logger.getEffectiveLevel() <= logging.INFO
+    assert log.control_layer_logger.getEffectiveLevel() <= logging.INFO
+
+
+def test_config_ophyd_logging():
+    datefmt = "%Y:%m:%d %H-%M-%S"
+    backupCount = 10
+
+    log.config_ophyd_logging(
+        file="ophyd.log",
+        datefmt=datefmt,
+        color=False,
+        level="DEBUG",
+        backupCount=backupCount,
+    )
+
+    assert isinstance(log.current_handler, logging.handlers.TimedRotatingFileHandler)
+    assert log.current_handler.backupCount == backupCount
+    assert log.current_handler.formatter.datefmt == datefmt
+    assert log.logger.getEffectiveLevel() <= logging.DEBUG
+    assert log.control_layer_logger.getEffectiveLevel() <= logging.DEBUG

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -55,9 +55,9 @@ def test_logger_adapter_ophyd_object():
 
     log.logger.addHandler(log_stream)
 
-    ophyd_object = OphydObject(name="testing")
+    ophyd_object = OphydObject(name="testing OphydObject.log")
     ophyd_object.log.info("here is some info")
-    assert log_buffer.getvalue().endswith("[testing] here is some info\n")
+    assert log_buffer.getvalue().endswith("[testing OphydObject.log] here is some info\n")
 
 
 def test_logger_adapter_status():

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -31,18 +31,15 @@ def test_default_config_ophyd_logging():
 
 def test_config_ophyd_logging():
     datefmt = "%Y:%m:%d %H-%M-%S"
-    backupCount = 10
 
     log.config_ophyd_logging(
         file="ophyd.log",
         datefmt=datefmt,
         color=False,
         level="DEBUG",
-        backupCount=backupCount,
     )
 
-    assert isinstance(log.current_handler, logging.handlers.TimedRotatingFileHandler)
-    assert log.current_handler.backupCount == backupCount
+    assert isinstance(log.current_handler, logging.FileHandler)
     assert log.current_handler.formatter.datefmt == datefmt
     assert log.logger.getEffectiveLevel() <= logging.DEBUG
     assert log.control_layer_logger.getEffectiveLevel() <= logging.DEBUG


### PR DESCRIPTION
This PR proposes
  - automatic logging configuration on import of ophyd/log.py - taken from caproto with one change described below
  - logging calls in the Signal class

The logging configuration in caproto is used as a template, but the file handler has been changed to TimedRotatingFileHandler set to rollover to a new file every week and to keep the last four log files.

