### PR TITLE
Add way to escape 'Another set in progress'.

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -105,6 +105,8 @@ class Signal(OphydObject):
 
         self._set_thread = None
         self._poison_pill = None
+        self._set_thread_finalizer = None
+
         self._tolerance = tolerance
         # self.tolerance is a property
         self.rtolerance = rtolerance
@@ -296,6 +298,7 @@ class Signal(OphydObject):
                 th = self._set_thread
                 # these two must be in this order to avoid a race condition
                 self._set_thread = None
+                self._set_thread_finalizer = None
                 self._poison_pill = None
                 st._finished(success=success)
                 del th
@@ -313,6 +316,10 @@ class Signal(OphydObject):
         self._set_thread.daemon = True
         self._set_thread.start()
         self._poison_pill = poison_pill
+        self._set_thread_finalizer = None
+        # If we get gc-ed, stop the thread. This helps ensure that the process
+        # exits cleanly without dangling threads.
+        self._set_thread_finalizer = weakref.finalize(self, poison_pill.set)
         return self._status
 
     def clear_set(self):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -325,7 +325,7 @@ class Signal(OphydObject):
         self._poison_pill.set()  # Break the polling loop in set_and_wait.
         self._set_thread.join()  # Wait for that to take effect.
         warnings.warn(
-            "A previous set() operaiton is being ignored. Only this do this "
+            "A previous set() operation is being ignored. Only this do this "
             "when debugging or recovering from a hardware failure.")
 
     @property

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -297,8 +297,11 @@ class Signal(OphydObject):
                 del th
 
         if self._set_thread is not None:
-            raise RuntimeError('Another set() call is still in progress '
-                               f'for {self.name}')
+            raise RuntimeError(
+                f"Another set() call is still in progress for {self.name}. "
+                "If this is due to some transient failure, verify that the "
+                "device is configured the way you expect, and use clear_set() "
+                "to ignore and abandon the previous set() operation.")
 
         st = Status(self)
         self._status = st
@@ -306,6 +309,15 @@ class Signal(OphydObject):
         self._set_thread.daemon = True
         self._set_thread.start()
         return self._status
+
+    def clear_set(self):
+        """
+        Escape 'Another set in progress'.
+        """
+        warnings.warn(
+            "A previous set() operaiton is being ignored. Only this do this "
+            "when debugging or recovering from a hardware failure.")
+        self._set_thread = None
 
     @property
     def value(self):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -104,6 +104,7 @@ class Signal(OphydObject):
         self._destroyed = False
 
         self._set_thread = None
+        self._poison_pill = None
         self._tolerance = tolerance
         # self.tolerance is a property
         self.rtolerance = rtolerance
@@ -263,10 +264,12 @@ class Signal(OphydObject):
             value, timeout, settle_time
         )
 
+        poison_pill = threading.Event()
+
         def set_thread():
             try:
                 set_and_wait(self, value, timeout=timeout, atol=self.tolerance,
-                             rtol=self.rtolerance)
+                             rtol=self.rtolerance, poison_pill=poison_pill)
             except TimeoutError:
                 success = False
                 self.log.warning(
@@ -293,6 +296,7 @@ class Signal(OphydObject):
                 th = self._set_thread
                 # these two must be in this order to avoid a race condition
                 self._set_thread = None
+                self._poison_pill = None
                 st._finished(success=success)
                 del th
 
@@ -308,16 +312,21 @@ class Signal(OphydObject):
         self._set_thread = self.cl.thread_class(target=set_thread)
         self._set_thread.daemon = True
         self._set_thread.start()
+        self._poison_pill = poison_pill
         return self._status
 
     def clear_set(self):
         """
         Escape 'Another set in progress'.
         """
+        if self._poison_pill is None:
+            # Nothing to do
+            return
+        self._poison_pill.set()  # Break the polling loop in set_and_wait.
+        self._set_thread.join()  # Wait for that to take effect.
         warnings.warn(
             "A previous set() operaiton is being ignored. Only this do this "
             "when debugging or recovering from a hardware failure.")
-        self._set_thread = None
 
     @property
     def value(self):

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -268,7 +268,9 @@ def set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
             ttime.sleep(poll_time)
         elif poison_pill.wait(poll_time):
             # This set operation has been abandoned.
-            raise AbandonedSet
+            raise AbandonedSet(
+                f"The signal {signal} was set to {val} but it does not seem "
+                "to have finished. We are no longer watching for it.")
         if poll_time < 0.1:
             poll_time *= 2  # logarithmic back-off
         current_value = signal.get()


### PR DESCRIPTION
See #757. This is one possible approach.

TO DO
- [ ] Needs broad input about whether this is the right way to address #757
- [ ] Needs tests
- [x] As written this leaves a polling thread dangling. To fix that properly, we'd need `set_and_wait` to accept a poison pill `threading.Event` or some other means of signaling that it should stop waiting.