### PR TITLE
WIP - Introduce new FileBase class for use with FilePlugin + detectors that have direct disk write access

### DIFF
--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -61,6 +61,7 @@ __all__ = [
     'Overlay',
     'OverlayPlugin',
     'PluginBase',
+    'FileBase',
     'PosPlugin',
     'ProcessPlugin',
     'PvaPlugin',
@@ -776,10 +777,8 @@ class TransformPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     )
 
 
-class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_type='ADCore'):
+class FileBase:
     _default_suffix = ''
-    _html_docs = ['NDPluginFile.html']
-    _plugin_type = 'NDPluginFile'
     FileWriteMode = enum(SINGLE=0, CAPTURE=1, STREAM=2)
 
     auto_increment = Cpt(SignalWithRBV, 'AutoIncrement', kind='config')
@@ -803,6 +802,12 @@ class FilePlugin(PluginBase, GenerateDatumInterface, version=(1, 9, 1), version_
     write_file = Cpt(SignalWithRBV, 'WriteFile')
     write_message = Cpt(EpicsSignal, 'WriteMessage', string=True)
     write_status = Cpt(EpicsSignal, 'WriteStatus')
+
+
+class FilePlugin(PluginBase, FileBase, GenerateDatumInterface, version=(1, 9, 1), version_type='ADCore'):
+    _default_suffix = ''
+    _html_docs = ['NDPluginFile.html']
+    _plugin_type = 'NDPluginFile'
 
 
 @register_plugin

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -777,7 +777,7 @@ class TransformPlugin(PluginBase, version=(1, 9, 1), version_type='ADCore'):
     )
 
 
-class FileBase:
+class FileBase(Device):
     _default_suffix = ''
     FileWriteMode = enum(SINGLE=0, CAPTURE=1, STREAM=2)
 


### PR DESCRIPTION
This is a work in progress PR that tries to address the issue I described here: https://github.com/bluesky/ophyd/issues/911

Essentially, certain detectors use the typical `NDFile` PVs to perform direct I/O via the vendor API rather than the areaDetector plugins - this is often the case for max-speed modes on high speed detectors (ex. Eiger). As a result, I broke off most of the signals defined by `FilePlugin` into a new `FileBase` class, and had `FilePlugin` extend from it. Then, if detectors need, they could extend the `FileBase` class. 

I am marking this as a WIP, since I would like some feedback, and to perform some real world tests.