### PR TITLE
Some Minor Fixes

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -117,6 +117,8 @@ class Signal(OphydObject):
 
             self._metadata.update(**unset_metadata)
 
+        self._run_metadata_callbacks()
+
     def trigger(self):
         '''Call that is used by bluesky prior to read()'''
         # NOTE: this is a no-op that exists here for bluesky purposes

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -127,7 +127,10 @@ class SynSignal(Signal):
             # Initialize readback with a None value
             self._readback = None
         if loop is None:
-            loop = asyncio.get_event_loop()
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = None
         self._func = func
         self.exposure_time = exposure_time
         self.precision = precision
@@ -260,6 +263,7 @@ class _ReadbackSignal(Signal):
             connected=True,
             write_access=False,
         )
+        self._run_metadata_callbacks()
 
     def get(self):
         return self.parent.sim_state['readback']
@@ -354,7 +358,10 @@ class SynAxis(Device):
             def readback_func(x):
                 return x
         if loop is None:
-            loop = asyncio.get_event_loop()
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = None
         self.sim_state = {}
         self._readback_func = readback_func
         self.delay = delay
@@ -690,7 +697,10 @@ class MockFlyer:
         self._data = deque()
         self._completion_status = None
         if loop is None:
-            loop = asyncio.get_event_loop()
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = None
         self.loop = loop
 
     def __setstate__(self, val):

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -377,7 +377,7 @@ def test_soft_derived():
 
     event.wait(1)
 
-    assert called == [('meta', True, True, False)]
+    assert called[-1] == [('meta', True, True, False)]
 
 
 def test_epics_signal_derived(ro_signal):

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -377,7 +377,7 @@ def test_soft_derived():
 
     event.wait(1)
 
-    assert called[-1] == [('meta', True, True, False)]
+    assert called[-1] == ('meta', True, True, False)
 
 
 def test_epics_signal_derived(ro_signal):


### PR DESCRIPTION
FIX: Run callbacks for Signal at init.
- For Typhos we need to receive information that the Signal was connected in order to properly render the correct widget. With `EPICS Signal` all works great because we can get the metadata callback. For Signal it is not true. This PR fixes this issue.

FIX: Don't blow if SynSignal was not created with asyncio loop.
- We are instantiating some test devices in a separated thread and this blows when we try with SynSignals. This commit avoids it to break when creating the signal outside of an asyncio loop.