### PR TITLE
Make timeouts more configurable.

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -132,8 +132,8 @@ class OphydObject:
     # OphydObject.add_instantiation_callback().
     __instantiation_callbacks = []
     _default_sub = None
-    # This is set to True when the first OphydObj is instiated. This may be of
-    # interest to code that adds something to instantiation_callbacks, which
+    # This is set to True when the first OphydObj is instantiated. This may be
+    # of interest to code that adds something to instantiation_callbacks, which
     # may want to know whether it has already "missed" any instances.
     __any_instantiated = False
 

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -186,11 +186,11 @@ class OphydObject:
         if not self.__any_instantiated:
             self.log.debug("This is the first instance of OphydObject. "
                            "name={self.name}, id={id(self)}")
-            self.__mark_as_instantiated()
+            OphydObject._mark_as_instantiated()
         self.__register_instance(self)
 
     @classmethod
-    def __mark_as_instantiated(cls):
+    def _mark_as_instantiated(cls):
         cls.__any_instantiated = True
 
     @classmethod

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -672,10 +672,10 @@ class EpicsSignalBase(Signal):
         if not self.__any_instantiated:
             self.log.debug("This is the first instance of EpicsSignalBase. "
                            "name={self.name}, id={id(self)}")
-            self.__mark_as_instantiated()
+            EpicsSignalBase._mark_as_instantiated()
 
     @classmethod
-    def __mark_as_instantiated(cls):
+    def _mark_as_instantiated(cls):
         "Update state indicated that this class has been instantiated."
         cls.__any_instantiated = True
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1003,7 +1003,7 @@ class EpicsSignalBase(Signal):
                             attempts,
                             pv.pvname,
                             connection_timeout)
-                    elif isinstance(err, ReadTimeoutError):
+                    else:
                         self.log.warning(
                             "Attempt %d/%d to read PV %s timed out "
                             "in %.2f sec. Retrying....",
@@ -1011,8 +1011,6 @@ class EpicsSignalBase(Signal):
                             attempts,
                             pv.pvname,
                             read_timeout)
-                    else:
-                        assert False, "Unexpected error type"
             else:
                 # Success.
                 return info

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -940,10 +940,9 @@ class EpicsSignalBase(Signal):
         attempts = 1 + retries
         start_time = time.monotonic()
         if timeout is None:
-            # The user has told us to wait forever. How shall we divide
-            # "forever" up into retries? Let us choose 100X the floor timeout
-            # per read.  This is a pretty weird edge case not worth worry about
-            # much: users really shouldn't ask us to wait forever.
+            # The user has told us to go until we run out of retires, with no
+            # overall time limit. How shall we divide "unlimited time" up into
+            # retries? Let us choose 100X the floor timeout per read.
             read_timeout = floor * 100
             deadline = None
         else:

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -968,7 +968,7 @@ class EpicsSignalBase(Signal):
                     self.wait_for_connection(timeout=connection_timeout)
                 except TimeoutError:
                     raise ConnectionTimeoutError(
-                        f"Failed to connect to {self._read_pvname} "
+                        f"Failed to connect to {pv.pvname} "
                         f"within {connection_timeout:.2} sec")
                 # Pyepics returns None when a read request times out.
                 # Raise a TimeoutError on its behalf.
@@ -978,7 +978,7 @@ class EpicsSignalBase(Signal):
 
                 if info is None:
                     raise ReadTimeoutError(
-                        f"Failed to read {self._read_pvname} "
+                        f"Failed to read {pv.pvname} "
                         f"within {read_timeout:.2} sec")
             except TimeoutError as err_:
                 err = err_
@@ -990,7 +990,7 @@ class EpicsSignalBase(Signal):
                     # the immediate cause of this failure and a more general
                     # message specifying how long we tried.
                     raise TimeoutError(
-                        f"Failed to read {self._read_pvname} in "
+                        f"Failed to read {pv.pvname} in "
                         f"{timeout:.2} sec. {attempt + 1} attempt(s) were made. "
                         f"Giving up because timeout has been reached.") from err
                 elif attempt + 1 < attempts:
@@ -1001,7 +1001,7 @@ class EpicsSignalBase(Signal):
                             "in %.2f sec. Retrying....",
                             attempt + 1,
                             attempts,
-                            self._read_pvname,
+                            pv.pvname,
                             connection_timeout)
                     elif isinstance(err, ReadTimeoutError):
                         self.log.warning(
@@ -1009,7 +1009,7 @@ class EpicsSignalBase(Signal):
                             "in %.2f sec. Retrying....",
                             attempt + 1,
                             attempts,
-                            self._read_pvname,
+                            pv.pvname,
                             read_timeout)
                     else:
                         assert False, "Unexpected error type"
@@ -1020,7 +1020,7 @@ class EpicsSignalBase(Signal):
             # We have run out of attempts. Give up.
             elapsed = time.monotonic() - start_time
             raise TimeoutError(
-                f"Failed to read {self._read_pvname} "
+                f"Failed to read {pv.pvname} "
                 f"after {attempt} attempt(s) taking place over about "
                 f"{elapsed:.2} seconds in total. "
                 f"Giving up because max retries were reached.") from err


### PR DESCRIPTION
Per @prjemian, there is a decades-long bug in the EPICS servers that causes IOCs to sometimes ignore read requests, even though the specification requires them to respond. Reportedly, SPEC works around this by simply retrying. This is a little scary, because if the IOC is suddenly not abiding by the specification one could worry that it could be giving wrong data.

We have observed this intermittently at NSLS, typically in the context of Area Detector and at least once with a Scaler. At APS (particulartly 8ID) they have observed it significantly more. Anecdotally, this server issue seems to be easier to hit with hard IOCs than soft IOCs, which may explain why it is more common at APS than NSLS.

As a compromise, ophyd will allow users to opt in to retries. Default settings can be applied at the class level, via a new classmethod on `EpicsSignalBase`. Individual signals may be separately configured at instantiation time.

Basic demo and relevant docstring:

```py
In [1]: import ophyd                                                                                                                                                                          

In [2]: ophyd.EpicsSignal.set_default_timeout(timeout=60, read_retries=5, floor=10)                                                                                                           

In [3]: signal = ophyd.signal.EpicsSignal('simple:A')                                                                                                                                         

In [4]: signal.get()                                                                                                                                                                          
Out[4]: 1

In [5]: signal.get_setpoint()                                                                                                                                                                 
Out[5]: 1

In [6]: ophyd.EpicsSignal.set_default_timeout?                                                                                                                                                
Signature:
ophyd.EpicsSignal.set_default_timeout(
    *,
    timeout=2.0,
    connection_timeout=1.0,
    read_retries=0,
    floor=0.5,
)
Docstring:
Set the class-wide defaults for timeouts and read retries.

This may only be called before any instances of EpicsSignalBase are
made.

Parameters
----------
timeout: float, optional
    Total time budget (seconds) for connecting and reading, including
    all retries.
connection_timeout: float, optional
    Time (seconds) allocated for establishing a connection with the
    IOC.
read_retries: integer, optional
    Number of retries. The default value is 0, meaning one total
    read attempt will be made.
floor: float, optional
    Minimum time per read attempt. Each read attempt will be given
    ``max(timeout / read_retries, floor)`` seconds to succeed or
    timeout.

Raises
------
RuntimeError
    If called after :class:`EpicsSignalBase` has been instantiated for
    the first time.
File:      ~/Repos/bnl/ophyd/ophyd/signal.py
Type:      method
```

The finer points of this API were worked out in a brief conversation with @tacaswell and @MikeHart85. The implementation here seems to basically work, but needs testing and likely some polishing. Handing off to @prjemian....