### PR TITLE
Help newcomers to learn what trigger() does

### DIFF
--- a/doc/source/device-overview.rst
+++ b/doc/source/device-overview.rst
@@ -332,6 +332,15 @@ There are three classes
 Trigger, Read and Describe
 --------------------------
 
+The :meth:`~ophyd.device.BlueskyInterface.trigger()` method is responsible for
+implementing 'trigger' or 'acquire' functionality of the Device.
+
+The :meth:`~ophyd.device.BlueskyInterface.read()` method is responsible for
+for returning the data from the Device.
+
+The :meth:`~ophyd.device.BlueskyInterface.describe()` method is responsible for
+providing schema and meta-data for the `read()` method.
+
 .. _cfg_and_f:
 
 


### PR DESCRIPTION
Came to [this page](https://blueskyproject.io/ophyd/device-overview.html?highlight=trigger#trd) looking for a clear description of `trigger()` for a tutorial.  As it reads, the section does not connect the dots for a newcomer.  This change makes a quick summary and connects to [existing documentation](https://blueskyproject.io/ophyd/generated/ophyd.device.BlueskyInterface.trigger.html?highlight=trigger) for more details.  Same for `read()` and `describe()` since they are in the same section.