### PR TITLE
MNT: remove annoying teardown messages

### DIFF
--- a/ophyd/_caproto_shim.py
+++ b/ophyd/_caproto_shim.py
@@ -149,9 +149,7 @@ def setup(logger):
 
         pyepics_compat.get_pv = pyepics_compat._get_pv
 
-        logger.debug('Performing ophyd cleanup')
         if _dispatcher.is_alive():
-            logger.debug('Joining the dispatcher thread')
             _dispatcher.stop()
 
         _dispatcher = None

--- a/ophyd/_dispatch.py
+++ b/ophyd/_dispatch.py
@@ -49,15 +49,12 @@ class _CallbackThread(threading.Thread):
                     )
 
         self.detach_context()
-        self.logger.debug('Callback thread %s exiting', self.name)
 
     def attach_context(self):
         self.logger.debug('Callback thread %s attaching to context %s',
                           self.name, self.context)
 
     def detach_context(self):
-        self.logger.debug('Callback thread %s detaching from context %s',
-                          self.name, self.context)
         self.context = None
 
 

--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -155,9 +155,7 @@ def setup(logger):
             return
         epics.pv.default_pv_class = epics.PV
 
-        logger.debug('Performing ophyd cleanup')
         if _dispatcher.is_alive():
-            logger.debug('Joining the dispatcher thread')
             _dispatcher.stop()
 
         _dispatcher = None


### PR DESCRIPTION
A torn-down logger can cause these messages to blow up as tracebacks at the end of a pytest session