### PR TITLE
MNT/API: remove the asyncio integration in ophyd.sim

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,3 +8,4 @@ exclude =
     doc/source,
     ophyd/areadetector/docs.py
 max-line-length = 115
+ignore: W504,W503

--- a/doc/area_detector/gen.py
+++ b/doc/area_detector/gen.py
@@ -31,7 +31,7 @@ rbv_re = re.compile(r'^(.*)\s+(.*)_RBV$',
 
 class DocRow(object):
     __slots__ = ['param_idx_var', 'asyn_interface',
-                 'access',  'description',
+                 'access', 'description',
                  'drvinfo', 'record', 'record_type']
 
     def __init__(self, row):

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -71,33 +71,33 @@ def get_cl():
 
 set_cl()
 
-from .ophydobj import (Kind, select_version,  # noqa: F401, F402
+from .ophydobj import (Kind, select_version,  # noqa: F401, F402, E402
                        register_instances_in_weakset,
                        register_instances_keyed_on_name)
 
 # Signals
-from .signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)  # noqa: F401, F402
+from .signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)  # noqa: F401, F402, E402
 
 # Positioners
-from .positioner import (PositionerBase, SoftPositioner)  # noqa: F401, F402
-from .epics_motor import EpicsMotor, MotorBundle  # noqa: F401, F402
-from .pv_positioner import (PVPositioner, PVPositionerPC)  # noqa: F401, F402
-from .pseudopos import (PseudoPositioner, PseudoSingle)  # noqa: F401, F402
+from .positioner import (PositionerBase, SoftPositioner)  # noqa: F401, F402, E402
+from .epics_motor import EpicsMotor, MotorBundle  # noqa: F401, F402, E402
+from .pv_positioner import (PVPositioner, PVPositionerPC)  # noqa: F401, F402, E402
+from .pseudopos import (PseudoPositioner, PseudoSingle)  # noqa: F401, F402, E402
 
 # Devices
-from .scaler import EpicsScaler  # noqa: F401, F402
-from .device import (Device, Component, FormattedComponent,  # noqa: F401, F402
+from .scaler import EpicsScaler  # noqa: F401, F402, E402
+from .device import (Device, Component, FormattedComponent,  # noqa: F401, F402, E402
                      DynamicDeviceComponent, ALL_COMPONENTS, kind_context,
                      wait_for_lazy_connection, do_not_wait_for_lazy_connection)
-from .status import StatusBase, wait  # noqa: F401, F402
-from .mca import EpicsMCA, EpicsDXP  # noqa: F401, F402
-from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM  # noqa: F401, F402
+from .status import StatusBase, wait  # noqa: F401, F402, E402
+from .mca import EpicsMCA, EpicsDXP  # noqa: F401, F402, E402
+from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM  # noqa: F401, F402, E402
 
 # Areadetector-related
-from .areadetector import *  # noqa: F401, F402, F403
-from ._version import get_versions  # noqa: F402
+from .areadetector import *  # noqa: F401, F402, E402, F403
+from ._version import get_versions  # noqa: F402, E402
 
-from .utils.startup import setup as setup_ophyd  # noqa: F401, F402
+from .utils.startup import setup as setup_ophyd  # noqa: F401, F402, E402
 
 
 __version__ = get_versions()['version']

--- a/ophyd/areadetector/__init__.py
+++ b/ophyd/areadetector/__init__.py
@@ -5,18 +5,18 @@ import logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-from .base import *  # noqa: F401, F402, F403
-from .cam import *  # noqa: F401, F402, F403
-from .detectors import *  # noqa: F401, F402, F403
+from .base import *  # noqa: F401, F402, E402, F403
+from .cam import *  # noqa: F401, F402, E402, F403
+from .detectors import *  # noqa: F401, F402, E402, F403
 
 # NOTE: the following imports are here for backward compatibility with
 # previous ophyd versions. This does not represent all available plugins
 # in ophyd. For that, import directly from ophyd.areadetector.plugins.
-from .plugins import (ColorConvPlugin, FilePlugin, HDF5Plugin, ImagePlugin,  # noqa: F401, F402
+from .plugins import (ColorConvPlugin, FilePlugin, HDF5Plugin, ImagePlugin,  # noqa: F401, F402, E402
                       JPEGPlugin, MagickPlugin, NetCDFPlugin, NexusPlugin,  # noqa: F401
                       OverlayPlugin, ProcessPlugin, ROIPlugin, StatsPlugin,
                       TIFFPlugin, TransformPlugin, get_areadetector_plugin,
                       plugin_from_pvname, register_plugin)
 
-from .common_plugins import *  # noqa: F401, F402, F403
-from .trigger_mixins import *  # noqa: F401, F402, F403
+from .common_plugins import *  # noqa: F401, F402, E402, F403
+from .trigger_mixins import *  # noqa: F401, F402, E402, F403

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -227,9 +227,9 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
         self._datum_uids = defaultdict(list)
         if reg is None and fs is not PH:
             reg = fs
-            warnings.warn("The device is provided with fs not reg"
-                          .format(self),
-                          stacklevel=2)
+            warnings.warn(
+                f"The device {self} is provided with fs not reg",
+                stacklevel=2)
 
         self._reg = reg
 

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -92,16 +92,16 @@ class EpicsMotor(Device, PositionerBase):
             update EpicsSignal object when a limit CA monitor received from EPICS
             """
             if (
-                    self.connected
-                    and old_value is not None
-                    and value != old_value
-                    ):
+                self.connected
+                and old_value is not None
+                and value != old_value
+            ):
                 self.user_setpoint._metadata_changed(
                     self.user_setpoint.pvname,
                     self.user_setpoint._read_pv.get_ctrlvars(),
                     from_monitor=True,
                     update=True,
-                    )
+                )
 
         self.low_limit_travel.subscribe(on_limit_changed)
         self.high_limit_travel.subscribe(on_limit_changed)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -19,10 +19,10 @@ from . import get_cl
 # Catch semi-frequent issue with scripts accidentally run from inside module
 if __name__ != 'ophyd.signal':
     raise RuntimeError(
-       'A script tried to import ophyd.signal instead of the signal built-in '
-       'module. This usually happens when a script is run from inside the '
-       'ophyd directory and can cause extremely confusing bugs. Please '
-       'run your script elsewhere for better results.'
+        'A script tried to import ophyd.signal instead of the signal built-in '
+        'module. This usually happens when a script is run from inside the '
+        'ophyd directory and can cause extremely confusing bugs. Please '
+        'run your script elsewhere for better results.'
     )
 
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -421,6 +421,7 @@ class SynAxisEmptyHints(SynAxis):
 
 class SynAxisNoHints(SynAxis):
     readback = Cpt(_ReadbackSignal, value=0, kind='omitted')
+
     @property
     def hints(self):
         raise AttributeError
@@ -732,6 +733,7 @@ class MockFlyer:
         self._data = deque()
         st = DeviceStatus(device=self)
         self._completion_status = st
+
         def flyer_worker():
             self._scan()
             st.set_finished()

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -121,9 +121,9 @@ class SynSignal(Signal):
             func = self.get
             # Initialize readback with 0.
             self._readback = 0
-        sentinal = object()
-        loop = kwargs.pop('loop', sentinal)
-        if loop is not sentinal:
+        sentinel = object()
+        loop = kwargs.pop('loop', sentinel)
+        if loop is not sentinel:
             warnings.warn(
                 f"{self.__class__} no longer takes a loop as input.  "
                 "Your input will be ignored and may raise in the future",
@@ -351,9 +351,9 @@ class SynAxis(Device):
         if readback_func is None:
             def readback_func(x):
                 return x
-        sentinal = object()
-        loop = kwargs.pop('loop', sentinal)
-        if loop is not sentinal:
+        sentinel = object()
+        loop = kwargs.pop('loop', sentinel)
+        if loop is not sentinel:
             warnings.warn(
                 f"{self.__class__} no longer takes a loop as input.  "
                 "Your input will be ignored and may raise in the future",
@@ -685,9 +685,9 @@ class MockFlyer:
         self._steps = np.linspace(start, stop, num)
         self._data = deque()
         self._completion_status = None
-        sentinal = object()
-        loop = kwargs.pop('loop', sentinal)
-        if loop is not sentinal:
+        sentinel = object()
+        loop = kwargs.pop('loop', sentinel)
+        if loop is not sentinel:
             warnings.warn(
                 f"{self.__class__} no longer takes a loop as input.  "
                 "Your input will be ignored and may raise in the future",

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1,4 +1,3 @@
-import asyncio
 import copy
 import inspect
 import itertools
@@ -11,6 +10,7 @@ import threading
 import time as ttime
 import uuid
 import weakref
+import warnings
 
 from collections import deque, OrderedDict
 from tempfile import mkdtemp

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -567,11 +567,11 @@ def test_many_connect(ad_prefix, cleanup):
         det = MyDetector(ad_prefix, name='det')
         print('made detector')
         try:
-            print('*'*25)
+            print('*' * 25)
             print('about to murder socket')
             det.cam.acquire._read_pv._caproto_pv.circuit_manager._disconnected()
             print('murdered socket')
-            print('*'*25)
+            print('*' * 25)
         except AttributeError:
             # must be pyepics
             pass

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -115,7 +115,7 @@ def test_synaxis_timestamps():
     orig_time = tester(motor, orig_time)
 
     motor.setpoint.put(3)
-    time.sleep(2*motor.delay)
+    time.sleep(2 * motor.delay)
     orig_time = tester(motor, orig_time)
 
 

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -358,4 +358,4 @@ def fmt_time(tstamp=None):
     tstamp, frac = divmod(tstamp, 1)
     return "%s.%5.5i" % (ttime.strftime("%Y-%m-%d %H:%M:%S",
                                         ttime.localtime(tstamp)),
-                         round(1.e5*frac))
+                         round(1.e5 * frac))


### PR DESCRIPTION
It was not quite correct and is causing dead-locks in jupyter notebooks.  Rather than attempt to discover and attach to an asyncio loop, always use threads to implement delays.

This should un break the tutorials notebooks.