### PR TITLE
Update required pyepics version

### DIFF
--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -6,7 +6,7 @@ from epics import ca, caget, caput
 
 from ._dispatch import _CallbackThread, EventDispatcher, wrap_callback
 
-_min_pyepics = '3.4.0'
+_min_pyepics = '3.4.2'
 
 if LooseVersion(epics.__version__) < LooseVersion(_min_pyepics):
     raise ImportError('Version of pyepics too old. '

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,6 @@ epics-pypdb
 flake8
 h5py
 matplotlib
-pyepics>=3.4.0
+pyepics>=3.4.2
 pytest
 pytest-faulthandler


### PR DESCRIPTION
Updates pyepics pin to 3.4.2 in the pyepics shim and `test-requirement.txt`, for the libca teardown crash fix.