### PR TITLE
MNT: clip progress fraction to [0, 1] to be safe

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -477,7 +477,7 @@ class MoveStatus(DeviceStatus):
         initial = self.start_pos
         time_elapsed = time.time() - self.start_ts
         try:
-            fraction = abs(target - current) / abs(initial - target)
+            fraction = np.clip(abs(target - current) / abs(initial - target), 0, 1)
         # maybe we can't do math?
         except (TypeError, ZeroDivisionError):
             fraction = None


### PR DESCRIPTION
tqdm does not like things that are out of range and correctly think it
is the clients problem to ensure this invariant.