### PR TITLE
Give callbacks access to status

### DIFF
--- a/ophyd/mixins.py
+++ b/ophyd/mixins.py
@@ -101,7 +101,7 @@ class SignalPositionerMixin(PositionerBase):
         self._moving = True
         self._run_subs(sub_type=self.SUB_START, timestamp=time.time())
 
-        def finished():
+        def finished(status):
             success = self._internal_status.success
             self._moving = False
             self._done_moving(success=success)

--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -158,7 +158,15 @@ class PositionerBase(OphydObject):
         moved_cb : callable
             Call this callback when movement has finished. This callback
             must accept one keyword argument: 'obj' which will be set to
-            this positioner instance.
+            this positioner instance. It should also accept a positional
+            argument 'status', the Status object.
+
+            .. versionchanged:: 1.5.0
+
+               The expected signature changed from ``moved_cb(*, obj)`` to
+               ``moved_cb(status, *, obj)``. The old signature is still
+               supported, but a warning will be issued.
+
         timeout : float, optional
             Maximum time to wait for the motion. If None, the default timeout
             for this positioner is used.

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -228,8 +228,13 @@ class StatusBase:
         # Handle func with signature callback() for back-compat.
         callback = adapt_old_callback_signature(callback)
         if self.done:
+            # Call it once and do not hold a reference to it.
             callback(self)
         else:
+            # Hold a strong reference to this. In other contexts we tend to
+            # hold weak references to callbacks, but this is a single-shot
+            # callback, so we will hold a strong reference until we call it,
+            # and then clear this cache to drop the reference(s).
             self._callbacks.append(callback)
 
     @finished_cb.setter

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -8,6 +8,7 @@ from warnings import warn
 import numpy as np
 
 from .log import logger
+from .utils import adapt_old_callback_signature
 
 
 class UseNewProperty(RuntimeError):
@@ -140,7 +141,7 @@ class StatusBase:
             self._settled()
 
             for cb in self._callbacks:
-                cb()
+                cb(self)
             self._callbacks.clear()
 
     def _finished(self, success=True, **kwargs):
@@ -203,11 +204,33 @@ class StatusBase:
                                  "property instead.")
 
     @_locked
-    def add_callback(self, cb):
+    def add_callback(self, callback):
+        """
+        Register a callback to be called once when the Status finishes.
+
+        The callback will be called exactly once. If the Status is finished
+        before a callback is added, it will be called immediately. This is
+        threadsafe.
+
+        The callback will be called regardless of success of failure. The
+        callback has access to this status object, so it can distinguish success
+        or failure by inspecting the object.
+
+        Parameters
+        ----------
+        callback: callable
+            Expected signature: ``callback(status)``.
+
+            The signature ``callback()`` is also supported for
+            backward-compatibility but will issue warnings. Support will be
+            removed in a future release of ophyd.
+        """
+        # Handle func with signature callback() for back-compat.
+        callback = adapt_old_callback_signature(callback)
         if self.done:
-            cb()
+            callback(self)
         else:
-            self._callbacks.append(cb)
+            self._callbacks.append(callback)
 
     @finished_cb.setter
     @_locked

--- a/ophyd/tests/test_epicsmotor.py
+++ b/ophyd/tests/test_epicsmotor.py
@@ -268,10 +268,13 @@ def test_watchers(motor):
     def collect(fraction, **kwargs):
         collector.append(fraction)
 
+    def callback(status):
+        ev.set()
+
     st = motor.set(1)
     st.watch(collect)
     ev = threading.Event()
-    st.add_callback(ev.set)
+    st.add_callback(callback)
     ev.wait()
     assert collector
     assert collector[-1] == 1

--- a/ophyd/tests/test_ophydobj.py
+++ b/ophyd/tests/test_ophydobj.py
@@ -28,7 +28,7 @@ def test_status_callback_deprecated():
         st.finished_cb = None
 
     st._finished()
-    cb.assert_called_once_with()
+    cb.assert_called_once_with(st)
 
 
 def test_status_callback():
@@ -40,7 +40,7 @@ def test_status_callback():
     assert st.callbacks[0] is cb
 
     st._finished()
-    cb.assert_called_once_with()
+    cb.assert_called_once_with(st)
 
 
 def test_status_others():

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -166,7 +166,7 @@ def test_notify_watchers():
 def test_old_signature():
     st = StatusBase()
     state, cb = _setup_state_and_cb(new_signature=False)
-    with pytest.warns(UserWarning, match="signature"):
+    with pytest.warns(DeprecationWarning, match="signature"):
         st.add_callback(cb)
     assert not state
     st._finished()
@@ -177,6 +177,6 @@ def test_old_signature_on_finished_status():
     st = StatusBase()
     state, cb = _setup_state_and_cb(new_signature=False)
     st._finished()
-    with pytest.warns(UserWarning, match="signature"):
+    with pytest.warns(DeprecationWarning, match="signature"):
         st.add_callback(cb)
     assert state

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -5,11 +5,15 @@ from ophyd.status import (StatusBase, SubscriptionStatus, UseNewProperty,
 import pytest
 
 
-def _setup_state_and_cb():
+def _setup_state_and_cb(new_signature=True):
     state = {}
 
-    def cb():
-        state['done'] = True
+    if new_signature:
+        def cb(status):
+            state['done'] = True
+    else:
+        def cb():
+            state['done'] = True
     return state, cb
 
 
@@ -157,3 +161,22 @@ def test_notify_watchers():
     mst.target = 0
     mst.start_pos = 0
     mst._notify_watchers(0)
+
+
+def test_old_signature():
+    st = StatusBase()
+    state, cb = _setup_state_and_cb(new_signature=False)
+    with pytest.warns(UserWarning, match="signature"):
+        st.add_callback(cb)
+    assert not state
+    st._finished()
+    assert state
+
+
+def test_old_signature_on_finished_status():
+    st = StatusBase()
+    state, cb = _setup_state_and_cb(new_signature=False)
+    st._finished()
+    with pytest.warns(UserWarning, match="signature"):
+        st.add_callback(cb)
+    assert state

--- a/ophyd/utils/__init__.py
+++ b/ophyd/utils/__init__.py
@@ -164,7 +164,7 @@ def adapt_old_callback_signature(callback):
             "The signature of a Status callback is now expected to "
             "be cb(status). The signature cb() is "
             "supported, but support will be removed in a future release "
-            "of ophyd.")
+            "of ophyd.", DeprecationWarning)
         raw_callback = callback
 
         def callback(status):

--- a/ophyd/utils/__init__.py
+++ b/ophyd/utils/__init__.py
@@ -1,6 +1,8 @@
 # vi: ts=4 sw=4 sts=4 expandtab
+import inspect
 import logging
 from collections import OrderedDict
+import warnings
 
 from .errors import *  # noqa: F401, F403
 from .epics_pvs import *  # noqa: F401, F403
@@ -136,3 +138,38 @@ def getattrs(obj, gen):
 class DO_NOT_USE:
     "sentinel value"
     ...
+
+
+def adapt_old_callback_signature(callback):
+    """
+    If callback has signature callback(), wrap in signature callback(status).
+
+    Parameters
+    ----------
+    callback: callable
+        Expected signature ``callback(status)`` or ``callback()``
+
+    Returns
+    -------
+    callback: callable
+        Signature ``callback(status)``
+    """
+    # Handle callback with signature callback() for back-compat.
+    sig = inspect.signature(callback)
+    try:
+        # Does this callbacktion accept one positional argument?
+        sig.bind(None)
+    except TypeError:
+        warnings.warn(
+            "The signature of a Status callback is now expected to "
+            "be cb(status). The signature cb() is "
+            "supported, but support will be removed in a future release "
+            "of ophyd.")
+        raw_callback = callback
+
+        def callback(status):
+            # Do nothing with sub because the user-provided callback cannot
+            # accept it.
+            raw_callback()
+
+    return callback

--- a/ophyd/utils/__init__.py
+++ b/ophyd/utils/__init__.py
@@ -157,7 +157,7 @@ def adapt_old_callback_signature(callback):
     # Handle callback with signature callback() for back-compat.
     sig = inspect.signature(callback)
     try:
-        # Does this callbacktion accept one positional argument?
+        # Does this callback accept one positional argument?
         sig.bind(None)
     except TypeError:
         warnings.warn(
@@ -168,7 +168,7 @@ def adapt_old_callback_signature(callback):
         raw_callback = callback
 
         def callback(status):
-            # Do nothing with sub because the user-provided callback cannot
+            # Do nothing with status because the user-provided callback cannot
             # accept it.
             raw_callback()
 


### PR DESCRIPTION
Addresses Point 1 of #825.

```py
In [1]: def f(): 
   ...:     print("BANG!") 
   ...:                                                                                                                                                                                       

In [2]: def g(status): 
   ...:     print(f"BANG! from {status}") 
   ...:                                                                                                                                                                                       

In [3]: import ophyd                                                                                                                                                                          

In [4]: thing = ophyd.Device(name='thing')                                                                                                                                                    

In [5]: status = ophyd.DeviceStatus(thing)                                                                                                                                                    

In [6]: status.add_callback(f)                                                                                                                                                                
/home/dallan/Repos/bnl/ophyd/ophyd/utils/__init__.py:166: UserWarning: The signature of a Status callback is now expected to be cb(status). The signature cb() is supported, but support will be removed in a future release of ophyd.
  warnings.warn(

In [7]: status.add_callback(g)                                                                                                                                                                

In [8]: status._finished()                                                                                                                                                                    
BANG!
BANG! from DeviceStatus(device=thing, done=True, success=True)
```

The implementation of the backward-compatibility in `adapt_old_callback_signature` is adapted from caproto, where we recently made a similar change.

TO DO:
- [x] Update all internal callbacks to use the new signature.
- [x] Unit tests