### PR TITLE
CA library not safe to use when shutting down

### DIFF
--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -7,7 +7,14 @@ from epics import ca, caget, caput
 from ._dispatch import _CallbackThread, EventDispatcher, wrap_callback
 
 import atexit
-atexit.register(lambda: ca = None)
+
+
+def invalidate_ca():
+    global ca
+    ca = None
+
+
+atexit.register(invalidate_ca)
 
 _min_pyepics = '3.4.0'
 

--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -6,6 +6,9 @@ from epics import ca, caget, caput
 
 from ._dispatch import _CallbackThread, EventDispatcher, wrap_callback
 
+import atexit
+atexit.register(lambda: ca = None)
+
 _min_pyepics = '3.4.0'
 
 if LooseVersion(epics.__version__) < LooseVersion(_min_pyepics):
@@ -115,6 +118,9 @@ class PyepicsShimPV(epics.PV):
 
 
 def release_pvs(*pvs):
+    if ca is None:
+        return
+
     for pv in pvs:
         pv._reference_count -= 1
         if pv._reference_count == 0:


### PR DESCRIPTION
Following up on the recurring unexpected exceptions/segfaults during teardown:

@danielballan and @dmgav and I chatted about this a bit this morning and in a nutshell concluded:

1. Solving this in pyepics, along the lines of what @klauer you proposed [here](https://github.com/pyepics/pyepics/compare/master...klauer:fix_shutdown_perhaps), is ultimately the correct way to tackle this. It will need some fleshing out though, to address the additional exceptions I mentioned here https://github.com/bluesky/ophyd/issues/834#issuecomment-615480304. 
2. Alternatively, or additionally, to make ophyd play nice with current versions of pyepics, it may be a good idea to have ophyd avoid making any calls that involve libCA once it detects that Python is shutting down, since it is no longer safe to do so at that point.

The change in this PR is an idea on how to achieve point 2.

It appears to work, in that the caproto tests run without problems with this in place.

It feels a bit dirty though, and makes me question my sanity, so I welcome any and all critical comments and thoughts on why this is a horrible idea.