### PR TITLE
Let wait_for_connection() return self instead of None.

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -2,6 +2,26 @@
  Release History
 =================
 
+Unreleased
+==========
+
+Added
+------
+
+* The method ``wait_for_connection()`` on various Signal classes now returns
+  the Signal instance. The enables shortening
+
+  .. code:: python
+
+     x = Signal(...)
+     x.wait_for_connection()
+
+  to
+
+  .. code:: python
+
+     x = Signal(...).wait_for_connection()
+
 1.5.0 (2020-05-01)
 ==================
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -141,8 +141,14 @@ class Signal(OphydObject):
         return d
 
     def wait_for_connection(self, timeout=0.0):
-        '''Wait for the underlying signals to initialize or connect'''
-        pass
+        '''
+        Wait for the original signal to connect
+
+        This method returns the Signal to facilitate the usage::
+
+            signal = SomeSignalClass(...).wait_for_connection()
+        '''
+        return self
 
     @property
     def metadata_keys(self):
@@ -614,7 +620,13 @@ class DerivedSignal(Signal):
         return value
 
     def wait_for_connection(self, timeout=0.0):
-        '''Wait for the original signal to connect'''
+        '''
+        Wait for the original signal to connect
+
+        This method returns the Signal to facilitate the usage::
+
+            signal = SomeSignalClass(...).wait_for_connection()
+        '''
         return self._derived_from.wait_for_connection(timeout=timeout)
 
     @property
@@ -984,13 +996,20 @@ class EpicsSignalBase(Signal):
                                f'access rights information within {float(timeout):.1f} sec')
 
     def wait_for_connection(self, timeout=1.0):
-        '''Wait for the underlying signals to initialize or connect'''
+        '''
+        Wait for the underlying signals to initialize or connect
+
+        This method returns the Signal to facilitate the usage::
+
+            signal = SomeSignalClass(...).wait_for_connection()
+        '''
         try:
             self._ensure_connected(self._read_pv, timeout=timeout)
         except TimeoutError:
             if self._destroyed:
                 raise DestroyedError('Signal has been destroyed')
             raise
+        return self
 
     @property
     def timestamp(self):
@@ -1391,8 +1410,15 @@ class EpicsSignal(EpicsSignalBase):
         return super().subscribe(callback, event_type=event_type, run=run)
 
     def wait_for_connection(self, timeout=1.0):
-        '''Wait for the underlying signals to initialize or connect'''
+        '''
+        Wait for the original signal to connect
+
+        This method returns the Signal to facilitate the usage::
+
+            signal = SomeSignalClass(...).wait_for_connection()
+        '''
         self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
+        return self
 
     @property
     def tolerance(self):


### PR DESCRIPTION
Now that we find ourselves adding ``wait_for_connection()`` in more places, it
would be convenient to be able to do it in one statement:

```py
x = SomeSignalClass(...).wait_for_connection()
```