### PR TITLE
FIX: Set attributes before invoking super at NDDerivedSignal

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -62,7 +62,6 @@ class NDDerivedSignal(DerivedSignal):
     """
     def __init__(self, derived_from, *, shape, num_dimensions=None,
                  parent=None, **kwargs):
-        super().__init__(derived_from=derived_from, parent=parent, **kwargs)
         # Assemble our shape of signals
         self._shape = []
         self._has_subscribed = False
@@ -77,6 +76,7 @@ class NDDerivedSignal(DerivedSignal):
         if isinstance(num_dimensions, str):
             num_dimensions = getattr(parent, num_dimensions)
         self._num_dimensions = num_dimensions
+        super().__init__(derived_from=derived_from, parent=parent, **kwargs)
 
     @property
     def derived_shape(self):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ attrs>=19.3.0
 caproto[standard] >=0.4.2rc1
 codecov
 databroker>=1.0.0b1
+epics-pypdb
 flake8
 h5py
 matplotlib


### PR DESCRIPTION
I came across this issue while debugging https://github.com/pcdshub/typhos/issues/288.

The problem here is that when the DerivedSignal source (in this case ArrayData_RBV) is connected, the VALUE callback is invoked many times but the attributes of NDDerivedSignal such as `_shape` and `_num_dimensions` were not yet set which then generates an issue if `describe` is invoked at the NDDerivedSignal as the `_readback` was never set as the callback for Value triggered by ArrayData_RBV changes was never successful.
That results into wrong metadata at the describe.

Steps to Reproduce
--------------------
```python
import time
import logging

logging.basicConfig(format='%(levelname)s:%(message)s', level="ERROR")
logger = logging.getLogger("ophyd")
logger.setLevel("ERROR")

from ophyd import Component as Cpt
from ophyd import Device, Signal
from ophyd.epics_motor import EpicsMotor
from ophyd.areadetector import SimDetector, CommonPlugins, ImagePlugin
class Camera(SimDetector):
    image = Cpt(ImagePlugin, "image1:")
class CamMotors(Device):
    camera = Cpt(Camera, "13SIM1:")
    motor_x = Cpt(EpicsMotor, "IOC:m1")
    motor_y = Cpt(EpicsMotor, "IOC:m2")
device = CamMotors('', name='sample')
device.wait_for_connection()

arr_data = device.camera.image.array_data
print('Array Data - Describe')
print(arr_data.describe())

si = device.camera.image.shaped_image
print('Shaped Image - Describe')
print(si.describe())
si.get()
print('Shaped Image - Describe - 2')
print(si.describe())
```

When running the test above, note that Array Data describe will return the proper values. The first describe at the Shaped Image (NDDerivedSignal) is incorrect until we prime it with a get.

The proposed fix here was tested locally and it works. For now, clients suffering from this issue can force a `get` call at the NDDerivedSignal before calling describe but this can impose big performance issues.