### PR TITLE
FIX: mixin classes that have components must inherit from Device

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1205,7 +1205,14 @@ class Device(BlueskyInterface, OphydObject):
             # Initial access of signal
             cpt = self._sig_attrs[attr]
         except KeyError:
-            raise AttributeError(f'Component does not exist: {attr}') from None
+            raise RuntimeError(
+                f'Component {attr!r} exists at the Python level and '
+                'the has triggered the `_instantiate_component` '
+                'code path on Device, but has not been registered with '
+                'the Component management machinery.  This maybe due to '
+                'using multiple inheritance with a mix-in class that defines '
+                'a Component but does not inherent from Device.'
+            ) from None
 
         try:
             self._signals[attr] = cpt.create_component(self)

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1206,10 +1206,10 @@ class Device(BlueskyInterface, OphydObject):
             cpt = self._sig_attrs[attr]
         except KeyError:
             raise RuntimeError(
-                f'Component {attr!r} exists at the Python level and '
-                'the has triggered the `_instantiate_component` '
+                f'The Component {attr!r} exists at the Python level and '
+                'has triggered the `_instantiate_component` '
                 'code path on Device, but has not been registered with '
-                'the Component management machinery.  This maybe due to '
+                'the Component management machinery in Device.  This maybe due to '
                 'using multiple inheritance with a mix-in class that defines '
                 'a Component but does not inherent from Device.'
             ) from None

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1209,7 +1209,7 @@ class Device(BlueskyInterface, OphydObject):
                 f'The Component {attr!r} exists at the Python level and '
                 'has triggered the `_instantiate_component` '
                 'code path on Device, but has not been registered with '
-                'the Component management machinery in Device.  This maybe due to '
+                'the Component management machinery in Device.  This may be due to '
                 'using multiple inheritance with a mix-in class that defines '
                 'a Component but does not inherent from Device.'
             ) from None

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from .signal import (Signal, EpicsSignal, EpicsSignalRO)
 from .device import (Device, Component as Cpt, DynamicDeviceComponent as DDC,
-                     BlueskyInterface, Kind)
+                     Kind)
 from .areadetector import EpicsSignalWithRBV as SignalWithRBV
 
 

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -356,7 +356,7 @@ class Mercury1(EpicsDXPMultiElementSystem):
     mca = Cpt(EpicsMCARecord, 'mca1')
 
 
-class SoftDXPTrigger(BlueskyInterface):
+class SoftDXPTrigger(Device):
     '''Simple soft trigger for DXP devices
 
     Parameters

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -773,3 +773,20 @@ def test_lazy_wait_context(lazy_state, cntx):
         ...
 
     assert d.lazy_wait_for_connection is lazy_state
+
+
+def test_non_Divice_mixin_with_components():
+
+    class Host(Device):
+        a = Component(Signal)
+
+    class MixIn:
+        b = Component(Signal)
+
+    class Target(Host, MixIn):
+        ...
+
+    t = Target(name='target')
+
+    with pytest.raises(RuntimeError):
+        t.b

--- a/ophyd/tests/test_mca.py
+++ b/ophyd/tests/test_mca.py
@@ -4,7 +4,8 @@ import pytest
 from types import SimpleNamespace
 
 from ophyd import EpicsMCA, EpicsDXP
-from ophyd.mca import add_rois
+from ophyd.mca import add_rois, Mercury1, SoftDXPTrigger
+
 from ophyd.utils import enum, ReadOnlyError
 
 from caproto.tests.conftest import run_example_ioc
@@ -142,3 +143,10 @@ def test_dxp_signals(dxp):
         dxp.input_count_rate.put(2)
     with pytest.raises(ReadOnlyError):
         dxp.output_count_rate.put(2)
+
+
+def test_mixin_signals():
+    class Mercury(Mercury1, SoftDXPTrigger):
+        pass
+    mercury = Mercury('Will_Not_Try_To_connect', name='mercury')
+    assert 'count_time' in mercury.component_names


### PR DESCRIPTION
This is likely a side-effect of changing from using a full meta-class
to `__init_subclass__`.