### PR TITLE
One particular log line in ophyd is too verbose.

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -210,7 +210,7 @@ class Signal(OphydObject):
             Check the value prior to setting it, defaults to False
 
         '''
-        self.log.info(
+        self.log.debug(
             'put(value=%s, timestamp=%s, force=%s, metadata=%s)',
             value, timestamp, force, metadata
         )


### PR DESCRIPTION
This line dominates `bluesky.log` and generated 9 MB of log data in
about a minute at SMI. This should be DEBUG level.