### PR TITLE
ENH #802 connect EPICS soft motor limits

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -344,7 +344,6 @@ class EpicsMotor(Device, PositionerBase):
             # update EPICS
             lo = min(low, high)
             hi = max(low, high)
-            print(lo, self.position, hi)
             if lo <= self.position <= hi:
                 self.high_limit_travel.put(lo)
                 self.low_limit_travel.put(hi)

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -90,10 +90,10 @@ class EpicsMotor(Device, PositionerBase):
             update EpicsSignal object when a limit CA monitor received
             """
             if (
-                self.connected
-                and old_value is not None
-                and value != old_value
-            ):
+                    self.connected
+                    and old_value is not None
+                    and value != old_value
+                ):
                 self.user_setpoint._metadata_changed(
                     self.user_setpoint.pvname,
                     self.user_setpoint._read_pv.get_ctrlvars(),

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -90,8 +90,8 @@ class EpicsMotor(Device, PositionerBase):
             update EpicsSignal object when a limit CA monitor received
             """
             if (
-                self.connected 
-                and old_value is not None 
+                self.connected
+                and old_value is not None
                 and value != old_value
             ):
                 self.user_setpoint._metadata_changed(
@@ -304,11 +304,11 @@ class EpicsMotor(Device, PositionerBase):
     def get_lim(self, flag):
         '''
         Returns the travel limit of motor
-        
+
         * flag > 0: returns high limit
         * flag < 0: returns low limit
         * flag == 0: returns None
-        
+
         Included here for compatibility with similar with SPEC command.
 
         Parameters
@@ -322,15 +322,15 @@ class EpicsMotor(Device, PositionerBase):
             return self.high_limit_travel.get()
         elif flag < 0:
             return self.low_limit_travel.get()
-    
+
     def set_lim(self, low, high):
         '''
         Sets the low and high travel limits of motor
-        
+
         * No action taken if motor is moving.
         * Low limit is set to lesser of (low, high)
         * High limit is set to greater of (low, high)
-        
+
         Included here for compatibility with similar with SPEC command.
 
         Parameters

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -87,7 +87,7 @@ class EpicsMotor(Device, PositionerBase):
 
         def on_limit_changed(value, old_value, **kwargs):
             """
-            update EpicsSignal object when a limit CA monitor received
+            update EpicsSignal object when a limit CA monitor received from EPICS
             """
             if (
                     self.connected

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -93,7 +93,7 @@ class EpicsMotor(Device, PositionerBase):
                     self.connected
                     and old_value is not None
                     and value != old_value
-                ):
+                    ):
                 self.user_setpoint._metadata_changed(
                     self.user_setpoint.pvname,
                     self.user_setpoint._read_pv.get_ctrlvars(),


### PR DESCRIPTION
Fixes #802 by connecting to EPICS motor record soft limits (`.HLM` and `.LLM`) and keeping ophyd `EpicsMotor` object synchronized with EPICS.

Also supplies two methods for call compatibility with SPEC.