### PR TITLE
Add missing return  value in test IOC.

### DIFF
--- a/ophyd/tests/signal_ioc.py
+++ b/ophyd/tests/signal_ioc.py
@@ -37,6 +37,7 @@ class SignalTestIOC(PVGroup):
     @path.putter
     async def path(self, instance, value):
         await self.path_RBV.write(value=value)
+        return value
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This bug was introduced recently in #749. It was my oversight.