### PR TITLE
Add logging documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,6 +28,8 @@ import sphinx_rtd_theme
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.doctest', 'sphinx.ext.autosummary',
+              'IPython.sphinxext.ipython_directive',
+              'IPython.sphinxext.ipython_console_highlighting',
               'matplotlib.sphinxext.plot_directive',
               'sphinx.ext.inheritance_diagram',
               'numpydoc', 'sphinx.ext.mathjax', 'sphinx.ext.intersphinx']

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -1,0 +1,191 @@
+*********************
+Debugging and Logging
+*********************
+
+.. versionchanged:: 1.6.0
+
+   Bluesky's use of Python's logging framework has been completely reworked to
+   follow Python's documented best practices for libraries.
+
+Bluesky uses Python's logging framework, which enables sophisticated log
+management. For common simple cases, including viewing logs in the terminal or
+writing them to a file, the next section illustrates streamlined,
+copy/paste-able examples. Users who are familiar with that framework or who
+need to route logs to multiple destinations may wish to skip ahead to
+:ref:`logger_api`.
+
+Useful Snippets
+===============
+
+Log warnings
+------------
+
+This is the recommended standard setup.
+
+.. code-block:: python
+
+   from bluesky import config_bluesky_logging
+   config_bluesky_logging()
+
+It will display ``'bluesky'`` log records of ``WARNING`` level or higher in the
+terminal (standard out) with a format tailored to bluesky.
+
+Maximum verbosity
+-----------------
+
+If the RunEngine is "hanging," running slowly, or repeatedly encountering an
+error, it is useful to know exactly where in the plan the problem is occurring.
+To follow the RunEngine's progress through the plan, crank up the verbosity of
+the logging.
+
+This will display each message from the plan just before the RunEngine
+processes it, giving a clear indication of when plan execution is stuck.
+
+.. code-block:: python
+
+   from bluesky import config_bluesky_logging
+   config_bluesky_logging(level='DEBUG')
+
+Log to a file
+-------------
+
+This will direct all log messages to a file instead of the terminal (standard
+out).
+
+.. code-block:: python
+
+    from bluesky import config_bluesky_logging
+    config_bluesky_logging(file='/tmp/bluesky.log', level='DEBUG')
+
+.. important::
+
+   We strongly recommend setting levels on *handlers* not on *loggers*.
+   In previous versions of bluesky, we recommended adjusting the level on the
+   *logger*, as in ``RE.log.setLevel('DEBUG')``. We now recommended
+   that you *avoid* setting levels on loggers because it would affect all
+   handlers downstream, potentially inhibiting some other part of the program
+   from collecting the records it wants to collect.
+
+.. _logger_api:
+
+Bluesky's Logging-Related API
+=============================
+
+Logger Names
+------------
+
+Here are the primary loggers used by bluesky.
+
+* ``'bluesky'`` --- the logger to which all bluesky log records propagate
+* ``'bluesky.emit_document'`` --- A log record is emitted whenever a Document
+  is emitted. The log record does not contain the full content of the
+  Document.
+* ``'bluesky.RE'`` --- Records from a RunEngine. INFO-level notes state
+  changes. DEBUG-level notes when each message from a plan is about to be
+  processed and when a status object has completed.
+* ``'bluesky.RE.msg`` --- A log record is emitted when each
+  :class:`~bluesky.utils.Msg` is about to be processed.
+* ``'bluesky.RE.state`` --- A log record is emitted when the RunEngine's state
+  changes.
+
+There are also some module-level loggers for specific features.
+
+Formatter
+---------
+
+.. autoclass:: bluesky.log.LogFormatter
+
+Global Handler
+---------------
+
+Following Python's recommendation, bluesky does not install any handlers at
+import time, but it provides a function to set up a basic useful configuration
+in one line, similar to Python's :py:func:`logging.basicConfig` but with some
+additional options---and scoped to the ``'bluesky'`` logger with bluesky's
+:class:`bluesky.log.LogFormatter`. It streamlines common use cases without
+interfering with more sophisticated use cases.
+
+We recommend that facilities using bluesky leave this function for users and
+configure any standardized, facility-managed logging handlers separately, as
+described in the next section.
+
+.. autofunction:: bluesky.log.config_bluesky_logging
+.. autofunction:: bluesky.log.get_handler
+
+Advanced Example
+================
+
+The flow of log event information in loggers and handlers is illustrated in the
+following diagram:
+
+.. image:: https://docs.python.org/3/_images/logging_flow.png
+
+For further reference, see the Python 3 logging howto:
+https://docs.python.org/3/howto/logging.html#logging-flow
+
+As an illustrative example, we will set up two handlers using the Python
+logging framework directly, ignoring bluesky's convenience function.
+
+Suppose we set up a handler aimed at a file:
+
+.. code-block:: python
+
+    import logging
+    file_handler = logging.FileHandler('bluesky.log')
+
+And another aimed at `Logstash <https://www.elastic.co/products/logstash>`_:
+
+.. code-block:: python
+
+    import logstash  # requires python-logstash package
+    logstash_handler = logstash.TCPLogstashHandler(<host>, <port>, version=1)
+
+We can attach the handlers to the bluesky logger, to which all log records
+created by bluesky propagate:
+
+.. code-block:: python
+
+    logger = logging.getLogger('bluesky')
+    logger.addHandler(logstash_handler)
+    logger.addHandler(file_filter)
+
+We can set the verbosity of each handler. Suppose want maximum verbosity in the
+file but only medium verbosity in logstash.
+
+.. code-block:: python
+
+    logstash_handler.setLevel('INFO')
+    file_handler.setLevel('DEBUG')
+
+Finally, ensure that "effective level" of ``logger`` is at least as verbose as
+the most verbose handler---in this case, ``'DEBUG'``. By default, at import,
+its level is not set
+
+.. ipython:: python
+   :verbatim:
+
+    logging.getLevelName(logger.level)
+    'NOTSET'
+
+and so it inherits the level of Python's default
+"handler of last resort," :py:obj:`logging.lastResort`, which is ``'WARNING'``.
+
+.. ipython:: python
+   :verbatim:
+
+    logging.getLevelName(logger.getEffectiveLevel())
+    'WARNING'
+
+In this case we should set it to ``'DEBUG'``, to match the most verbose level
+of the handler we have added.
+
+.. code-block:: python
+
+   logger.setLevel('DEBUG')
+
+This makes DEBUG-level records *available* to all handlers. Our logstash
+handler, set to ``'INFO'``, will filter out DEBUG-level records.
+
+To globally disable the generation of any log records at or below a certain
+verbosity, which may be helpful for optimizing performance, Python provides
+:py:func:`logging.disable`.

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -2,12 +2,12 @@
 Debugging and Logging
 *********************
 
-.. versionchanged:: 1.6.0
+.. versionchanged:: 1.4.0
 
-   Bluesky's use of Python's logging framework has been completely reworked to
+   Ophyd's use of Python's logging framework has been completely reworked to
    follow Python's documented best practices for libraries.
 
-Bluesky uses Python's logging framework, which enables sophisticated log
+Ophyd uses Python's logging framework, which enables sophisticated log
 management. For common simple cases, including viewing logs in the terminal or
 writing them to a file, the next section illustrates streamlined,
 copy/paste-able examples. Users who are familiar with that framework or who
@@ -24,27 +24,22 @@ This is the recommended standard setup.
 
 .. code-block:: python
 
-   from bluesky import config_bluesky_logging
-   config_bluesky_logging()
+   from ophyd import config_ophyd_logging
+   config_ophyd_logging()
 
-It will display ``'bluesky'`` log records of ``WARNING`` level or higher in the
-terminal (standard out) with a format tailored to bluesky.
+It will display ``'ophyd'`` log records of ``WARNING`` level or higher in the
+terminal (standard out) with a format tailored to ophyd.
 
 Maximum verbosity
 -----------------
 
-If the RunEngine is "hanging," running slowly, or repeatedly encountering an
-error, it is useful to know exactly where in the plan the problem is occurring.
-To follow the RunEngine's progress through the plan, crank up the verbosity of
-the logging.
-
-This will display each message from the plan just before the RunEngine
-processes it, giving a clear indication of when plan execution is stuck.
+If operations are "hanging," running slowly, or repeatedly encountering an
+error, increasing the logging verbosity can help identify the underlying issue.
 
 .. code-block:: python
 
-   from bluesky import config_bluesky_logging
-   config_bluesky_logging(level='DEBUG')
+   from ophyd import config_ophyd_logging
+   config_ophyd_logging(level='DEBUG')
 
 Log to a file
 -------------
@@ -54,63 +49,48 @@ out).
 
 .. code-block:: python
 
-    from bluesky import config_bluesky_logging
-    config_bluesky_logging(file='/tmp/bluesky.log', level='DEBUG')
-
-.. important::
-
-   We strongly recommend setting levels on *handlers* not on *loggers*.
-   In previous versions of bluesky, we recommended adjusting the level on the
-   *logger*, as in ``RE.log.setLevel('DEBUG')``. We now recommended
-   that you *avoid* setting levels on loggers because it would affect all
-   handlers downstream, potentially inhibiting some other part of the program
-   from collecting the records it wants to collect.
+    from ophyd import config_ophyd_logging
+    config_ophyd_logging(file='/tmp/ophyd.log', level='DEBUG')
 
 .. _logger_api:
 
-Bluesky's Logging-Related API
+Ophyd's Logging-Related API
 =============================
 
 Logger Names
 ------------
 
-Here are the primary loggers used by bluesky.
+Here are the primary loggers used by ophyd.
 
-* ``'bluesky'`` --- the logger to which all bluesky log records propagate
-* ``'bluesky.emit_document'`` --- A log record is emitted whenever a Document
-  is emitted. The log record does not contain the full content of the
-  Document.
-* ``'bluesky.RE'`` --- Records from a RunEngine. INFO-level notes state
-  changes. DEBUG-level notes when each message from a plan is about to be
-  processed and when a status object has completed.
-* ``'bluesky.RE.msg`` --- A log record is emitted when each
-  :class:`~bluesky.utils.Msg` is about to be processed.
-* ``'bluesky.RE.state`` --- A log record is emitted when the RunEngine's state
-  changes.
+* ``'ophyd'`` --- the logger to which all ophyd log records propagate
+* ``'ophyd.control_layer'`` --- logs requests issued to the underlying control
+  layer (e.g. pyepics, caproto)
+* ``'ophyd.event_dispatcher'`` --- issues regular summaries of the backlog of
+  updates from the control layer that are being processed on background threads
 
-There are also some module-level loggers for specific features.
+There are also many module-level loggers for specific features.
 
 Formatter
 ---------
 
-.. autoclass:: bluesky.log.LogFormatter
+.. autoclass:: ophyd.log.LogFormatter
 
 Global Handler
 ---------------
 
-Following Python's recommendation, bluesky does not install any handlers at
+Following Python's recommendation, ophyd does not install any handlers at
 import time, but it provides a function to set up a basic useful configuration
 in one line, similar to Python's :py:func:`logging.basicConfig` but with some
-additional options---and scoped to the ``'bluesky'`` logger with bluesky's
-:class:`bluesky.log.LogFormatter`. It streamlines common use cases without
+additional options---and scoped to the ``'ophyd'`` logger with ophyd's
+:class:`ophyd.log.LogFormatter`. It streamlines common use cases without
 interfering with more sophisticated use cases.
 
-We recommend that facilities using bluesky leave this function for users and
+We recommend that facilities using ophyd leave this function for users and
 configure any standardized, facility-managed logging handlers separately, as
 described in the next section.
 
-.. autofunction:: bluesky.log.config_bluesky_logging
-.. autofunction:: bluesky.log.get_handler
+.. autofunction:: ophyd.log.config_ophyd_logging
+.. autofunction:: ophyd.log.get_handler
 
 Advanced Example
 ================
@@ -124,14 +104,14 @@ For further reference, see the Python 3 logging howto:
 https://docs.python.org/3/howto/logging.html#logging-flow
 
 As an illustrative example, we will set up two handlers using the Python
-logging framework directly, ignoring bluesky's convenience function.
+logging framework directly, ignoring ophyd's convenience function.
 
 Suppose we set up a handler aimed at a file:
 
 .. code-block:: python
 
     import logging
-    file_handler = logging.FileHandler('bluesky.log')
+    file_handler = logging.FileHandler('ophyd.log')
 
 And another aimed at `Logstash <https://www.elastic.co/products/logstash>`_:
 
@@ -140,12 +120,12 @@ And another aimed at `Logstash <https://www.elastic.co/products/logstash>`_:
     import logstash  # requires python-logstash package
     logstash_handler = logstash.TCPLogstashHandler(<host>, <port>, version=1)
 
-We can attach the handlers to the bluesky logger, to which all log records
-created by bluesky propagate:
+We can attach the handlers to the ophyd logger, to which all log records
+created by ophyd propagate:
 
 .. code-block:: python
 
-    logger = logging.getLogger('bluesky')
+    logger = logging.getLogger('ophyd')
     logger.addHandler(logstash_handler)
     logger.addHandler(file_filter)
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -56,6 +56,7 @@ other control systems.
    signals
    status
    area-detector
+   debugging
 
 .. toctree::
    :maxdepth: 1

--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -45,10 +45,13 @@ def _stderr_supports_color():
 
 class LogFormatter(logging.Formatter):
     """Log formatter used in Tornado, modified for Python3-only ophyd.
+
     Key features of this formatter are:
+
     * Color support when logging to a terminal that supports it.
     * Timestamps on every log line.
     * Robust against str/bytes encoding problems.
+
     This formatter is enabled automatically by
     `tornado.options.parse_command_line` or `tornado.options.parse_config_file`
     (unless ``--logging=none`` is used).
@@ -56,8 +59,11 @@ class LogFormatter(logging.Formatter):
     enabled by use of the colorama__ library. Applications that wish to use
     this must first initialize colorama with a call to ``colorama.init``.
     See the colorama documentation for details.
+
     __ https://pypi.python.org/pypi/colorama
+
     .. versionchanged:: 4.5
+
        Added support for ``colorama``. Changed the constructor
        signature to be compatible with `logging.config.dictConfig`.
     """
@@ -89,7 +95,9 @@ class LogFormatter(logging.Formatter):
           code
         :arg str datefmt: Datetime format.
           Used for formatting ``(asctime)`` placeholder in ``prefix_fmt``.
+
         .. versionchanged:: 3.2
+
            Added ``fmt`` and ``datefmt`` arguments.
         """
         super().__init__(datefmt=datefmt)


### PR DESCRIPTION
The first commit copied the logging documentation from bluesky as is. The
second commit makes the necessary changes to account for library-specific
details.