### PR TITLE
MNT: auto_monitor signals that will be subscribed to

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -65,7 +65,7 @@ class EpicsMotor(Device, PositionerBase):
     high_limit_travel = Cpt(EpicsSignal, '.HLM', kind='omitted',
                             auto_monitor=True)
     low_limit_travel = Cpt(EpicsSignal, '.LLM', kind='omitted',
-                            auto_monitor=True)
+                           auto_monitor=True)
     direction_of_travel = Cpt(EpicsSignal, '.TDIR', kind='omitted')
 
     # commands

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -62,8 +62,10 @@ class EpicsMotor(Device, PositionerBase):
                           auto_monitor=True)
     high_limit_switch = Cpt(EpicsSignal, '.HLS', kind='omitted')
     low_limit_switch = Cpt(EpicsSignal, '.LLS', kind='omitted')
-    high_limit_travel = Cpt(EpicsSignal, ".HLM", kind="omitted")
-    low_limit_travel = Cpt(EpicsSignal, ".LLM", kind="omitted")
+    high_limit_travel = Cpt(EpicsSignal, '.HLM', kind='omitted',
+                            auto_monitor=True)
+    low_limit_travel = Cpt(EpicsSignal, '.LLM', kind='omitted',
+                            auto_monitor=True)
     direction_of_travel = Cpt(EpicsSignal, '.TDIR', kind='omitted')
 
     # commands


### PR DESCRIPTION
Due to #847, `subscribe` will block waiting for connection for epics signals. Recently in #802 two `subscribe` calls were added in `EpicsMotor.__init__`. This means that creating `EpicsMotor` instances now blocks on connection, which isn't desirable.

A quick way around this is to set `auto_monitor=True` on the signals that we plan to monitor during `__init__`, this allows the subscriptions to be set without the waiting for connection that is normally required to turn on signal monitoring.