### PR TITLE
Make 'NPY_SEQ' handler discoverable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,8 @@ install:
   - pip freeze
   - python -m pip install -e .
   - python -m pip install -r test-requirements.txt
+  # Avoid incompatibility issues between third-party dependencies and numpy.
+  - pip install --upgrade numpy
   # record installed packages after ophyd is installed
   - pip freeze
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@ setup(name='ophyd',
       python_requires='>=3.6',
       install_requires=requirements,
       packages=find_packages(),
+      entry_points={
+          'databroker.handlers': [
+              'NPY_SEQ = ophyd.sim:NumpySeqHandler',
+      ]},
       classifiers=[
           "Development Status :: 5 - Production/Stable",
           "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Ophyd has long included a simple "databroker handler" for numpy pickle files in `ophyd.sim` for testing and teaching purposes.

This PR hooks into the new discovery mechanism for handlers using entrypoints ([documentation](https://blueskyproject.io/event-model/external.html#handler-packaging)). Note that this does not introduce a databroker dependency of any kind. Its effect is to add a line to `entry_points.txt` inside the installation directory that standard Python tooling can discover. For example, a utility function in databroker can find it like this:

```py
In [2]: databroker.core.discover_handlers()                                                                                                                                                   
Out[2]: 
{'NPY_SEQ': ophyd.sim.NumpySeqHandler,  <--- here it is!
 'AD_CBF': area_detector_handlers.handlers.PilatusCBFHandler,
 'AD_EIGER': area_detector_handlers.eiger.EigerHandler,
 'AD_EIGER2': area_detector_handlers.eiger.EigerHandler,
 'AD_HDF5': area_detector_handlers.handlers.AreaDetectorHDF5Handler,
 'AD_HDF5_SWMR': area_detector_handlers.handlers.AreaDetectorHDF5SWMRHandler,
 'AD_HDF5_SWMR_TS': area_detector_handlers.handlers.AreaDetectorHDF5SWMRTimestampHandler,
 'AD_HDF5_TS': area_detector_handlers.handlers.AreaDetectorHDF5TimestampHandler,
 'AD_SPE': area_detector_handlers.handlers.AreaDetectorSPEHandler,
 'AD_TIFF': area_detector_handlers.handlers.AreaDetectorTiffHandler,
 'IMM': area_detector_handlers.handlers.IMMHandler,
 'XSP3': area_detector_handlers._xspress3.Xspress3HDF5Handler,
 'XSP3_FLY': area_detector_handlers._xspress3.BulkXSPRESS}
```

We take the same approach [in the `area-detector-handlers` `setup.py`](https://github.com/bluesky/area-detector-handlers/blob/316e126663772f0a0597844c4184d4dc0800039e/setup.py#L47-L62).

