### PR TITLE
API: make Signal.value sometimes defer to self.get()

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -369,7 +369,10 @@ class Signal(OphydObject):
             The keys must be strings and the values must be dict-like
             with the ``event_model.event_descriptor.data_key`` schema.
         """
-        val = self.value
+        if self._readback is DEFAULT_EPICSSIGNAL_VALUE:
+            val = self.get()
+        else:
+            val = self._readback
         return {self.name: {'source': 'SIM:{}'.format(self.name),
                             'dtype': data_type(val),
                             'shape': data_shape(val)}}
@@ -1125,7 +1128,10 @@ class EpicsSignalBase(Signal):
         dict
             Dictionary of name and formatted description string
         """
-        val = self.value
+        if self._readback is DEFAULT_EPICSSIGNAL_VALUE:
+            val = self.get()
+        else:
+            val = self._readback
         lower_ctrl_limit, upper_ctrl_limit = self.limits
         desc = dict(
             source='PV:{}'.format(self._read_pvname),

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -750,8 +750,8 @@ class EpicsSignalBase(Signal):
             connected=False,
         )
 
-        kwargs.pop('value', None)
-        super().__init__(name=name, metadata=metadata, value=DEFAULT_EPICSSIGNAL_VALUE, **kwargs)
+        kwargs.setdefault('value', DEFAULT_EPICSSIGNAL_VALUE)
+        super().__init__(name=name, metadata=metadata, **kwargs)
 
         validate_pv_name(read_pv)
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -255,22 +255,22 @@ class Signal(OphydObject):
                 set_and_wait(self, value, timeout=timeout, atol=self.tolerance,
                              rtol=self.rtolerance)
             except TimeoutError:
+                success = False
                 self.log.warning(
                     'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
                     value, timeout, self.tolerance, self.rtolerance
                 )
-                success = False
             except Exception as ex:
+                success = False
                 self.log.exception(
                     'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
                     value, timeout, self.tolerance, self.rtolerance
                 )
-                success = False
             else:
+                success = True
                 self.log.info(
                     'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
                     value, timeout, self.tolerance, self.rtolerance, self._readback)
-                success = True
 
                 if settle_time is not None:
                     self.log.info('settling for %d seconds', settle_time)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -269,8 +269,9 @@ class Signal(OphydObject):
             else:
                 self.log.info(
                     'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
-                    value, timeout, self.tolerance, self.rtolerance, self.value)
+                    value, timeout, self.tolerance, self.rtolerance, self._readback)
                 success = True
+
                 if settle_time is not None:
                     self.log.info('settling for %d seconds', settle_time)
                     time.sleep(settle_time)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1789,7 +1789,7 @@ class AttributeSignal(Signal):
                        value=value, timestamp=time.time())
 
     def describe(self):
-        value = self.value
+        value = self.get()
         desc = {'source': 'PY:{}.{}'.format(self.parent.name, self.full_attr),
                 'dtype': data_type(value),
                 'shape': data_shape(value),

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -574,7 +574,7 @@ class DerivedSignal(Signal):
 
         self._run_metadata_callbacks()
 
-    def _derived_value_callback(self, value=None, **kwargs):
+    def _derived_value_callback(self, value, **kwargs):
         'Main signal value updated - update the DerivedSignal'
         # if some how we get cycled with the default value sentinel, just bail
         if value is DEFAULT_EPICSSIGNAL_VALUE:

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -30,7 +30,6 @@ from ophyd.areadetector.util import stub_templates
 from ophyd.device import (Component as Cpt, )
 from ophyd.signal import Signal
 import uuid
-import epics
 
 logger = logging.getLogger(__name__)
 ad_path = '/epics/support/areaDetector/1-9-1/ADApp/Db/'

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -158,7 +158,7 @@ def test_epicssignal_readonly(cleanup, signal_test_ioc):
     cleanup.add(signal)
     signal.wait_for_connection()
     print('EpicsSignalRO.metadata=', signal.metadata)
-    signal.value
+    signal.get()
 
     assert not signal.write_access
     assert signal.read_access
@@ -214,13 +214,13 @@ def test_epicssignal_readwrite(signal_test_ioc, pair_signal):
 
     assert signal.setpoint_pvname == signal_test_ioc.pvs['pair_set']
     assert signal.pvname == signal_test_ioc.pvs['pair_rbv']
-    signal.value
+    signal.get()
 
     time.sleep(0.2)
 
     value = 10
     signal.value = value
-    signal.setpoint = value
+    signal.put(value)
     assert signal.setpoint == value
     signal.setpoint_ts
 
@@ -246,7 +246,7 @@ def test_epicssignal_waveform(cleanup, signal_test_ioc):
     signal.wait_for_connection()
 
     sub = signal.subscribe(update_cb, event_type=signal.SUB_VALUE)
-    assert len(signal.value) > 1
+    assert len(signal.get()) > 1
     signal.unsubscribe(sub)
 
 
@@ -393,7 +393,7 @@ def test_epics_signal_derived(ro_signal):
     assert not derived.write_access
 
     assert derived.timestamp == ro_signal.timestamp
-    assert derived.get() == ro_signal.value
+    assert derived.get() == ro_signal.get()
 
 
 @pytest.mark.motorsim

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -251,6 +251,9 @@ def test_epicssignal_waveform(cleanup, signal_test_ioc):
 
     sub = signal.subscribe(update_cb, event_type=signal.SUB_VALUE)
     assert len(signal.get()) > 1
+    # force the current thread to allow other threads to run to service
+    # subscription
+    time.sleep(0)
     assert called
     signal.unsubscribe(sub)
 

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -238,8 +238,12 @@ def test_epicssignal_readwrite(signal_test_ioc, pair_signal):
 
 
 def test_epicssignal_waveform(cleanup, signal_test_ioc):
+    called = False
+
     def update_cb(value=None, **kwargs):
+        nonlocal called
         assert len(value) > 1
+        called = True
 
     signal = EpicsSignal(signal_test_ioc.pvs['waveform'], string=True)
     cleanup.add(signal)
@@ -247,6 +251,7 @@ def test_epicssignal_waveform(cleanup, signal_test_ioc):
 
     sub = signal.subscribe(update_cb, event_type=signal.SUB_VALUE)
     assert len(signal.get()) > 1
+    assert called
     signal.unsubscribe(sub)
 
 

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -175,11 +175,11 @@ def test_clear_fake_device():
     my_fake = FakeSample('KITCHEN', name='kitchen')
     clear_fake_device(my_fake, default_value=49,
                       default_string_value='string')
-    assert my_fake.butter.value == 49
-    assert my_fake.flour.value == 49
-    assert my_fake.sink.value == 49
-    assert my_fake.egg.yolk.value == 'string'
-    assert my_fake.egg.whites.value == 49
+    assert my_fake.butter.get() == 49
+    assert my_fake.flour.get() == 49
+    assert my_fake.sink.get() == 49
+    assert my_fake.egg.yolk.get() == 'string'
+    assert my_fake.egg.whites.get() == 49
 
 
 def test_instantiate_fake_device():

--- a/ophyd/tests/test_timestamps.py
+++ b/ophyd/tests/test_timestamps.py
@@ -16,7 +16,7 @@ def test_read_pv_timestamp_no_monitor(motor):
 
     rbv_value0 = rbv.get()
     ts0 = rbv.timestamp
-    sp.put(sp.value + 0.1, wait=True)
+    sp.put(sp.get() + 0.1, wait=True)
     time.sleep(0.1)
 
     rbv_value1 = rbv.get()

--- a/ophyd/tests/test_timestamps.py
+++ b/ophyd/tests/test_timestamps.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.motorsim
 def test_read_pv_timestamp_no_monitor(motor):
+    motor.set(0, wait=True)
     sp = EpicsSignal(motor.user_setpoint.pvname, name='test')
     rbv = EpicsSignalRO(motor.user_readback.pvname, name='test')
 
@@ -29,6 +30,7 @@ def test_read_pv_timestamp_no_monitor(motor):
 
 @pytest.mark.motorsim
 def test_write_pv_timestamp_no_monitor(motor):
+    motor.set(0, wait=True)
     sp = EpicsSignal(motor.user_setpoint.pvname, name='test')
 
     sp_value0 = sp.get()
@@ -46,6 +48,8 @@ def test_write_pv_timestamp_no_monitor(motor):
 
 @pytest.mark.motorsim
 def test_read_pv_timestamp_monitor(motor):
+    motor.set(0, wait=True)
+
     sp = EpicsSignal(motor.user_setpoint.pvname, auto_monitor=True,
                      name='test')
     rbv = EpicsSignalRO(motor.user_readback.pvname, auto_monitor=True,
@@ -66,6 +70,7 @@ def test_read_pv_timestamp_monitor(motor):
 
 @pytest.mark.motorsim
 def test_write_pv_timestamp_monitor(motor):
+    motor.set(0, wait=True)
     sp = EpicsSignal(motor.user_setpoint.pvname, auto_monitor=True,
                      name='test')
 

--- a/ophyd/tests/test_timestamps.py
+++ b/ophyd/tests/test_timestamps.py
@@ -15,17 +15,17 @@ def test_read_pv_timestamp_no_monitor(motor):
     sp = EpicsSignal(motor.user_setpoint.pvname, name='test')
     rbv = EpicsSignalRO(motor.user_readback.pvname, name='test')
 
+    assert rbv.get() == sp.get()
     rbv_value0 = rbv.get()
     ts0 = rbv.timestamp
     sp.put(sp.get() + 0.1)
-    time.sleep(0.1)
-
+    time.sleep(.5)
     rbv_value1 = rbv.get()
     ts1 = rbv.timestamp
     assert ts1 > ts0
     assert_almost_equal(rbv_value0 + 0.1, rbv_value1)
 
-    sp.put(sp.value - 0.1, wait=True)
+    sp.put(sp.get() - 0.1)
 
 
 @pytest.mark.motorsim
@@ -43,7 +43,7 @@ def test_write_pv_timestamp_no_monitor(motor):
     assert ts1 > ts0
     assert_almost_equal(sp_value0 + 0.1, sp_value1)
 
-    sp.put(sp.value - 0.1, wait=True)
+    sp.put(sp.get() - 0.1, wait=True)
 
 
 @pytest.mark.motorsim
@@ -55,12 +55,12 @@ def test_read_pv_timestamp_monitor(motor):
     rbv = EpicsSignalRO(motor.user_readback.pvname, auto_monitor=True,
                         name='test')
 
-    rbv_value0 = rbv.get()
+    rbv_value0 = rbv.value
     ts0 = rbv.timestamp
     sp.put(rbv_value0 + 0.1, wait=True)
     time.sleep(0.2)
 
-    rbv_value1 = rbv.get()
+    rbv_value1 = rbv.value
     ts1 = rbv.timestamp
     assert ts1 > ts0
     assert_almost_equal(rbv_value0 + 0.1, rbv_value1)
@@ -74,12 +74,12 @@ def test_write_pv_timestamp_monitor(motor):
     sp = EpicsSignal(motor.user_setpoint.pvname, auto_monitor=True,
                      name='test')
 
-    sp_value0 = sp.get()
+    sp_value0 = sp.value
     ts0 = sp.timestamp
     sp.put(sp_value0 + 0.1, wait=True)
     time.sleep(0.1)
 
-    sp_value1 = sp.get()
+    sp_value1 = sp.value
     ts1 = sp.timestamp
     assert ts1 > ts0
     assert_almost_equal(sp_value0 + 0.1, sp_value1)

--- a/ophyd/tests/test_timestamps.py
+++ b/ophyd/tests/test_timestamps.py
@@ -16,7 +16,7 @@ def test_read_pv_timestamp_no_monitor(motor):
 
     rbv_value0 = rbv.get()
     ts0 = rbv.timestamp
-    sp.put(sp.get() + 0.1, wait=True)
+    sp.put(sp.get() + 0.1)
     time.sleep(0.1)
 
     rbv_value1 = rbv.get()


### PR DESCRIPTION
This restores the behavior for ophyd <= 1.4.

While properties that may take an (arbitrarily) long time are not
great, silently changing the semantics of the property has too high of
a chance of causing hard to detect bugs in beamline code.

xref #814

I can cook up some tests for this if required (basically get a real PV to talk to, make an epics signal, side-band change it, assert `obj.value` changed).