### PR TITLE
Ensure that describe() works on ophyd.sim.hw objects.

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -122,8 +122,8 @@ class SynSignal(Signal):
         if func is None:
             # When triggered, just put the current value.
             func = self.get
-            # Initialize readback with a None value
-            self._readback = None
+            # Initialize readback with 0.
+            self._readback = 0
         if loop is None:
             loop = asyncio.get_event_loop()
         self._func = func
@@ -344,8 +344,8 @@ class SynAxis(Device):
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
     """
-    readback = Cpt(_ReadbackSignal, value=None, kind='hinted')
-    setpoint = Cpt(_SetpointSignal, value=None, kind='normal')
+    readback = Cpt(_ReadbackSignal, value=0, kind='hinted')
+    setpoint = Cpt(_SetpointSignal, value=0, kind='normal')
 
     velocity = Cpt(Signal, value=1, kind='config')
     acceleration = Cpt(Signal, value=1, kind='config')
@@ -441,7 +441,7 @@ class SynAxisEmptyHints(SynAxis):
 
 
 class SynAxisNoHints(SynAxis):
-    readback = Cpt(_ReadbackSignal, value=None, kind='omitted')
+    readback = Cpt(_ReadbackSignal, value=0, kind='omitted')
     @property
     def hints(self):
         raise AttributeError
@@ -640,6 +640,8 @@ class Syn2DGauss(Device):
         self.random_state = random_state
         self.val.name = self.name
         self.val.sim_set_func(self._compute)
+
+        self.trigger()
 
     def trigger(self, *args, **kwargs):
         return self.val.trigger(*args, **kwargs)

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -273,3 +273,23 @@ def test_synaxis_describe():
     motor1 = SynAxis(name='motor1')
     RE = bs.RunEngine()
     RE(bp.scan([], motor1, -5, 5, 5))
+
+
+def test_describe(hw):
+    # These need to be staged and triggered before they can be described, just
+    # like real area detectors do. We plan to change this approach and remove
+    # this limitation in ophyd 1.6.0, but for now we'll just skip these.
+    SKIP = (
+        'img',
+        'direct_img',
+        'direct_img_list',
+    )
+    for name, obj in hw.__dict__.items():
+        if name in SKIP:
+            continue
+        if hasattr(obj, 'describe'):
+            obj.describe()
+        elif hasattr(obj, 'describe_collect'):
+            obj.describe_collect()
+        else:
+            raise AttributeError("expected describe or describe_collect")


### PR DESCRIPTION
It should be possilbe to call `describe()` any time after an object is
intialized. This fixes a regression from 1.3.x and adds a test.

We make an exception for area-detector-like objects until ophyd 1.6.0
applies a re-think to how `describe()` works on those to make it just
like everything else.

Thanks @lsammut for the bug report.