### PR TITLE
Capture num_images as config.

### DIFF
--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -42,6 +42,7 @@ class CamBase(ADBase):
     _default_configuration_attrs = (ADBase._default_configuration_attrs +
                                     ('acquire_time', 'acquire_period',
                                      'model', 'num_exposures', 'image_mode',
+                                     'num_images',
                                      'manufacturer', 'trigger_mode'))
 
     ImageMode = enum(SINGLE=0, MULTIPLE=1, CONTINUOUS=2)


### PR DESCRIPTION
We should have been capturing `num_images`! I notice that we do capture
`num_exposures`, which is a counter of how many images have been acquired so
far, whereas `num_images` is the total that *will* be acquired in this batch.

We might consider removing `num_exposures` to avoid confusion---I don't think it
very useful to capture it.