### PR TITLE
HACK: set read timeout unconditionally to 10s

### DIFF
--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -65,10 +65,10 @@ class FakeEpicsPV(object):
         except Exception:
             pass
 
-    def get_timevars(self):
+    def get_timevars(self, timeout=None, warn=None):
         pass
 
-    def get_ctrlvars(self):
+    def get_ctrlvars(self, timeout=None, warn=None):
         pass
 
     @property
@@ -191,8 +191,8 @@ class FakeEpicsPV(object):
     def __repr__(self):
         return '<FakePV %s value=%s>' % (self._pvname, self.value)
 
-    def get(self, as_string=False, use_numpy=False,
-            use_monitor=False):
+    def get(self, count=None, as_string=False, use_numpy=False,
+            timeout=None, with_ctrlvals=False, use_monitor=False):
         if as_string:
 
             if isinstance(self.value, list):


### PR DESCRIPTION
In #788 we added the ability to control the default timeout (and
per-signal PV timeout).  For unclear reasons some IOCs can take an
unexpectedly long time to service read requests and this knob gives us
the ability to accept that delay rather than failing the `get` which
returns `None` which tends to cause issues with down stream code.

That enhancement was built on top of a number of other
changes (including the machinery to know if any Signals have been
instantiated yet and an overhaul of EpicsSignal internals) which makes
it impossible to directly back-port that change to the 1.3.x branch.

Instead, we hard-code the default timeout to 10s.  This will increase
how long it will take for us to fail if the server truly has become
non-responsive, but will greatly reduce the number of false-positive
failures.