### PR TITLE
Reset status to None when trigger completes.

### DIFF
--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -144,6 +144,7 @@ class SingleTrigger(TriggerBase):
         if (old_value == 1) and (value == 0):
             # Negative-going edge means an acquisition just finished.
             self._status.set_finished()
+            self._status = None
 
 
 class MultiTrigger(TriggerBase):


### PR DESCRIPTION
Review of how triggering works now:

When staged, we set up a subscription to the `self._acquisition_signal` which is removed when we are unstaged. The subscription calls the method `self._acquire_changed`, which operates on the state `self._status`. When `self._status is None`, `self._acquire_changed` becomes a no-op.

It looks like we _intended_ to reset `self._status` to `None` when trigger completed, so that any subsequent calls to `self._acquire_changed` would be a no-op. [But I can't find where we actually _do_ that, so this PR adds it.]

There is another problem here that this PR does not address. It is possible to trigger the device twice without waiting for the first trigger to complete. The result would be that the status object corresponding to the first trigger will never be marked complete. There are a couple ways we could fix that, and all of them involve changing things to an extent that might break some corner case in a subclass in some beamline's profile if we aren't very careful. I propose to defer fixing that until the planned overhaul of triggering generally and stick with this "light touch" partial solution for now.