### PR TITLE
Refactor Status around a threading.Event and add methods.

### DIFF
--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -141,7 +141,7 @@ class SingleTrigger(TriggerBase):
             return
         if (old_value == 1) and (value == 0):
             # Negative-going edge means an acquisition just finished.
-            self._status._finished()
+            self._status.set_finished()
 
 
 class MultiTrigger(TriggerBase):
@@ -251,7 +251,7 @@ class MultiTrigger(TriggerBase):
             key, signals_settings = next(self._acq_iter)
         except StopIteration:
             logger.debug("Trigger cycle is complete.")
-            self._status._finished()
+            self._status.set_finished()
             return
         logger.debug('Configuring signals for acquisition labeled %r', key)
         for sig, val in signals_settings.items():

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1298,7 +1298,7 @@ class Device(BlueskyInterface, OphydObject):
                                       'currently supported')
         status = DeviceStatus(self)
         if not signals:
-            status._finished()
+            status.set_finished()
             return status
 
         acq_signal, = signals

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -124,7 +124,7 @@ class AreaDetectorTimeseriesCollector(Device):
         # make status object
         status = DeviceStatus(self)
         # it always done, the scan should never even try to wait for this
-        status._finished()
+        status.set_finished()
         return status
 
     def pause(self):
@@ -145,7 +145,7 @@ class AreaDetectorTimeseriesCollector(Device):
 
         # Data is ready immediately
         st = DeviceStatus(self)
-        st._finished(success=True)
+        st.set_finished()
         return st
 
     def collect(self):
@@ -213,7 +213,7 @@ class WaveformCollector(Device):
     def complete(self):
         self.pause()
         st = DeviceStatus(self)
-        st._finished(success=True)
+        st.set_finished()
         return st
 
     def kickoff(self):
@@ -226,7 +226,7 @@ class WaveformCollector(Device):
         # make status object
         status = DeviceStatus(self)
         # it always done, the scan should never even try to wait for this
-        status._finished()
+        status.set_finished()
         return status
 
     def collect(self):
@@ -306,7 +306,7 @@ class MonitorFlyerMixin(BlueskyInterface):
         self._paused = False
         self._add_monitors()
         st = DeviceStatus(self)
-        st._finished(success=True)
+        st.set_finished()
         return st
 
     def _add_monitors(self):
@@ -405,7 +405,7 @@ class MonitorFlyerMixin(BlueskyInterface):
 
         # Data is ready immediately
         st = DeviceStatus(self)
-        st._finished(success=True)
+        st.set_finished()
         return st
 
     def collect(self):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -47,7 +47,7 @@ class NullStatus(StatusBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._finished(success=True)
+        self.set_finished()
 
 
 class EnumSignal(Signal):
@@ -157,7 +157,7 @@ class SynSignal(Signal):
                 def update_and_finish():
                     self.log.info('update_and_finish %s', self)
                     self.put(self._func())
-                    st._finished()
+                    st.set_finished()
 
                 self.loop.call_later(delay_time, update_and_finish)
             else:
@@ -166,7 +166,7 @@ class SynSignal(Signal):
                     self.log.info('sleep_and_finish %s', self)
                     ttime.sleep(delay_time)
                     self.put(self._func())
-                    st._finished()
+                    st.set_finished()
 
                 threading.Thread(target=sleep_and_finish, daemon=True).start()
             return st
@@ -413,7 +413,7 @@ class SynAxis(Device):
 
                 def update_and_finish():
                     update_state()
-                    st._finished()
+                    st.set_finished()
 
                 self.loop.call_later(self.delay, update_and_finish)
             else:
@@ -421,7 +421,7 @@ class SynAxis(Device):
                 def sleep_and_finish():
                     ttime.sleep(self.delay)
                     update_state()
-                    st._finished()
+                    st.set_finished()
 
                 threading.Thread(target=sleep_and_finish, daemon=True).start()
             return st
@@ -747,7 +747,7 @@ class MockFlyer:
         self._future = self.loop.run_in_executor(None, self._scan)
         st = DeviceStatus(device=self)
         self._completion_status = st
-        self._future.add_done_callback(lambda x: st._finished())
+        self._future.add_done_callback(lambda x: st.set_finished())
         return st
 
     def collect(self):

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -742,27 +742,24 @@ def wait(status, timeout=None, *, poll_rate=0.05):
 
     Parameters
     ----------
-    timeout : float, optional
+    status: StatusBase
+        A Status object
+    timeout: Union[Number, None], optional
         Amount of time in seconds to wait. None disables, such that wait() will
         only return when either the status completes or if interrupted by the
         user.
-    poll_rate : float, optional
+    poll_rate: "DEPRECATED"
         DEPRECATED. Has no effect because this does not poll.
 
     Raises
     ------
-    TimeoutError
-        If time waited exceeds specified timeout
-    RuntimeError
-        If the status failed to complete successfully
+    WaitTimeoutError
+        If the status has not completed within ``timeout`` (starting from
+        when this method was called, not from the beginning of the action).
+    Exception
+        This is ``status.exception()``, raised if the status has finished
+        with an error.  This may include ``TimeoutError``, which
+        indicates that the action itself raised ``TimeoutError``, distinct
+        from ``WaitTimeoutError`` above.
     """
-    # It would probably be more useful to just return status.wait(timeout)
-    # directly rather than chaining a RuntimeError on the end here. Is it worth
-    # maintaining back-compat on this?
-    try:
-        return status.wait(timeout)
-    except WaitTimeoutError as exc:
-        raise TimeoutError(*exc.args)
-    except Exception as exc:
-        raise RuntimeError('Operation completed but reported an error: {}'
-                           ''.format(status)) from exc
+    return status.wait(timeout)

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -178,10 +178,6 @@ class StatusBase:
         """
         Sleep for the settle_time, set the Event, run the callbacks.
         """
-        # wait until the settling time is done to mark completion
-        if self.settle_time > 0.0:
-            time.sleep(self.settle_time)
-
         with self._lock:
             if self._event.is_set():
                 # We timed out while waiting for the settle time.
@@ -229,8 +225,9 @@ class StatusBase:
 
         if self.settle_time > 0:
             # delay gratification until the settle time is up
-            self._settle_thread = threading.Thread(
-                target=self._settle_then_run_callbacks, daemon=True,
+            self._settle_thread = threading.Timer(
+                self.settle_time,
+                self._settle_then_run_callbacks,
             )
             self._settle_thread.start()
         else:

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -71,6 +71,11 @@ class StatusBase:
         if timeout is not None:
             self.timeout = float(timeout)
 
+        # We cannot know that we are successful if we are not done.
+        if success and not done:
+            raise ValueError(
+                "Cannot initialize with done=False but success=True.")
+
         self._callback_thread = threading.Thread(
             target=self._run_callbacks, daemon=True, name=self._tname)
         self._callback_thread.start()
@@ -88,10 +93,6 @@ class StatusBase:
                     "set_exception(...) instead of setting success=False "
                     "at __init__ time.")
                 self.set_exception(exc)
-        elif success:
-            # This is a backward-incompatible change.
-            raise ValueError(
-                "Cannot initialize with done=False but success=True.")
 
     @property
     def done(self):

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -253,7 +253,7 @@ class StatusBase:
             if (isinstance(exc, exc_class)
                     or isinstance(exc, type) and issubclass(exc, exc_class)):
                 raise ValueError(
-                    f"{exc_class} as special significance and cannot be set "
+                    f"{exc_class} has special significance and cannot be set "
                     "as the exception. Use a plain TimeoutError or some other "
                     "subclass thereof.")
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -84,17 +84,17 @@ class StatusBase:
         self._externally_initiated_completion = False
         self._callbacks = deque()
         self._exception = None
-        self.timeout = None
 
         self.log = LoggerAdapter(logger=logger, extra={'status': self})
 
         if settle_time is None:
             settle_time = 0.0
 
-        self.settle_time = float(settle_time)
+        self._settle_time = float(settle_time)
 
         if timeout is not None:
-            self.timeout = float(timeout)
+            timeout = float(timeout)
+        self._timeout = timeout
 
         # We cannot know that we are successful if we are not done.
         if success and not done:
@@ -118,6 +118,24 @@ class StatusBase:
                     "set_exception(...) instead of setting success=False "
                     "at __init__ time.")
                 self.set_exception(exc)
+
+    @property
+    def timeout(self):
+        """
+        The timeout for this action.
+
+        This is set when the Status is created, and it cannot be changed.
+        """
+        return self._timeout
+
+    @property
+    def settle_time(self):
+        """
+        A delay between when :meth:`set_finished` is when the Status is done.
+
+        This is set when the Status is created, and it cannot be changed.
+        """
+        return self._settle_time
 
     @property
     def done(self):

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -193,7 +193,7 @@ class StatusBase:
         """
         Mark as finished but failed with the given Exception.
 
-        This method should generally not be caled by the *recipient* of this
+        This method should generally not be called by the *recipient* of this
         Status object, but only by the object that created and returned it.
 
         Parameters
@@ -215,7 +215,7 @@ class StatusBase:
         """
         Mark as finished successfully.
 
-        This method should generally not be caled by the *recipient* of this
+        This method should generally not be called by the *recipient* of this
         Status object, but only by the object that created and returned it.
         """
         if self.done:
@@ -269,11 +269,19 @@ class StatusBase:
         """
         Return the exception raised by the action.
 
-        If the action has completed successfully, return ``None``.
+        If the action has completed successfully, return ``None``. If it has
+        finished in error, return the exception.
 
-        If the action has not completed in *timeout* seconds (starting from
-        when this method is called, not the beginning of the action) raise
-        ``WaitTimeoutError``.
+        Parameters
+        ----------
+        timeout: Union[Number, None], optional
+            If None (default) wait indefinitely until the status finishes.
+
+        Raises
+        ------
+        WaitTimeoutError
+            If the status has not completed within ``timeout`` (starting from
+            when this method was called, not from the beginning of the action).
         """
         if not self._event.wait(timeout=timeout):
             raise WaitTimeoutError("Status has not completed yet.")
@@ -286,11 +294,21 @@ class StatusBase:
         When the action has finished succesfully, return ``None``. If the
         action has failed, raise the exception.
 
-        If the action has not completed in *timeout* seconds (starting from
-        when this method is called, not the beginning of the action) raise
-        ``WaitTimeoutError``. This is distinct from ``TimeoutError``; a plain
-        ``TimeoutError`` indicates that the action itself raised a
-        ``TimeoutError``.
+        Parameters
+        ----------
+        timeout: Union[Number, None], optional
+            If None (default) wait indefinitely until the status finishes.
+
+        Raises
+        ------
+        WaitTimeoutError
+            If the status has not completed within ``timeout`` (starting from
+            when this method was called, not from the beginning of the action).
+        Exception
+            This is ``status.exception()``, raised if the status has finished
+            with an error.  This may include ``TimeoutError``, which
+            indicates that the action itself raised ``TimeoutError``, distinct
+            from ``WaitTimeoutError`` above.
         """
         if not self._event.wait(timeout=timeout):
             raise WaitTimeoutError("Status has not completed yet.")

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -385,7 +385,7 @@ class AndStatus(StatusBase):
         self.left = left
         self.right = right
 
-        def inner():
+        def inner(status):
             with self._lock:
                 with self.left._lock:
                     with self.right._lock:

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -580,7 +580,7 @@ class SubscriptionStatus(DeviceStatus):
         # Clear callback
         self.device.clear_sub(self.check_value)
         # Run completion
-        super().set_finished(exc)
+        super().set_exception(exc)
 
 
 class MoveStatus(DeviceStatus):

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -96,8 +96,9 @@ class StatusBase:
         """
         Boolean indicating whether associated operation has completed.
 
-        This is set to True at __init__ time or by calling `_finished()`. Once
-        True, it can never become False.
+        This is set to True at __init__ time or by calling
+        :meth:`set_finished`, :meth:`set_exception`, or (deprecated)
+        :meth:`_finished`. Once True, it can never become False.
         """
         return self._event.is_set()
 
@@ -108,10 +109,12 @@ class StatusBase:
         if bool(self._event.is_set()) != bool(value):
             raise RuntimeError(
                 "The done-ness of a status object cannot be changed by "
-                "setting its `done` attribute directly. Call `_finished()`.")
+                "setting its `done` attribute directly. Call `set_finished()` "
+                "or `set_exception(exc).")
         warn(
             "Do not set the `done` attribute of a status object directly. "
-            "It should only be set indirectly by calling `_finished()`. "
+            "It should only be set indirectly by calling `set_finished()` "
+            "or `set_exception(exc)`. "
             "Direct setting was never intended to be supported and it will be "
             "disallowed in a future release of ophyd, causing this code path "
             "to fail.",
@@ -122,10 +125,9 @@ class StatusBase:
         """
         Boolean indicating whether associated operation has completed.
 
-        The method :meth:`exception` provides more specific information about
-        failure.
-
-        Once it is set to True, it can never change to be False.
+        This is set to True at __init__ time or by calling
+        :meth:`set_finished`, :meth:`set_exception`, or (deprecated)
+        :meth:`_finished`. Once True, it can never become False.
         """
         return self.done and self._exception is None
 
@@ -136,10 +138,12 @@ class StatusBase:
         if bool(self.success) != bool(value):
             raise RuntimeError(
                 "The success state of a status object cannot be changed by "
-                "setting its `success` attribute directly. Call `_finished()`.")
+                "setting its `success` attribute directly. Call "
+                "`set_finished()` or `set_exception(exc)`.")
         warn(
             "Do not set the `success` attribute of a status object directly. "
-            "It should only be set indirectly by calling `_finished()`. "
+            "It should only be set indirectly by calling `set_finished()` "
+            "or `set_exception(exc)`. "
             "Direct setting was never intended to be supported and it will be "
             "disallowed in a future release of ophyd, causing this code path "
             "to fail.",
@@ -236,8 +240,8 @@ class StatusBase:
         """
         Inform the status object that it is done and if it succeeded.
 
-        This method is deprecated. Please use :meth:`set_finished()` or
-        :meth:`set_exception(exc)`.
+        This method is deprecated. Please use :meth:`set_finished` or
+        :meth:`set_exception`.
 
         .. warning::
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -138,7 +138,7 @@ class StatusBase:
                 "The success state of a status object cannot be changed by "
                 "setting its `success` attribute directly. Call `_finished()`.")
         warn(
-            "Do not set the `succcess` attribute of a status object directly. "
+            "Do not set the `success` attribute of a status object directly. "
             "It should only be set indirectly by calling `_finished()`. "
             "Direct setting was never intended to be supported and it will be "
             "disallowed in a future release of ophyd, causing this code path "

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -159,6 +159,9 @@ class StatusBase:
                 if self.done:
                     # Avoid race condition with settling.
                     return
+                # If we get here, we are on the "failure by timeout" path.
+                # Hold the lock the whole time to ensure that no one else can
+                # sneak it and call set_exception.
                 self.log.warning('timeout after %.2f seconds', timeout)
                 try:
                     self._handle_failure()

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -282,11 +282,13 @@ class StatusBase:
                     "Either set_finished() or set_exception() has "
                     f"already been called on {self!r}")
             self._externally_initiated_completion.set()
-        self._settle_thread = threading.Timer(
-            self.settle_time,
-            self._settled_event.set,
-        )
-        self._settle_thread.start()
+        # Note that in either case, the callbacks themselves are run from the
+        # same thread. This just sets an Event, either from this thread (the
+        # one calling set_finished) or the thread created below.
+        if self.settle_time > 0:
+            threading.Timer(self.settle_time, self._settled_event.set).start()
+        else:
+            self._settled_event.set()
 
     def _finished(self, success=True, **kwargs):
         """

--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import uuid
 
 import pytest

--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -64,11 +64,7 @@ def motor(request, cleanup):
     motor.wait_for_connection()
     motor.low_limit_value.put(-100, wait=True)
     motor.high_limit_value.put(100, wait=True)
-    # set the motor to 0
-    motor.set(0)
-    while motor.motor_done_move.get() != 1:
-        print('Waiting for {} to stop moving...'.format(motor))
-        time.sleep(0.5)
+    motor.set(0).wait()
 
     return motor
 

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -68,6 +68,6 @@ def test_logger_adapter_status():
     status.log.info("here is some info")
     assert log_buffer.getvalue().endswith(f"[{str(status)}] here is some info\n")
 
-    status._finished(success=True)
+    status.set_finished()
     status.log.info("here is more info")
     assert log_buffer.getvalue().endswith(f"[{str(status)}] here is more info\n")

--- a/ophyd/tests/test_ophydobj.py
+++ b/ophyd/tests/test_ophydobj.py
@@ -6,6 +6,7 @@ from ophyd.ophydobj import (OphydObject,
                             register_instances_keyed_on_name,
                             register_instances_in_weakset)
 from ophyd.status import (StatusBase, DeviceStatus, wait)
+from ophyd.utils import WaitTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -55,14 +56,14 @@ def test_status_wait():
 
 def test_wait_status_failed():
     st = StatusBase(timeout=0.05)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TimeoutError):
         wait(st)
 
 
 def test_status_wait_timeout():
     st = StatusBase()
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(WaitTimeoutError):
         wait(st, timeout=0.05)
 
 

--- a/ophyd/tests/test_ophydobj.py
+++ b/ophyd/tests/test_ophydobj.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def test_status_basic():
     st = StatusBase()
-    st._finished()
+    st.set_finished()
 
 
 def test_status_callback_deprecated():
@@ -28,7 +28,8 @@ def test_status_callback_deprecated():
     with pytest.raises(RuntimeError):
         st.finished_cb = None
 
-    st._finished()
+    st.set_finished()
+    st.wait()
     cb.assert_called_once_with(st)
 
 
@@ -40,7 +41,8 @@ def test_status_callback():
     st.add_callback(cb)
     assert st.callbacks[0] is cb
 
-    st._finished()
+    st.set_finished()
+    st.wait()
     cb.assert_called_once_with(st)
 
 
@@ -50,7 +52,7 @@ def test_status_others():
 
 def test_status_wait():
     st = StatusBase()
-    st._finished()
+    st.set_finished()
     wait(st)
 
 

--- a/ophyd/tests/test_ophydobj.py
+++ b/ophyd/tests/test_ophydobj.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 
 from unittest.mock import Mock
 from ophyd.ophydobj import (OphydObject,
@@ -29,7 +30,8 @@ def test_status_callback_deprecated():
         st.finished_cb = None
 
     st.set_finished()
-    st.wait()
+    st.wait(1)
+    time.sleep(0.1)  # Wait for callbacks to run.
     cb.assert_called_once_with(st)
 
 
@@ -42,7 +44,8 @@ def test_status_callback():
     assert st.callbacks[0] is cb
 
     st.set_finished()
-    st.wait()
+    st.wait(1)
+    time.sleep(0.1)  # Wait for callbacks to run.
     cb.assert_called_once_with(st)
 
 

--- a/ophyd/tests/test_positioner.py
+++ b/ophyd/tests/test_positioner.py
@@ -63,6 +63,11 @@ def test_soft_positioner():
     target_pos = 1
     res = p.move(target_pos, wait=False)
 
+    # At first, this is not done (because wait=False above) but trying to
+    # confirm that here in the commented out assert below does not always work
+    # because it is race-y.
+    # assert not res.done
+    res.wait(3)  # a generous timeout
     assert res.done
     assert res.error == 0
     assert res.elapsed > 0

--- a/ophyd/tests/test_pvpositioner.py
+++ b/ophyd/tests/test_pvpositioner.py
@@ -63,7 +63,7 @@ def test_pvpos(motor):
     m.read()
 
     motor.move(0.1, wait=True)
-    time.sleep(0.1)
+    time.sleep(1)
     assert m.position == 0.1
 
     m.stop()

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -354,7 +354,8 @@ def test_set_finished_after_timeout():
     st.set_finished()
     assert isinstance(st.exception(), StatusTimeoutError)
 
-def test_set_finished_after_timeout():
+
+def test_set_exception_after_timeout():
     """
     If an external callback (e.g. pyepics) calls set_exception after the status
     has timed out, ignore it.

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -402,3 +402,8 @@ def test_set_exception_after_timeout():
     # External callback reports failure, too late.
     st.set_exception(LocalException())
     assert isinstance(st.exception(), StatusTimeoutError)
+
+
+def test_nonsensical_init():
+    with pytest.raises(ValueError):
+        StatusBase(success=True, done=False)

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -340,3 +340,32 @@ def test_race_settle_time_and_timeout():
         st.wait(1)
     # Now we should be done successfully.
     st.wait(3)
+
+
+def test_set_finished_after_timeout():
+    """
+    If an external callback (e.g. pyepics) calls set_finished after the status
+    has timed out, ignore it.
+    """
+    st = StatusBase(timeout=0)
+    time.sleep(0.1)
+    assert isinstance(st.exception(), StatusTimeoutError)
+    # External callback fires, too late.
+    st.set_finished()
+    assert isinstance(st.exception(), StatusTimeoutError)
+
+def test_set_finished_after_timeout():
+    """
+    If an external callback (e.g. pyepics) calls set_exception after the status
+    has timed out, ignore it.
+    """
+    st = StatusBase(timeout=0)
+    time.sleep(0.1)
+    assert isinstance(st.exception(), StatusTimeoutError)
+
+    class LocalException(Exception):
+        ...
+
+    # External callback reports failure, too late.
+    st.set_exception(LocalException())
+    assert isinstance(st.exception(), StatusTimeoutError)

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -407,3 +407,33 @@ def test_set_exception_after_timeout():
 def test_nonsensical_init():
     with pytest.raises(ValueError):
         StatusBase(success=True, done=False)
+
+
+def test_error_in_settled_method():
+    state, cb = _setup_state_and_cb()
+
+    class BrokenStatus(StatusBase):
+        def _settled(self):
+            raise Exception
+
+    st = BrokenStatus()
+    st.add_callback(cb)
+    st.set_finished()
+    st.wait(1)
+    time.sleep(0.1)  # Wait for callbacks to run.
+    assert state
+
+
+def test_error_in_handle_failure_method():
+    state, cb = _setup_state_and_cb()
+
+    class BrokenStatus(StatusBase):
+        def _handle_failure(self):
+            raise Exception
+
+    st = BrokenStatus()
+    st.add_callback(cb)
+    st.set_finished()
+    st.wait(1)
+    time.sleep(0.1)  # Wait for callbacks to run.
+    assert state

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -257,6 +257,23 @@ def test_set_exception_wrong_type():
         st.set_exception(NOT_AN_EXCEPTION)
 
 
+def test_set_exception_special_banned_exceptions():
+    """
+    Exceptions with special significant to StatusBase are banned. See comments
+    in set_exception.
+    """
+    st = StatusBase()
+    # Test the class and the instance of each.
+    with pytest.raises(ValueError):
+        st.set_exception(StatusTimeoutError)
+    with pytest.raises(ValueError):
+        st.set_exception(StatusTimeoutError())
+    with pytest.raises(ValueError):
+        st.set_exception(WaitTimeoutError)
+    with pytest.raises(ValueError):
+        st.set_exception(WaitTimeoutError())
+
+
 def test_exception_fail_path():
     st = StatusBase()
 
@@ -266,6 +283,21 @@ def test_exception_fail_path():
     exc = LocalException()
     st.set_exception(exc)
     assert exc is st.exception()
+    with pytest.raises(LocalException):
+        st.wait(1)
+
+
+def test_exception_fail_path_with_class():
+    """
+    Python allows `raise Exception` and `raise Exception()` so we do as well.
+    """
+    st = StatusBase()
+
+    class LocalException(Exception):
+        ...
+
+    st.set_exception(LocalException)
+    assert LocalException is st.exception()
     with pytest.raises(LocalException):
         st.wait(1)
 

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -132,12 +132,16 @@ def test_and():
     st4.add_callback(cb4)
     st5.add_callback(cb5)
     st1._finished()
+    st1.wait(1)
     assert 'done' in state1
     assert 'done' not in state2
     assert 'done' not in state3
     assert 'done' not in state4
     assert 'done' not in state5
     st2._finished()
+    st3.wait(1)
+    st4.wait(1)
+    st5.wait(1)
     assert 'done' in state3
     assert 'done' in state4
     assert 'done' in state5

--- a/ophyd/utils/errors.py
+++ b/ophyd/utils/errors.py
@@ -59,3 +59,10 @@ class WaitTimeoutError(TimeoutError):
     raised a TimeoutError.
     """
     ...
+
+
+class InvalidState(RuntimeError):
+    """
+    When Status.set_finished() or Status.set_exception(exc) is called too late
+    """
+    ...

--- a/ophyd/utils/errors.py
+++ b/ophyd/utils/errors.py
@@ -41,3 +41,21 @@ class PluginMisconfigurationError(TypeError, OpException):
 
 class UnprimedPlugin(RuntimeError, OpException):
     ...
+
+
+class UnknownStatusFailure(OpException):
+    """
+    Generic error when a Status object is marked success=False without details.
+    """
+    ...
+
+
+class WaitTimeoutError(TimeoutError):
+    """
+    TimeoutError raised when we ware waiting on completion of a task.
+
+    This is distinct from TimeoutError, just as concurrent.futures.TimeoutError
+    is distinct from TimeoutError, to differentiate when the task itself has
+    raised a TimeoutError.
+    """
+    ...

--- a/ophyd/utils/errors.py
+++ b/ophyd/utils/errors.py
@@ -50,7 +50,14 @@ class UnknownStatusFailure(OpException):
     ...
 
 
-class WaitTimeoutError(TimeoutError):
+class StatusTimeoutError(TimeoutError, OpException):
+    """
+    Timeout specified when a Status object was created has expired.
+    """
+    ...
+
+
+class WaitTimeoutError(TimeoutError, OpException):
     """
     TimeoutError raised when we ware waiting on completion of a task.
 
@@ -61,7 +68,7 @@ class WaitTimeoutError(TimeoutError):
     ...
 
 
-class InvalidState(RuntimeError):
+class InvalidState(RuntimeError, OpException):
     """
     When Status.set_finished() or Status.set_exception(exc) is called too late
     """


### PR DESCRIPTION
This is a fully-backward-compatible implementation of (3) and (4) in #825.

Adds methods:

```py
set_exception(exc)
set_finished()

# Return None (success), *return* exception (failure), or raise WaitTimeoutError (in progress)
exception(timeout=...)

# Return None (success), *raise* exception (failure), or raise WaitTimeoutError (in progress)
wait(timeout=...)
```

The done state is now implemented internally in terms of a `threading.Event` instead of a boolean. The success state is now implemented internally in terms of a stashed exception. A generic exception is used when we are given `Status(sucesss=False, ...)` or `status._finished(success=False)` and the Device has thus not told us the cause of failure.

The polling logic in the timeout thread and in the top-level function `wait(status, timeout, poll_rate)` uses `threading.Event.wait(timeout)` instead.

Example:

```py
In [1]: import ophyd                                                                                                                                                                          

In [2]: thing = ophyd.Device(name='thing')                                                                                                                                                    

In [3]: good_status = ophyd.DeviceStatus(thing)                                                                                                                                               

In [4]: good_status                                                                                                                                                                           
Out[4]: DeviceStatus(device=thing, done=False, success=False)

In [5]: good_status.wait(1)                                                                                                                                                                   
---------------------------------------------------------------------------
WaitTimeoutError                          Traceback (most recent call last)
<ipython-input-5-f756f3bbec98> in <module>
----> 1 good_status.wait(1)

~/Repos/bnl/ophyd/ophyd/status.py in wait(self, timeout)
    290         """
    291         if not self._event.wait(timeout=timeout):
--> 292             raise WaitTimeoutError("Status has not completed yet.")
    293         if self._exception is not None:
    294             raise self._exception

WaitTimeoutError: Status has not completed yet.

In [6]: good_status.exception(1)                                                                                                                                                              
---------------------------------------------------------------------------
WaitTimeoutError                          Traceback (most recent call last)
<ipython-input-6-1e2c6444abff> in <module>
----> 1 good_status.exception(1)

~/Repos/bnl/ophyd/ophyd/status.py in exception(self, timeout)
    273         """
    274         if not self._event.wait(timeout=timeout):
--> 275             raise WaitTimeoutError("Status has not completed yet.")
    276         return self._exception
    277 

WaitTimeoutError: Status has not completed yet.

In [7]: good_status.set_finished()                                                                                                                                                            

In [8]: good_status                                                                                                                                                                           
Out[8]: DeviceStatus(device=thing, done=True, success=True)

In [9]: good_status.wait()                                                                                                                                                                    

In [10]: good_status.exception()                                                                                                                                                              

In [11]: class MotorOnFire(Exception): 
    ...:     ... 
    ...:                                                                                                                                                                                      

In [12]: bad_status = ophyd.DeviceStatus(thing)                                                                                                                                               

In [13]: bad_status                                                                                                                                                                           
Out[13]: DeviceStatus(device=thing, done=False, success=False)

In [14]: bad_status.set_exception(MotorOnFire("Oh no!"))                                                                                                                                      

In [15]: bad_status                                                                                                                                                                           
Out[15]: DeviceStatus(device=thing, done=True, success=False)

In [16]: bad_status.exception()                                                                                                                                                               
Out[16]: __main__.MotorOnFire('Oh no!')

In [17]: bad_status.wait()                                                                                                                                                                    
---------------------------------------------------------------------------
MotorOnFire                               Traceback (most recent call last)
<ipython-input-17-7670c6fbb488> in <module>
----> 1 bad_status.wait()

~/Repos/bnl/ophyd/ophyd/status.py in wait(self, timeout)
    292             raise WaitTimeoutError("Status has not completed yet.")
    293         if self._exception is not None:
--> 294             raise self._exception
    295 
    296     @property

MotorOnFire: Oh no!

In [18]: good_status_old_way = ophyd.DeviceStatus(thing)                                                                                                                                      

In [19]: good_status_old_way._finished()                                                                                                                                                      

In [20]: good_status_old_way                                                                                                                                                                  
Out[20]: DeviceStatus(device=thing, done=True, success=True)

In [21]: bad_status_old_way = ophyd.DeviceStatus(thing)                                                                                                                                       

In [22]: bad_status_old_way._finished(success=False)                                                                                                                                          

In [23]: bad_status_old_way.exception()                                                                                                                                                       
Out[23]: ophyd.utils.errors.UnknownStatusFailure('The status DeviceStatus(device=thing, done=True, success=False) has failed. To obtain more specific, helpful errors in the future, update the Device to use set_exception(...) instead of _finished(success=False).')
```

Needs tests.

The `_finished(...)` method is deprecated but intentionally does not warn because that would be very noisy, and moving everything over to use `set_exception(...)` where appropriate and provide more useful info will take some time. I propose to handle that in separate future PRs.