### PR TITLE
Note that walk_ instance methods are experimental.

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -867,6 +867,9 @@ class Device(BlueskyInterface, OphydObject):
     def walk_signals(self, *, include_lazy=False):
         '''Walk all signals in the Device hierarchy
 
+        EXPERIMENTAL: This method is experimental, and there are tentative
+        plans to change its API in a way that may not be backward-compatible.
+
         Parameters
         ----------
         include_lazy : bool, optional
@@ -924,6 +927,9 @@ class Device(BlueskyInterface, OphydObject):
 
     def walk_subdevices(self, *, include_lazy=False):
         '''Walk all sub-Devices in the hierarchy
+
+        EXPERIMENTAL: This method is experimental, and there are tentative
+        plans to change its API in a way that may not be backward-compatible.
 
         Yields
         ------


### PR DESCRIPTION
Touches docstrings only.

Closes #766.
Related to #752 where we discuss possible changes to these methods.