### PR TITLE
ENH: add IndexedDevice and IndexedComponent

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -89,6 +89,7 @@ from .scaler import EpicsScaler
 from .device import (Device, Component, FormattedComponent,
                      DynamicDeviceComponent, ALL_COMPONENTS, kind_context,
                      wait_for_lazy_connection, do_not_wait_for_lazy_connection)
+from .indexed_device import IndexedDevice, IndexedComponent
 from .status import StatusBase, wait
 from .mca import EpicsMCA, EpicsDXP
 from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -304,7 +304,8 @@ class FormattedComponent(Component):
 
 
 class DynamicDeviceComponent(Component):
-    '''An Device component that dynamically creates an ophyd Device
+    '''
+    A Device component that dynamically creates an ophyd Device
 
     Parameters
     ----------
@@ -1500,6 +1501,7 @@ def create_device_from_components(name, *, docstring=None,
                                   default_read_attrs=None,
                                   default_configuration_attrs=None,
                                   base_class=Device, class_kwargs=None,
+                                  clsdict=None,
                                   **components):
     '''Factory function to make a Device from Components
 
@@ -1538,7 +1540,8 @@ def create_device_from_components(name, *, docstring=None,
     clsdict = OrderedDict(
         __doc__=docstring,
         _default_read_attrs=default_read_attrs,
-        _default_configuration_attrs=default_configuration_attrs
+        _default_configuration_attrs=default_configuration_attrs,
+        **(clsdict or {})
     )
 
     for attr, component in components.items():

--- a/ophyd/indexed_device.py
+++ b/ophyd/indexed_device.py
@@ -48,7 +48,7 @@ class _IndexedChildLevel(collections.abc.Mapping):
             # Rewrite the slice to be in terms of indices
             slc = slice(
                 match_list.index(slc.start) if slc.start else None,
-                match_list.index(slc.stop) if slc.stop else None,
+                match_list.index(slc.stop) + 1 if slc.stop else None,
                 match_list.index(slc.step) if slc.step else None,
             )
 

--- a/ophyd/indexed_device.py
+++ b/ophyd/indexed_device.py
@@ -1,0 +1,273 @@
+import collections
+import copy
+import itertools
+import string
+
+from .device import Device, Component, Kind, create_device_from_components
+from .utils import underscores_to_camel_case
+
+
+class _IndexedChildLevel(collections.abc.Mapping):
+    'A mapping helper to allow access of IndexedDevice[idx][idx2...]'
+    def __init__(self, device, mapping_dict):
+        self._device = device
+        self._d = mapping_dict
+
+    def __getitem__(self, item):
+        value = self._d[item]
+        if isinstance(value, str):
+            return getattr(self._device, value)
+        return _IndexedChildLevel(device=self._device, mapping_dict=value)
+
+    def __iter__(self):
+        yield from self._d
+
+    def __len__(self):
+        return len(self._d)
+
+    def __repr__(self):
+        options = set(str(s) for s in self)
+        return f'<{self.__class__.__name__} len={len(self)} options={options}>'
+
+
+class IndexedDevice(Device, collections.abc.Mapping):
+    '''
+    A Device subclass which allows for indexing of components (e.g., channels)
+    by using the getitem syntax (i.e., ``dev[idx]``)
+    '''
+
+    def __init__(self, prefix='', *, name, kind=None, read_attrs=None,
+                 configuration_attrs=None, parent=None, **kwargs):
+        self._root_index = _IndexedChildLevel(
+            self, mapping_dict=self._mapping_dict)
+        super().__init__(prefix=prefix, name=name, kind=kind,
+                         read_attrs=read_attrs,
+                         configuration_attrs=configuration_attrs,
+                         parent=parent, **kwargs)
+
+    def _instantiate_component(self, attr):
+        cpt = super()._instantiate_component(attr)
+        # Patch in the index on the component for reverse lookups:
+        cpt.index = self._attr_to_index[attr]
+        return cpt
+
+    def __getitem__(self, index):
+        return self._root_index[index]
+
+    def __iter__(self):
+        yield from self._root_index
+
+    def __len__(self):
+        return len(self._root_index)
+
+
+def _normalize_ranges(ranges):
+    'Normalize a range/str to be used with _apply_range_to_value'
+    if isinstance(ranges, (range, str)):
+        return [list(ranges)]
+
+    return [list(ri) for ri in ranges]
+
+
+def _apply_range_to_value(ranges, value):
+    'Get all values from a format string and the given range(s)'
+    return [
+        value.format(*item)
+        for item in itertools.product(*ranges)
+    ]
+
+
+def _mapping_dict_from_ranges(ranges, attrs, *, tuple_access=True):
+    'Create a dictionary to be used by _IndexedChildLevel'
+    mapping_dict = {}
+
+    for index, attr in zip(itertools.product(*ranges), attrs):
+        d = mapping_dict
+        for index_part in index[:-1]:
+            if index_part not in d:
+                d[index_part] = {}
+            d = d[index_part]
+
+        d[index[-1]] = attr
+
+        if tuple_access:
+            mapping_dict[index] = attr
+
+    return mapping_dict
+
+
+def _verify_with_formatter(formatter, format_str, num_args):
+    'Verify a format string with the given formatter'
+    parsed = list(formatter.parse(format_str))
+    unnamed_fields = [
+        field_name
+        for literal_text, field_name, format_spec, conversion in parsed
+        if field_name == ''
+    ]
+    if len(unnamed_fields) != num_args:
+        raise ValueError(
+            f'Expected a format string that would accept {num_args} args, but '
+            f'got one that takes {len(unnamed_fields)} args in string: '
+            f'{format_str!r}'
+        )
+
+    named_fields = [
+        field_name
+        for literal_text, field_name, format_spec, conversion in parsed
+        if field_name
+    ]
+    if named_fields:
+        named_fields = ', '.join(named_fields)
+        raise ValueError(
+            f'Expected a format string that would accept {num_args} args, but '
+            f'got one that takes named fields {named_fields}: {format_str!r}'
+        )
+
+
+class IndexedComponent(Component):
+    '''
+    A Device component that dynamically creates a sub Device
+
+    Parameters
+    ----------
+    attr : str
+        The attribute format to use
+    suffix:
+        The suffix format to use
+    ranges: str, range, or list of iterables
+        A single range of numbers to expand attr and suffix. For example::
+
+            ranges=range(10)
+
+        Or, a list of ranges or iterables, from which individual indexed
+        components will be created by taking the cartesian product of all
+        items, for example::
+
+            ranges=[range(2), 'AB']
+
+        will be expanded to::
+
+            [(0, 'A'), (0, 'B'), (1, 'A'), (1, 'B')]
+
+        The definition of all attributes to be created is based on the above.
+        Assuming component_class is Component, the following pseudo-code
+        shows what would happen on the Device::
+
+            for attr, suffix in expand_attr_and_suffix(ranges):
+                attr = Component(SignalClass, _suffix, **keyword_arg_dict)
+
+    allow_tuple_access : bool, optional
+        Normally, accessing components with __getitem__ would be done on
+        each level individually::
+
+            dev[0]['A']
+
+        Enabling this flag would allow for accessing the same component as
+        follows::
+
+            dev[(0, 'A')]
+
+    clsname : str, optional
+        The name of the class to be generated
+        This defaults to {parent_name}{this_attribute_name.capitalize()}
+    doc : str, optional
+        The docstring to put on the dynamically generated class
+    default_read_attrs : list, optional
+        A class attribute to put on the dynamically generated class
+    default_configuration_attrs : list, optional
+        A class attribute to put on the dynamically generated class
+    component_class : class, optional
+        Defaults to Component
+    base_class : class, optional
+        Defaults to Device
+    '''
+
+    # Allow for subclasses to override the formatting verifier:
+    _formatter = string.Formatter()
+
+    def __init__(self, cls, *, attr, suffix, ranges, clsname=None,
+                 doc=None, kind=Kind.normal, default_read_attrs=None,
+                 default_configuration_attrs=None, base_class=None,
+                 component_class=Component, allow_tuple_access=False,
+                 **kwargs):
+
+        if isinstance(default_read_attrs, collections.abc.Iterable):
+            default_read_attrs = tuple(default_read_attrs)
+
+        if isinstance(default_configuration_attrs, collections.abc.Iterable):
+            default_configuration_attrs = tuple(default_configuration_attrs)
+
+        ranges = _normalize_ranges(ranges)
+
+        _verify_with_formatter(self._formatter, suffix, num_args=len(ranges))
+        suffixes = _apply_range_to_value(ranges, suffix)
+
+        _verify_with_formatter(self._formatter, attr, num_args=len(ranges))
+        attrs = _apply_range_to_value(ranges, attr)
+
+        self.attr_to_suffix = dict(zip(attrs, suffixes))
+
+        self.mapping_dict = _mapping_dict_from_ranges(
+            ranges, attrs, tuple_access=allow_tuple_access)
+
+        self.attr_to_index = dict(zip(attrs, itertools.product(*ranges)))
+
+        self.allow_tuple_access = allow_tuple_access
+        self.attr = attr
+        self.base_class = base_class or IndexedDevice
+        self.clsname = clsname
+        self.component_class = component_class
+        self.default_configuration_attrs = default_configuration_attrs
+        self.default_read_attrs = default_read_attrs
+        self.kwargs = kwargs
+        self.ranges = ranges
+        self.suffix = suffix
+
+        self.components = {
+            attr: component_class(cls, suffix_, **kwargs)
+            for attr, suffix_ in self.attr_to_suffix.items()
+        }
+
+        # NOTE: cls is None here, as it gets created in __set_name__, below
+        super().__init__(cls=None, suffix='', lazy=False, kind=kind)
+
+        # Allow easy access to all generated components directly in the
+        # IndexedComponent instance
+        for attr, cpt in self.components.items():
+            if not hasattr(self, attr):
+                setattr(self, attr, cpt)
+
+    def __getnewargs_ex__(self):
+        'Get arguments needed to copy this class (used for pickle/copy)'
+        kwargs = dict(
+            attr=self.attr, suffix=self.suffix, ranges=self.ranges,
+            allow_tuple_access=self.allow_tuple_access, clsname=self.clsname,
+            doc=self.doc, kind=self.kind,
+            default_read_attrs=self.default_read_attrs,
+            default_configuration_attrs=self.default_configuration_attrs,
+            component_class=self.component_class, base_class=self.base_class
+        )
+        return ((self.cls, ), kwargs)
+
+    def __set_name__(self, owner, attr_name):
+        if self.clsname is None:
+            self.clsname = underscores_to_camel_case(attr_name)
+        super().__set_name__(owner, attr_name)
+        clsdict = dict(
+            _mapping_dict=copy.deepcopy(self.mapping_dict),
+            _attr_to_index=dict(self.attr_to_index),
+        )
+        self.cls = create_device_from_components(
+            self.clsname, default_read_attrs=self.default_read_attrs,
+            default_configuration_attrs=self.default_configuration_attrs,
+            base_class=self.base_class, clsdict=clsdict,
+            **self.components)
+
+    def __repr__(self):
+        return '\n'.join(f'{attr} = {cpt!r}'
+                         for attr, cpt in self.components.items()
+                         )
+
+    def subscriptions(self, event_type):
+        raise NotImplementedError('IndexedComponent does not yet '
+                                  'support decorator subscriptions')

--- a/ophyd/indexed_device.py
+++ b/ophyd/indexed_device.py
@@ -156,7 +156,28 @@ def _apply_range_to_value(ranges, value):
 
 
 def _mapping_dict_from_ranges(ranges, attrs):
-    'Create a dictionary to be used by _IndexedChildLevel'
+    '''
+    Create a dictionary to be used by _IndexedChildLevel
+
+    Parameters
+    ----------
+    ranges : str, range, or list of iterables
+        See the ``ranges`` kwarg in :class:`IndexedComponent`.
+    attrs : str, range, or list of iterables
+        The expanded list of attribute names
+
+    Returns
+    -------
+    mapping_dict : dict
+
+        A single-level dictionary might look like: {index: 'attr'}
+        A two-level dictionary might look like::
+
+            {index0: {index1: 'attr_01'},
+             index1: {index1: 'attr_11'},
+            }
+
+    '''
     mapping_dict = {}
 
     for index, attr in zip(itertools.product(*ranges), attrs):
@@ -207,9 +228,9 @@ class IndexedComponent(Component):
     ----------
     attr : str
         The attribute format to use
-    suffix:
+    suffix :
         The suffix format to use
-    ranges: str, range, or list of iterables
+    ranges : str, range, or list of iterables
         A single range of numbers to expand attr and suffix. For example::
 
             ranges=range(10)
@@ -270,11 +291,10 @@ class IndexedComponent(Component):
         attrs = _apply_range_to_value(ranges, attr)
 
         self.attr_to_suffix = dict(zip(attrs, suffixes))
-
-        self.mapping_dict = _mapping_dict_from_ranges(
-            ranges, attrs)
-
+        self.mapping_dict = _mapping_dict_from_ranges(ranges, attrs)
         self.attr_to_index = dict(zip(attrs, itertools.product(*ranges)))
+        self.slice_types = tuple(set(type(value) for value in range_)
+                                 for range_ in ranges)
 
         self.attr = attr
         self.base_class = base_class or IndexedDevice
@@ -320,6 +340,7 @@ class IndexedComponent(Component):
             _mapping_dict=copy.deepcopy(self.mapping_dict),
             _attr_to_index=dict(self.attr_to_index),
             _leaf_depth=len(self.ranges),
+            _slice_types=self.slice_types,
         )
         self.cls = create_device_from_components(
             self.clsname, default_read_attrs=self.default_read_attrs,

--- a/ophyd/indexed_device.py
+++ b/ophyd/indexed_device.py
@@ -9,8 +9,7 @@ from .utils import underscores_to_camel_case
 
 def _summarize_slice_type(slc):
     'Summarize + verify that only 1 type is used in a slice()'
-    slice_type = set((type(slc.start), type(slc.stop),
-                      type(slc.step)))
+    slice_type = set((type(slc.start), type(slc.stop)))
     if type(None) in slice_type:
         slice_type.remove(type(None))
 
@@ -18,6 +17,9 @@ def _summarize_slice_type(slc):
         raise ValueError(
             f'Unexpected types in slice: {slice_type}'
         )
+
+    if slc.step is not None and not isinstance(slc.step, int):
+        raise ValueError(f'Slice step must be an integer: {slc.step}')
 
     if len(slice_type):
         slice_type, = list(slice_type)
@@ -49,7 +51,7 @@ class _IndexedChildLevel(collections.abc.Mapping):
             slc = slice(
                 match_list.index(slc.start) if slc.start else None,
                 match_list.index(slc.stop) + 1 if slc.stop else None,
-                match_list.index(slc.step) if slc.step else None,
+                slc.step
             )
 
         return {key: self._d[key] for key in match_list[slc]}

--- a/ophyd/tests/test_indexed_device.py
+++ b/ophyd/tests/test_indexed_device.py
@@ -91,9 +91,8 @@ def test_2d_slice():
     assert len(dev.cpt1[:, 'A':]) == 40
     assert len(dev.cpt1[:, :'C']) == 20
 
-    # TODO - don't want a list here
-    assert len(dev.cpt1[0, 'A']) == 1
-    assert len(dev.cpt1[(0, 'A')]) == 1
+    assert dev.cpt1[0, 'A'] is dev.cpt1.channel_00A
+    assert dev.cpt1[(0, 'A')] is dev.cpt1.channel_00A
 
     with pytest.raises(ValueError):
         # too many slices
@@ -114,6 +113,7 @@ def test_3d_slice():
     assert len(dev.cpt1[:]) == 10 * 4 * 4
     assert len(dev.cpt1[:, 'A', '0']) == 10 * 1 * 1
     assert len(dev.cpt1[:, 'A':'C', '0']) == 10 * 2 * 1
+    assert dev.cpt1[0, 'A', '0'] is dev.cpt1.channel_00A0
 
 
 def test_string_range():

--- a/ophyd/tests/test_indexed_device.py
+++ b/ophyd/tests/test_indexed_device.py
@@ -87,9 +87,9 @@ def test_2d_slice():
     dev = MyDev(prefix='PREFIX:', name='dev')
     assert len(dev.cpt1[:]) == 10 * 4
     assert len(dev.cpt1[:, 'A']) == 10
-    assert len(dev.cpt1[:, 'A':'C']) == 20
+    assert len(dev.cpt1[:, 'A':'C']) == 30
     assert len(dev.cpt1[:, 'A':]) == 40
-    assert len(dev.cpt1[:, :'C']) == 20
+    assert len(dev.cpt1[:, :'C']) == 30
 
     assert dev.cpt1[0, 'A'] is dev.cpt1.channel_00A
     assert dev.cpt1[(0, 'A')] is dev.cpt1.channel_00A
@@ -112,7 +112,7 @@ def test_3d_slice():
     dev = MyDev(prefix='PREFIX:', name='dev')
     assert len(dev.cpt1[:]) == 10 * 4 * 4
     assert len(dev.cpt1[:, 'A', '0']) == 10 * 1 * 1
-    assert len(dev.cpt1[:, 'A':'C', '0']) == 10 * 2 * 1
+    assert len(dev.cpt1[:, 'A':'C', '0']) == 10 * 3 * 1
     assert dev.cpt1[0, 'A', '0'] is dev.cpt1.channel_00A0
 
 

--- a/ophyd/tests/test_indexed_device.py
+++ b/ophyd/tests/test_indexed_device.py
@@ -1,9 +1,7 @@
 import logging
 import pytest
 
-from ophyd import (Device, IndexedDevice, IndexedComponent, EpicsSignal,
-                   Component, FormattedComponent)
-from ophyd import Signal
+from ophyd import (Device, IndexedComponent, Component, FormattedComponent)
 
 from .test_device import FakeSignal
 

--- a/ophyd/tests/test_indexed_device.py
+++ b/ophyd/tests/test_indexed_device.py
@@ -1,0 +1,97 @@
+import logging
+from unittest.mock import Mock
+
+from ophyd import (Device, IndexedDevice, IndexedComponent, EpicsSignal,
+                   Component, FormattedComponent)
+from ophyd import Signal
+
+from .test_device import FakeSignal
+
+logger = logging.getLogger(__name__)
+
+
+def test_single_range():
+    class MyDev(Device):
+        cpt1 = IndexedComponent(
+            FakeSignal,
+            attr='channel_{:02d}',
+            suffix='{:02d}:Test',
+            ranges=range(10),
+            component_class=Component,
+        )
+
+    assert hasattr(MyDev.cpt1, 'channel_00')
+    assert hasattr(MyDev.cpt1, 'channel_09')
+    assert type(MyDev.cpt1.channel_00) is Component
+    assert MyDev.cpt1.channel_00.cls is FakeSignal
+    assert MyDev.cpt1.channel_00.suffix == '00:Test'
+    dev = MyDev(prefix='PREFIX:', name='dev')
+
+    assert dev.cpt1.channel_00.read_pv == 'PREFIX:00:Test'
+    assert dev.cpt1[0] is dev.cpt1.channel_00
+    assert len(dev.cpt1) == 10
+    assert list(dev.cpt1) == list(range(10))
+
+
+def test_formatted_component():
+    class MyDev(Device):
+        cpt1 = IndexedComponent(
+            FakeSignal,
+            attr='channel_{:02d}',
+            suffix='{{prefix}}{:02d}:Test',
+            ranges=range(10),
+            component_class=FormattedComponent,
+        )
+
+    dev = MyDev(prefix='PREFIX:', name='dev')
+    assert dev.cpt1.channel_00.read_pv == 'PREFIX:00:Test'
+
+
+def test_double_range():
+    class MyDev(Device):
+        cpt1 = IndexedComponent(
+            FakeSignal,
+            attr='channel_{:02d}{}',
+            suffix='{:02d}{}:Test',
+            ranges=[range(10), 'ABCD'],
+            component_class=Component,
+        )
+
+    assert hasattr(MyDev.cpt1, 'channel_00A')
+    assert hasattr(MyDev.cpt1, 'channel_01A')
+    assert hasattr(MyDev.cpt1, 'channel_09A')
+    assert hasattr(MyDev.cpt1, 'channel_09B')
+    assert type(MyDev.cpt1.channel_00A) is Component
+    assert MyDev.cpt1.channel_00A.cls is FakeSignal
+    assert MyDev.cpt1.channel_00B.suffix == '00B:Test'
+    dev = MyDev(prefix='PREFIX:', name='dev')
+
+    assert dev.cpt1.channel_00B.read_pv == 'PREFIX:00B:Test'
+    assert dev.cpt1[0]['A'] is dev.cpt1.channel_00A
+    assert len(dev.cpt1) == 10
+    assert len(dev.cpt1[0]) == 4
+    assert list(dev.cpt1) == list(range(10))
+    assert list(dev.cpt1[0]) == list('ABCD')
+
+
+def test_string_range():
+    class MyDev(Device):
+        cpt1 = IndexedComponent(FakeSignal,
+                                attr='channel{}',
+                                suffix='{}:Test',
+                                ranges='ABCD',
+                                )
+
+    assert hasattr(MyDev.cpt1, 'channelA')
+    assert hasattr(MyDev.cpt1, 'channelB')
+    assert hasattr(MyDev.cpt1, 'channelC')
+    assert hasattr(MyDev.cpt1, 'channelD')
+    assert type(MyDev.cpt1.channelA) is Component
+    assert MyDev.cpt1.channelA.cls is FakeSignal
+    assert MyDev.cpt1.channelB.suffix == 'B:Test'
+    dev = MyDev(prefix='PREFIX:', name='dev')
+
+    assert dev.cpt1.channelB.read_pv == 'PREFIX:B:Test'
+    assert dev.cpt1['A'] is dev.cpt1.channelA
+    assert len(dev.cpt1) == 4
+    assert list(dev.cpt1) == list('ABCD')

--- a/ophyd/tests/test_indexed_device.py
+++ b/ophyd/tests/test_indexed_device.py
@@ -95,6 +95,10 @@ def test_2d_slice():
     assert dev.cpt1[(0, 'A')] is dev.cpt1.channel_00A
 
     with pytest.raises(ValueError):
+        # slice step must be integer
+        dev.cpt1[0:5:'A']
+
+    with pytest.raises(ValueError):
         # too many slices
         dev.cpt1[:, :, :]
 

--- a/ophyd/tests/test_indexed_device.py
+++ b/ophyd/tests/test_indexed_device.py
@@ -30,7 +30,8 @@ def test_single_range():
     assert len(dev.cpt1) == 10
     assert list(dev.cpt1) == list(range(10))
     assert dev.cpt1[:2] == [dev.cpt1.channel_00,
-                            dev.cpt1.channel_01]
+                            dev.cpt1.channel_01,
+                            dev.cpt1.channel_02]
 
 
 def test_formatted_component():
@@ -90,6 +91,7 @@ def test_2d_slice():
     assert len(dev.cpt1[:, 'A':'C']) == 30
     assert len(dev.cpt1[:, 'A':]) == 40
     assert len(dev.cpt1[:, :'C']) == 30
+    assert len(dev.cpt1[0:1, 'A']) == 2  # (0, 'A'), (1, 'A')
 
     assert dev.cpt1[0, 'A'] is dev.cpt1.channel_00A
     assert dev.cpt1[(0, 'A')] is dev.cpt1.channel_00A
@@ -101,6 +103,14 @@ def test_2d_slice():
     with pytest.raises(ValueError):
         # too many slices
         dev.cpt1[:, :, :]
+
+    with pytest.raises(ValueError):
+        # Sorry, weird integer indexing
+        dev.cpt1[-1:, :]
+
+    with pytest.raises(ValueError):
+        # Sorry, weird integer indexing
+        dev.cpt1[1:12, :]
 
 
 def test_3d_slice():


### PR DESCRIPTION
In the same vein as `DynamicDeviceComponent`, but hopefully much easier to use. Here's a simple example:

```python
from ophyd import Device, IndexedDevice, IndexedComponent, EpicsSignal


class MyDev(Device):
    cpt1 = IndexedComponent(EpicsSignal,
                            attr='channel_{:02d}',
                            suffix='{:02d}:Test',
                            ranges=range(10)
                            )
    cpt2 = IndexedComponent(EpicsSignal,
                            attr='channel_{:02d}{}',
                            suffix='{:02d}:{}:Test',
                            ranges=[range(10), 'ABCD']
                            )
    cpt3 = IndexedComponent(EpicsSignal,
                            attr='channel_{}',
                            suffix='{}:Test',
                            ranges='ABCD',
                            )
```

Such a device would then allow for access of its components by their indices through `__getitem__` syntax:

```
dev = MyDev('PREFIX:', name='dev')

print(dev.cpt1[0])
print(dev.cpt2[9]['A'])
print(dev.cpt3['A'])
```

Would output:
```
EpicsSignal(read_pv='PREFIX:00:Test', name='dev_cpt1_channel_00', parent='dev_cpt1', timestamp=1583013244.530336, auto_monitor=False, string=False, write_pv='PREFIX:00:Test', limits=False, put_complete=False)
EpicsSignal(read_pv='PREFIX:09:A:Test', name='dev_cpt2_channel_09A', parent='dev_cpt2', timestamp=1583013244.546321, auto_monitor=False, string=False, write_pv='PREFIX:09:A:Test', limits=False, put_complete=False)
EpicsSignal(read_pv='PREFIX:A:Test', name='dev_cpt3_channel_A', parent='dev_cpt3', timestamp=1583013244.5474591, auto_monitor=False, string=False, write_pv='PREFIX:A:Test', limits=False, put_complete=False)
```