### PR TITLE
Mnt status warnings

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -127,7 +127,8 @@ class NDDerivedSignal(DerivedSignal):
         return cid
 
     def _array_shape_callback(self, **kwargs):
-        value = self.inverse(self._derived_from.value)
+        # TODO we need a better way to say "latest new is good enough"
+        value = self.inverse(self._derived_from._readback)
         self._readback = value
         self._run_subs(sub_type=self.SUB_VALUE, value=value,
                        **self._metadata)

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -697,7 +697,7 @@ class PseudoPositioner(Device, SoftPositioner):
         del self._real_waiting[:]
         super()._done_moving(success=success)
 
-    def _real_finished(self, obj=None):
+    def _real_finished(self, status=None, *, obj=None):
         '''Callback: A single real positioner has finished moving.
 
         Used for asynchronous motion, if all have finished moving then fire a
@@ -745,7 +745,7 @@ class PseudoPositioner(Device, SoftPositioner):
         pending_status = []
         t0 = time.time()
 
-        def move_next(obj=None):
+        def move_next(status=None, obj=None):
             # last motion complete message came from 'obj'
             self.log.debug('[%s:sequential] move_next called', self.name)
             with self._finished_lock:

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -81,7 +81,8 @@ def test_signal_base():
 
     assert signal.connected
     assert signal.name == name
-    assert signal.value == value
+    with pytest.warns(UserWarning):
+        assert signal.value == value
     assert signal.get() == value
     assert signal.timestamp == start_t
 
@@ -148,7 +149,8 @@ def test_signal_copy():
     sig_copy = copy.copy(signal)
 
     assert signal.name == sig_copy.name
-    assert signal.value == sig_copy.value
+    with pytest.warns(UserWarning):
+        assert signal.value == sig_copy.value
     assert signal.get() == sig_copy.get()
     assert signal.timestamp == sig_copy.timestamp
 
@@ -363,7 +365,8 @@ def test_soft_derived():
     assert derived.limits == original.limits
 
     copied = copy.copy(derived)
-    assert copied.derived_from.value == original.value
+    with pytest.warns(UserWarning):
+        assert copied.derived_from.value == original.value
     assert copied.derived_from.timestamp == original.timestamp
     assert copied.derived_from.name == original.name
 

--- a/ophyd/utils/__init__.py
+++ b/ophyd/utils/__init__.py
@@ -164,7 +164,7 @@ def adapt_old_callback_signature(callback):
             "The signature of a Status callback is now expected to "
             "be cb(status). The signature cb() is "
             "supported, but support will be removed in a future release "
-            "of ophyd.", DeprecationWarning)
+            "of ophyd.", DeprecationWarning, stacklevel=3)
         raw_callback = callback
 
         def callback(status):


### PR DESCRIPTION
Cleanups to avoid warnings due to the new expected signature on Status done callbacks.