### PR TITLE
'ophyd.sim': prevent threads for unused objects ('rand', 'rand2') from starting automatically

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -297,7 +297,7 @@ class SynPeriodicSignal(SynSignal):
 
     def subscribe(self, *args, **kwargs):
         self._start_simulation_deprecated()
-        return super().subscribe()
+        return super().subscribe(*args, **kwargs)
 
 
 class _ReadbackSignal(Signal):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -226,6 +226,10 @@ class SynPeriodicSignal(SynSignal):
                  **kwargs):
         if func is None:
             func = np.random.rand
+
+        self._period = period
+        self._period_jitter = period_jitter
+
         super().__init__(name=name, func=func,
                          exposure_time=exposure_time,
                          parent=parent, labels=labels, kind=kind,
@@ -247,13 +251,13 @@ class SynPeriodicSignal(SynSignal):
                     del signal
                     # Sleep for period +/- period_jitter.
                     ttime.sleep(
-                        max(period + period_jitter * np.random.randn(), 0))
+                        max(self._period + self._period_jitter * np.random.randn(), 0))
 
             self.__thread = threading.Thread(target=periodic_update,
                                              daemon=True,
                                              args=(weakref.ref(self),
-                                                   period,
-                                                   period_jitter))
+                                                   self._period,
+                                                   self._period_jitter))
             self.__thread.start()
 
     def trigger(self):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -237,7 +237,11 @@ class SynPeriodicSignal(SynSignal):
         self.__thread = None
 
     def start_simulation(self):
-
+        """
+        Start background thread that performs periodic PV updates. The method
+        should be called at least once before the beginning of simulation. Multiple
+        calls to the method are ignored.
+        """
         if self.__thread is None:
 
             def periodic_update(ref, period, period_jitter):
@@ -260,28 +264,39 @@ class SynPeriodicSignal(SynSignal):
                                                    self._period_jitter))
             self.__thread.start()
 
+    def _start_simulation_deprecated(self):
+        """Call `start_simulation` and print deprecation warning"""
+        if self.__thread is None:
+            msg = ("Deprecated API: Objects of SynPeriodicSignal must be initialized before simulation\n"
+                   "by calling 'start_simulation()' method. Two such objects ('rand' and 'rand2') are\n"
+                   "created by 'ophyd.sim' module. Call\n"
+                   "    rand.start_simulation() or rand2.start_simulation()\n"
+                   "before the object is used.")
+            logger.warning(msg)
+            self.start_simulation()
+
     def trigger(self):
-        self.start_simulation()
+        self._start_simulation_deprecated()
         return super().trigger()
 
     def get(self, **kwargs):
-        self.start_simulation()
+        self._start_simulation_deprecated()
         return super().get(**kwargs)
 
     def put(self, *args, **kwargs):
-        self.start_simulation()
+        self._start_simulation_deprecated()
         super().put(*args, **kwargs)
 
     def set(self, *args, **kwargs):
-        self.start_simulation()
+        self._start_simulation_deprecated()
         return super().set(*args, **kwargs)
 
     def read(self):
-        self.start_simulation()
+        self._start_simulation_deprecated()
         return super().read()
 
     def subscribe(self, *args, **kwargs):
-        self.start_simulation()
+        self._start_simulation_deprecated()
         return super().subscribe()
 
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -195,6 +195,8 @@ class SynSignalRO(SynSignal):
 class SynPeriodicSignal(SynSignal):
     """
     A synthetic Signal that evaluates a Python function periodically.
+    The signal value is updated in a background thread. To start the thread,
+    call the `start_simulation()` method before the beginning of simulation.
 
     Parameters
     ----------
@@ -238,7 +240,7 @@ class SynPeriodicSignal(SynSignal):
 
     def start_simulation(self):
         """
-        Start background thread that performs periodic PV updates. The method
+        Start background thread that performs periodic value updates. The method
         should be called at least once before the beginning of simulation. Multiple
         calls to the method are ignored.
         """
@@ -265,7 +267,7 @@ class SynPeriodicSignal(SynSignal):
             self.__thread.start()
 
     def _start_simulation_deprecated(self):
-        """Call `start_simulation` and print deprecation warning"""
+        """Call `start_simulation` and print deprecation warning."""
         if self.__thread is None:
             msg = ("Deprecated API: Objects of SynPeriodicSignal must be initialized before simulation\n"
                    "by calling 'start_simulation()' method. Two such objects ('rand' and 'rand2') are\n"

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -272,7 +272,7 @@ class SynPeriodicSignal(SynSignal):
                    "created by 'ophyd.sim' module. Call\n"
                    "    rand.start_simulation() or rand2.start_simulation()\n"
                    "before the object is used.")
-            logger.warning(msg)
+            self.log.warning(msg)
             self.start_simulation()
 
     def trigger(self):


### PR DESCRIPTION
This PR addresses the issue https://github.com/bluesky/ophyd/issues/876

The objects `rand` and `rand2`, which are instances of the class `SynPeriodicSignal`, are created at the time of importing of `ophyd.sim`. The constructor for the class `SynPeriodicSignal` is automatically starting a background thread for each object even if the object is not used in simulation. In this PR a new method `start_simulation` is added to `SynPeriodicSignal` to start the background thread before the object is used. The constructor now is not creating the thread. Instead, the method has to be called manually in order to start periodic updates of the PV. This breaks the existing API and may prevent existing simulation code from running correctly.

In order to provide backward compatibility, a number of methods of `Signal` and `SynSignal` classes are overridden in `SynPeriodicSignal`, including `trigger`, `get`, `put`, `set`, `read` and `subscribe` methods. In addition to their original functionality, those methods also verify if the background thread is started for the object and start it if necessary. In addition, those methods are printing a deprecation warning with informative message on how to fix the issue. The message is printed only once (before the thread is created), so it is not expected to be annoying.
  