### PR TITLE
dotted_name property should include the `obj`

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -304,6 +304,7 @@ class OphydObject:
         while obj.parent is not None:
             names.append(obj.attr_name)
             obj = obj.parent
+        names.append(obj.name)
         return '.'.join(names[::-1])
 
     @property


### PR DESCRIPTION
fixes #796

Here's what the fix looks like in practice:

```
In [14]: dotted_name??                                                                                                                      
Signature: dotted_name(obj)
Source:   
def dotted_name(obj):
    """Return the dotted name"""
    names = []
    while obj.parent is not None:
        names.append(obj.attr_name)
        obj = obj.parent
    names.append(obj.name)
    return '.'.join(names[::-1])
File:      ~/.ipython/user/mining.py
Type:      function

In [15]: dotted_name(m1.low_limit_switch)                                                                                                   
Out[15]: 'm1.low_limit_switch'
```