### PR TITLE
Support a Signal write_timeout pass to put.

### DIFF
--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -72,9 +72,12 @@ class PyepicsShimPV(epics.PV):
                                     run_now=run_now,
                                     with_ctrlvars=with_ctrlvars, **kw)
 
-    def put(self, value, wait=False, timeout=30.0, use_complete=False,
+    def put(self, value, wait=False, timeout=None, use_complete=False,
             callback=None, callback_data=None):
         callback = wrap_callback(_dispatcher, 'get_put', callback)
+        # pyepics does not accept an indefinite timeout
+        if timeout is None:
+            timeout = 315569520  # ten years
         return super().put(value, wait=wait, timeout=timeout,
                            use_complete=use_complete, callback=callback,
                            callback_data=callback_data)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -596,12 +596,47 @@ class EpicsSignalBase(Signal):
     ----------
     read_pv : str
         The PV to read from
+    string : bool, optional
+        Attempt to cast the EPICS PV value to a string by default
     auto_monitor : bool, optional
         Use automonitor with epics.PV
     name : str, optional
         Name of signal.  If not given defaults to read_pv
-    string : bool, optional
-        Attempt to cast the EPICS PV value to a string by default
+    metadata : dict
+        Merged with metadata received from EPICS
+    all_pvs : set
+        Set of PVs to watch for connection and access rights callbacks.
+        Defaults to ``{read_pvs}``.
+    timeout : float or None, optional
+        The timeout for serving a read request on a connected channel. This is
+        only applied if the PV is connected within connection_timeout (below).
+
+        The default value DEFAULT_TIMEOUT means, "Fall back to class-wide
+        default." See EpicsSignalBase.set_default_timeout to configure class
+        defaults.
+
+        Explicitly passing None means, "Wait forever."
+    write_timeout : float or None, optional
+        The timeout for a reply when put completion is used. This is
+        only applied if the PV is connected within connection_timeout (below).
+
+        This is very different than the connection and read timeouts
+        above. It relates to how long an action takes to complete, such motor
+        motion or data acquisition. Any default value we choose here is likely
+        to cause problems---either by being too short and giving up too early
+        on a lengthy action or being too long and delaying the report of a
+        failure. A finite value can be injected here or, perhaps more usefully,
+        via `set` at the Device level, where a context-appropriate value can be
+        chosen.
+    connection_timeout : float or None, optional
+        Timeout for connection. This includes the time to search and establish
+        a channel.
+
+        The default value DEFAULT_CONNECTION_TIMEOUT means, "Fall back to
+        class-wide default." See EpicsSignalBase.set_default_timeout to
+        configure class defaults.
+
+        Explicitly passing None means, "Wait forever."
     '''
     # This is set to True when the first instance is made. It is used to ensure
     # that certain class-global settings can only be made before any
@@ -1092,6 +1127,36 @@ class EpicsSignalRO(EpicsSignalBase):
         Use automonitor with epics.PV
     name : str, optional
         Name of signal.  If not given defaults to read_pv
+    timeout : float or None, optional
+        The timeout for serving a read request on a connected channel. This is
+        only applied if the PV is connected within connection_timeout (below).
+
+        The default value DEFAULT_TIMEOUT means, "Fall back to class-wide
+        default." See EpicsSignalBase.set_default_timeout to configure class
+        defaults.
+
+        Explicitly passing None means, "Wait forever."
+    write_timeout : float or None, optional
+        The timeout for a reply when put completion is used. This is
+        only applied if the PV is connected within connection_timeout (below).
+
+        This is very different than the connection and read timeouts
+        above. It relates to how long an action takes to complete, such motor
+        motion or data acquisition. Any default value we choose here is likely
+        to cause problems---either by being too short and giving up too early
+        on a lengthy action or being too long and delaying the report of a
+        failure. A finite value can be injected here or, perhaps more usefully,
+        via `set` at the Device level, where a context-appropriate value can be
+        chosen.
+    connection_timeout : float or None, optional
+        Timeout for connection. This includes the time to search and establish
+        a channel.
+
+        The default value DEFAULT_CONNECTION_TIMEOUT means, "Fall back to
+        class-wide default." See EpicsSignalBase.set_default_timeout to
+        configure class defaults.
+
+        Explicitly passing None means, "Wait forever."
     '''
 
     def __init__(self, read_pv, *, string=False, auto_monitor=False, name=None,
@@ -1153,6 +1218,36 @@ class EpicsSignal(EpicsSignalBase):
         the write PV
     rtolerance : any, optional
         The relative tolerance associated with the value
+    timeout : float or None, optional
+        The timeout for serving a read request on a connected channel. This is
+        only applied if the PV is connected within connection_timeout (below).
+
+        The default value DEFAULT_TIMEOUT means, "Fall back to class-wide
+        default." See EpicsSignalBase.set_default_timeout to configure class
+        defaults.
+
+        Explicitly passing None means, "Wait forever."
+    write_timeout : float or None, optional
+        The timeout for a reply when put completion is used. This is
+        only applied if the PV is connected within connection_timeout (below).
+
+        This is very different than the connection and read timeouts
+        above. It relates to how long an action takes to complete, such motor
+        motion or data acquisition. Any default value we choose here is likely
+        to cause problems---either by being too short and giving up too early
+        on a lengthy action or being too long and delaying the report of a
+        failure. A finite value can be injected here or, perhaps more usefully,
+        via `set` at the Device level, where a context-appropriate value can be
+        chosen.
+    connection_timeout : float or None, optional
+        Timeout for connection. This includes the time to search and establish
+        a channel.
+
+        The default value DEFAULT_CONNECTION_TIMEOUT means, "Fall back to
+        class-wide default." See EpicsSignalBase.set_default_timeout to
+        configure class defaults.
+
+        Explicitly passing None means, "Wait forever."
     '''
     SUB_SETPOINT = 'setpoint'
     SUB_SETPOINT_META = 'setpoint_meta'

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -15,9 +15,10 @@ from .status import Status
 from . import get_cl
 
 
-# Sentinels used for default values
+# Sentinels used for default values; see set_default_timeout below for details.
 DEFAULT_CONNECTION_TIMEOUT = object()
 DEFAULT_TIMEOUT = object()
+DEFAULT_WRITE_TIMEOUT = object()
 
 
 class ReadTimeoutError(TimeoutError):
@@ -172,7 +173,7 @@ class Signal(OphydObject):
         return self._readback
 
     def put(self, value, *, timestamp=None, force=False, metadata=None,
-            **kwargs):
+            timeout=DEFAULT_WRITE_TIMEOUT, **kwargs):
         '''Put updates the internal readback value
 
         The value is optionally checked first, depending on the value of force.
@@ -632,6 +633,7 @@ class EpicsSignalBase(Signal):
     def __init__(self, read_pv, *, string=False, auto_monitor=False, name=None,
                  metadata=None, all_pvs=None,
                  timeout=DEFAULT_TIMEOUT,
+                 write_timeout=DEFAULT_WRITE_TIMEOUT,
                  connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
                  **kwargs):
         self._metadata_lock = threading.RLock()
@@ -648,6 +650,16 @@ class EpicsSignalBase(Signal):
         if timeout is DEFAULT_TIMEOUT:
             timeout = self.__default_timeout
         self._timeout = timeout
+        if write_timeout is DEFAULT_WRITE_TIMEOUT:
+            # This is very different than the connection and read timeouts
+            # above. It relates to how long an action takes to complete. Any
+            # default value we choose here is likely to cause problems---either
+            # by being too short and giving up too early on a lengthy action or
+            # being too long and delaying the report of a failure.
+            # The important thing it is that it is configurable at per-Signal
+            # level via the write_timeout parameter.
+            write_timeout = None  # Wait forever.
+        self._write_timeout = write_timeout
 
         if name is None:
             name = read_pv
@@ -726,6 +738,9 @@ class EpicsSignalBase(Signal):
         cls.__default_connection_timeout = connection_timeout
         cls.__default_timeout = timeout
 
+    # TODO Is there a good reason to prohibit setting these three timeout
+    # properties?
+
     @property
     def connection_timeout(self):
         return self._connection_timeout
@@ -733,6 +748,10 @@ class EpicsSignalBase(Signal):
     @property
     def timeout(self):
         return self._timeout
+
+    @property
+    def write_timeout(self):
+        return self._write_timeout
 
     def __getnewargs_ex__(self):
         args, kwargs = super().__getnewargs_ex__()
@@ -1414,7 +1433,9 @@ class EpicsSignal(EpicsSignalBase):
     def put(self, value, force=False,
             connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
             callback=None,
-            use_complete=None, **kwargs):
+            use_complete=None,
+            timeout=DEFAULT_WRITE_TIMEOUT,
+            **kwargs:
         '''Using channel access, set the write PV to `value`.
 
         Keyword arguments are passed on to callbacks
@@ -1432,12 +1453,17 @@ class EpicsSignal(EpicsSignalBase):
             Override put completion settings
         callback : callable
             Callback for when the put has completed
+        timeout : float, optional
+            Timeout before assuming that put has failed. (Only relevant if
+            put completion is used.)
         '''
         if not force:
             self.check_value(value)
 
         if connection_timeout is DEFAULT_CONNECTION_TIMEOUT:
             connection_timeout = self.connection_timeout
+        if timeout is DEFAULT_WRITE_TIMEOUT:
+            timeout = self.write_timeout
         self.wait_for_connection(timeout=connection_timeout)
         if use_complete is None:
             use_complete = self._put_complete
@@ -1450,7 +1476,7 @@ class EpicsSignal(EpicsSignalBase):
             value, use_complete, callback, kwargs
         )
         self._write_pv.put(value, use_complete=use_complete, callback=callback,
-                           **kwargs)
+                           timeout=timeout, **kwargs)
 
         old_value = self._setpoint
         self._setpoint = value

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1530,7 +1530,7 @@ class EpicsSignal(EpicsSignalBase):
             callback=None,
             use_complete=None,
             timeout=DEFAULT_WRITE_TIMEOUT,
-            **kwargs:
+            **kwargs):
         '''Using channel access, set the write PV to `value`.
 
         Keyword arguments are passed on to callbacks


### PR DESCRIPTION
This makes the timeout for a *write* configurable on a per-put and
per-Signal basis. It uses a similar pattern to what we did for read and
connection timeout in #788.

At SST, we were hitting a hard-coded timeout of 30 seconds (somewhere
in caproto or ophyd, I now don't recall...) and the motion of their mono
can sometimes take longer. With these changes, we could set
``write_timeout=180.`` in anticipation of lengthy motions.