### PR TITLE
FIX: ordering of components for CommonPlugins classes

### DIFF
--- a/ophyd/areadetector/common_plugins.py
+++ b/ophyd/areadetector/common_plugins.py
@@ -112,7 +112,7 @@ for version in versions:
     _make_common_gather(f'CommonGatherPlugin_V{ver_string}', version)
 
 
-all_plugins = {
+all_plugins = [
     ('attr1', CommonAttributePlugin, 'Attr1:'),
     ('cb1', plugins.CircularBuffPlugin, 'CB1:'),
     ('cc1', plugins.ColorConvPlugin, 'CC1:'),
@@ -147,7 +147,7 @@ all_plugins = {
     ('stats5_ts', plugins.TimeSeriesPlugin, 'Stats5:TS:'),
     ('tiff1', plugins.TIFFPlugin, 'TIFF1:'),
     ('trans1', plugins.TransformPlugin, 'Trans1:')
-}
+]
 
 
 common_plugins = {}


### PR DESCRIPTION
Looks like this started out as a dictionary and turned into a `set` by mistake, losing the sensible component name ordering provided.

Before:
```python
In [4]: class MyDetector(ophyd.SimDetector, ophyd.areadetector.common_plugins.CommonPlugins_V32):
    ...

In [5]: MyDetector.component_names
Out[5]:
('scatter1',
 'roi1',
 'roi2',
 'stats4',
 'roistat1',
 'fft1',
 'cc2',
 'cc1',
 'netcdf1',
 'proc1',
 'stats3',
 'nexus1',
 'hdf1',
 'gather1',
 'roi4',
 'roi3',
 'stats2',
 'jpeg1',
 'tiff1',
 'attr1',
 'trans1',
 'over1',
 'stats1',
 'cb1',
 'stats5',
 'configuration_names',
 'cam')
```

After
```
In [1]: MyDetector.component_names
Out[1]:
('attr1',
 'cb1',
 'cc1',
 'cc2',
 'fft1',
 'gather1',
 'hdf1',
 'jpeg1',
 'netcdf1',
 'nexus1',
 'over1',
 'proc1',
 'roi1',
 'roi2',
 'roi3',
 'roi4',
 'roistat1',
 'scatter1',
 'stats1',
 'stats2',
 'stats3',
 'stats4',
 'stats5',
 'tiff1',
 'trans1',
 'configuration_names',
 'cam')
```