### PR TITLE
Correct documentaiton about SubscriptionStatus callback signature.

### DIFF
--- a/doc/source/status.rst
+++ b/doc/source/status.rst
@@ -148,7 +148,7 @@ is marked finished based on some ophyd event. It reduces this:
        acquire = Component(...)
 
        def trigger(self):
-           def check_value(old_value, value, **kwargs):
+           def check_value(*, old_value, value, **kwargs):
                "Mark status as finished when the acquisition is complete."
                if old_value == 1 and value == 0:
                    status.set_finished()
@@ -172,7 +172,7 @@ to this:
        acquire = Component(...)
 
        def trigger(self):
-           def check_value(old_value, value, **kwargs):
+           def check_value(*, old_value, value, **kwargs):
                "Return True when the acquisition is complete, False otherwise."
                return (old_value == 1 and value == 0)
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -640,7 +640,9 @@ class SubscriptionStatus(DeviceStatus):
 
     callback : callable
         Callback that takes event information and returns a boolean. Signature
-        should be `f(*args, **kwargs)`
+        should be ``f(*, old_value, value, **kwargs)``. The arguments
+        old_value and value will be passed in by keyword, so their order does
+        not matter.
 
     event_type : str, optional
         Name of event type to check whether the device has finished succesfully


### PR DESCRIPTION
When the subscriptions are run, `value` and `old_value` are always passed in by keyword, not positionally. This happens in the ophyd layer and is not dependent on the control layers (pyepics, caproto) so we can be sure of it. Thus, their order does not matter.  This created a recent concern when it was discovered that some callbacks had signature `f(value, old_value, **kwargs)` while other had signature `f(old_value, value, **kwargs)`. The documentation should be clear on this point, and might as well require `f(*, value, old_value, **kwargs)` to be future-proof against some caller than attempts to pass in arguments positionally.