### PR TITLE
Do not set the default logging handler ('NullHandler') at import

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -4,7 +4,6 @@ import os
 from ophyd.log import set_handler  # noqa: F401
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 cl = None
 

--- a/ophyd/areadetector/__init__.py
+++ b/ophyd/areadetector/__init__.py
@@ -3,7 +3,6 @@
 import logging
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 from .base import *  # noqa: F401, F402, E402, F403
 from .cam import *  # noqa: F401, F402, E402, F403

--- a/ophyd/utils/__init__.py
+++ b/ophyd/utils/__init__.py
@@ -9,7 +9,6 @@ from .epics_pvs import *  # noqa: F401, F403
 from .paths import makedirs, make_dir_tree  # noqa: F401
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 def enum(**enums):

--- a/ophyd/utils/startup.py
+++ b/ophyd/utils/startup.py
@@ -1,7 +1,6 @@
 import logging
 import warnings
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__ = ['setup', 'logger']
 


### PR DESCRIPTION
This PR follows the discussion with @danielballan regarding the default behavior of logging: the default behavior of the logger should be to print all logged messages with levels `warning` and above. Currently, the logger is set to use `NullHandler` at the time of importing Ophyd packages. This results in no log messages printed unless other handers are added, which needs to be done explicitly in the code. 
Changes: the line that adds `NullHandler` is deleted, therefore no handlers are added to the Ophyd logger during import.