### PR TITLE
Avoid closing over self in the finalizers.

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -2,6 +2,24 @@
  Release History
 =================
 
+Unreleased
+==========
+
+Changes
+-------
+
+* It was formerly the case that :meth:`~ophyd.signal.Signal.destroy` was always
+  called at teardown---either manually by the user or automatically using one
+  of Python mechanisms for running cleanup during garbage collection or process
+  teardown. Now, *automatic* teardown only involves internal weakref
+  finalizers and it does not call ``destroy``. The method is now only a
+  user-facing hook for manually invoking those finalizers. It should not be
+  used an extension point for adding more code to be run at teardown; rather,
+  additional finalizers should be set up in ``__init__`` and invoked in
+  ``destroy``. See https://github.com/bluesky/ophyd/pull/865 for an example.
+  This changed is in accordance with best practices recommended by the Python
+  weakref documentation.
+
 
 1.5.1 (2020-06-12)
 ==================

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -102,7 +102,6 @@ class Signal(OphydObject):
             timestamp = time.time()
 
         self._destroyed = False
-        self._finalizer = weakref.finalize(self, self.destroy)
 
         self._set_thread = None
         self._tolerance = tolerance
@@ -786,6 +785,15 @@ class EpicsSignalBase(Signal):
                            "name={self.name}, id={id(self)}")
             EpicsSignalBase._mark_as_instantiated()
 
+        def finalize(read_pv, cl):
+            cl.release_pvs(read_pv)
+
+        self._read_pv_finalizer = weakref.finalize(self, finalize, self._read_pv, self.cl)
+
+    def destroy(self):
+        super().destroy()
+        self._read_pv_finalizer()
+
     @classmethod
     def _mark_as_instantiated(cls):
         "Update state indicated that this class has been instantiated."
@@ -1165,13 +1173,6 @@ class EpicsSignalBase(Signal):
 
         return {self.name: desc}
 
-    def destroy(self):
-        '''Disconnect the EpicsSignal from the underlying PV instance'''
-        super().destroy()
-        if self._read_pv is not None:
-            self.cl.release_pvs(self._read_pv)
-            self._read_pv = None
-
 
 class EpicsSignalRO(EpicsSignalBase):
     '''A read-only EpicsSignal -- that is, one with no `write_pv`
@@ -1225,6 +1226,16 @@ class EpicsSignalRO(EpicsSignalBase):
         super().__init__(read_pv, string=string, auto_monitor=auto_monitor,
                          name=name, **kwargs)
         self._metadata['write_access'] = False
+
+        def finalize(write_pv, cl):
+            cl.release_pvs(write_pv)
+
+        self._write_pv_finalizer = weakref.finalize(self, finalize, self._write_pv, self.cl)
+
+    def destroy(self):
+        super().destroy()
+        self._write_pv_finalizer()
+
 
     def put(self, *args, **kwargs):
         'Disabled for a read-only signal'
@@ -1710,13 +1721,6 @@ class EpicsSignal(EpicsSignalBase):
     @use_limits.setter
     def use_limits(self, value):
         self._use_limits = bool(value)
-
-    def destroy(self):
-        '''Destroy the EpicsSignal from the underlying PV instance'''
-        super().destroy()
-        if self._write_pv is not None:
-            self.cl.release_pvs(self._write_pv)
-            self._write_pv = None
 
 
 class AttributeSignal(Signal):


### PR DESCRIPTION
This does not actually fix anything, but it seems a step closer to "good practice" so it may be worth merging for its own sake.

Notice that the original in `master` makes reference to the instance state when the finalizer is _run_ whereas this grabs the attributes it needs when the finalizer is _defined_ and then makes no further reference to `self`.

My reading of this line in the weakref docs

> A more robust alternative can be to define a finalizer which only references the specific functions and objects that it needs, rather than having access to the full state of the object:

is that to make full use of the benefits of `weakref.finalize` over `__del__`, the finalizer should avoid closing over `self`.