### PR TITLE
Remove run_tests.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ script:
   - echo "Checking if the areaDetector IOC is running:"
   - caproto-get -v 13SIM1:cam1:Acquire
 
-  - coverage run --concurrency=thread --parallel-mode run_tests.py -v -k "${TEST_CL}"
+  - coverage run --concurrency=thread --parallel-mode -m pytest -v -k "${TEST_CL}"
   - coverage combine
   - coverage report
   # Make sure only the primary build uploads to codecov

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-import sys
-import pytest
-
-if __name__ == '__main__':
-    sys.exit(pytest.main(sys.argv[1:]))


### PR DESCRIPTION
The ``run_tests.py`` just runs ``pytest`` and does nothing else; it
amounts to obsfuscation and should be removed.

The commit that added this file in October 2017
(0d0c9b52df1ac91b781ad83178f5634a0fdf64c1) was mine, and it had the
commit message

TST: Add run_tests.py like our other packages have.

Nowadays we tend to invoke ``pytest`` directly and use the pytest's
standard configuration file ``pytest.ini`` to apply any customizations
to its behavior. I think this approach is better because it is (1)
standard and (2) more constrained than a generic Python script. It makes
it clear in ``.travis.yml`` what program is being run.