### PR TITLE
Enh use monitor

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -264,11 +264,11 @@ class EpicsMotor(Device, PositionerBase):
             success = True
             # Check if we are moving towards the low limit switch
             if self.direction_of_travel.get() == 0:
-                if self.low_limit_switch.get() == 1:
+                if self.low_limit_switch.get(use_monitor=False) == 1:
                     success = False
             # No, we are going to the high limit switch
             else:
-                if self.high_limit_switch.get() == 1:
+                if self.high_limit_switch.get(use_monitor=False) == 1:
                     success = False
 
             # Check the severity of the alarm field after motion is complete.

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -2,11 +2,11 @@ import logging
 
 from .utils.epics_pvs import fmt_time
 
-from .signal import (EpicsSignal, EpicsSignalRO)
+from .signal import EpicsSignal, EpicsSignalRO
 from .utils import DisconnectedError
-from .utils.epics_pvs import (raise_if_disconnected, AlarmSeverity)
+from .utils.epics_pvs import raise_if_disconnected, AlarmSeverity
 from .positioner import PositionerBase
-from .device import (Device, Component as Cpt, required_for_connection)
+from .device import Device, Component as Cpt, required_for_connection
 from .status import wait as status_wait
 from enum import Enum
 
@@ -20,7 +20,7 @@ class HomeEnum(str, Enum):
 
 
 class EpicsMotor(Device, PositionerBase):
-    '''An EPICS motor record, wrapped in a :class:`Positioner`
+    """An EPICS motor record, wrapped in a :class:`Positioner`
 
     Keyword arguments are passed through to the base class, Positioner
 
@@ -39,34 +39,31 @@ class EpicsMotor(Device, PositionerBase):
         The amount of time to wait after moves to report status completion
     timeout : float, optional
         The default timeout to use for motion requests, in seconds.
-    '''
+    """
+
     # position
-    user_readback = Cpt(EpicsSignalRO, '.RBV', kind='hinted',
-                        auto_monitor=True)
-    user_setpoint = Cpt(EpicsSignal, '.VAL', limits=True)
+    user_readback = Cpt(EpicsSignalRO, ".RBV", kind="hinted", auto_monitor=True)
+    user_setpoint = Cpt(EpicsSignal, ".VAL", limits=True, auto_monitor=True)
 
     # calibration dial <-> user
-    user_offset = Cpt(EpicsSignal, '.OFF', kind='config')
-    user_offset_dir = Cpt(EpicsSignal, '.DIR', kind='config')
-    offset_freeze_switch = Cpt(EpicsSignal, '.FOFF', kind='omitted')
-    set_use_switch = Cpt(EpicsSignal, '.SET', kind='omitted')
+    user_offset = Cpt(EpicsSignal, ".OFF", kind="config", auto_monitor=True)
+    user_offset_dir = Cpt(EpicsSignal, ".DIR", kind="config", auto_monitor=True)
+    offset_freeze_switch = Cpt(EpicsSignal, ".FOFF", kind="omitted", auto_monitor=True)
+    set_use_switch = Cpt(EpicsSignal, ".SET", kind="omitted", auto_monitor=True)
 
     # configuration
-    velocity = Cpt(EpicsSignal, '.VELO', kind='config')
-    acceleration = Cpt(EpicsSignal, '.ACCL', kind='config')
-    motor_egu = Cpt(EpicsSignal, '.EGU', kind='config')
+    velocity = Cpt(EpicsSignal, ".VELO", kind="config", auto_monitor=True)
+    acceleration = Cpt(EpicsSignal, ".ACCL", kind="config", auto_monitor=True)
+    motor_egu = Cpt(EpicsSignal, ".EGU", kind="config", auto_monitor=True)
 
     # motor status
-    motor_is_moving = Cpt(EpicsSignalRO, '.MOVN', kind='omitted')
-    motor_done_move = Cpt(EpicsSignalRO, '.DMOV', kind='omitted',
-                          auto_monitor=True)
-    high_limit_switch = Cpt(EpicsSignal, '.HLS', kind='omitted')
-    low_limit_switch = Cpt(EpicsSignal, '.LLS', kind='omitted')
-    high_limit_travel = Cpt(EpicsSignal, '.HLM', kind='omitted',
-                            auto_monitor=True)
-    low_limit_travel = Cpt(EpicsSignal, '.LLM', kind='omitted',
-                           auto_monitor=True)
-    direction_of_travel = Cpt(EpicsSignal, '.TDIR', kind='omitted')
+    motor_is_moving = Cpt(EpicsSignalRO, ".MOVN", kind="omitted", auto_monitor=True)
+    motor_done_move = Cpt(EpicsSignalRO, ".DMOV", kind="omitted", auto_monitor=True)
+    high_limit_switch = Cpt(EpicsSignal, ".HLS", kind="omitted", auto_monitor=True)
+    low_limit_switch = Cpt(EpicsSignal, ".LLS", kind="omitted", auto_monitor=True)
+    high_limit_travel = Cpt(EpicsSignal, ".HLM", kind="omitted", auto_monitor=True)
+    low_limit_travel = Cpt(EpicsSignal, ".LLM", kind="omitted", auto_monitor=True)
+    direction_of_travel = Cpt(EpicsSignal, ".TDIR", kind="omitted", auto_monitor=True)
 
     # commands
     motor_stop = Cpt(EpicsSignal, '.STOP', kind='omitted')

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1166,7 +1166,8 @@ class EpicsSignalBase(Signal):
         '''
         if kwargs:
             warnings.warn('Signal.get no longer takes keyword arguments; '
-                          'These are ignored and will be deprecated.')
+                          'These are ignored and will be deprecated.',
+                          DeprecationWarning)
         if as_string is None:
             as_string = self._string
 
@@ -1592,7 +1593,8 @@ class EpicsSignal(EpicsSignalBase):
         '''
         if kwargs:
             warnings.warn('Signal.get_setpoint no longer takes keyword arguments; '
-                          'These are ignored and will be deprecated.')
+                          'These are ignored and will be deprecated.',
+                          DeprecationWarning)
         if as_string is None:
             as_string = self._string
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -737,10 +737,12 @@ class EpicsSignalBase(Signal):
                        )
                       )
 
-    def __init__(self, read_pv, *, string=False,
+    def __init__(self, read_pv, *,
+                 string=False,
                  auto_monitor=DEFAULT_AUTO_MONITOR,
                  name=None,
-                 metadata=None, all_pvs=None,
+                 metadata=None,
+                 all_pvs=None,
                  timeout=DEFAULT_TIMEOUT,
                  write_timeout=DEFAULT_WRITE_TIMEOUT,
                  connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
@@ -1092,7 +1094,7 @@ class EpicsSignalBase(Signal):
         return (self._metadata['lower_ctrl_limit'],
                 self._metadata['upper_ctrl_limit'])
 
-    def _get_with_timeout(self, pv, timeout, connection_timeout, as_string, form):
+    def _get_with_timeout(self, pv, timeout, connection_timeout, as_string, form, use_monitor):
         """
         Utility method implementing a retry loop for get and get_setpoint
 
@@ -1119,7 +1121,9 @@ class EpicsSignalBase(Signal):
             'pv[%s].get_with_metadata(as_string=%s, form=%s, timeout=%s)',
             pv.pvname, as_string, form, timeout
         )
-        info = pv.get_with_metadata(as_string=as_string, form=form, timeout=timeout)
+        info = pv.get_with_metadata(
+            as_string=as_string, form=form, timeout=timeout, use_monitor=use_monitor
+        )
         self.control_layer_log.debug('pv[%s].get_with_metadata(...) returned', pv.pvname)
 
         if info is None:
@@ -1129,12 +1133,14 @@ class EpicsSignalBase(Signal):
 
         return info
 
-    def get(self, *, as_string=None,
+    def get(self, *,
+            as_string=None,
             timeout=DEFAULT_TIMEOUT,
             connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
             form='time',
+            use_monitor=None,
             **kwargs):
-        '''Get the readback value through an explicit call to EPICS
+        '''Get the readback value through an explicit call to EPICS.
 
         Parameters
         ----------
@@ -1156,12 +1162,20 @@ class EpicsSignalBase(Signal):
             for the connection to complete.
         form : {'time', 'ctrl'}
             PV form to request
+
         '''
+        if kwargs:
+            warnings.warn('Signal.get no longer takes keyword arguments; '
+                          'These are ignored and will be deprecated.')
         if as_string is None:
             as_string = self._string
 
+        if use_monitor is None:
+            use_monitor = self._auto_monitor
+
         info = self._get_with_timeout(
-            self._read_pv, timeout, connection_timeout, as_string, form)
+            self._read_pv, timeout, connection_timeout, as_string, form, use_monitor
+        )
 
         value = info.pop('value')
         if as_string:
@@ -1546,10 +1560,13 @@ class EpicsSignal(EpicsSignalBase):
             raise LimitError('Value {} outside of range: [{}, {}]'
                              .format(value, low_limit, high_limit))
 
-    def get_setpoint(self, *, as_string=None,
+    def get_setpoint(self, *,
+                     as_string=None,
                      timeout=DEFAULT_TIMEOUT,
                      connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
-                     form='time', **kwargs):
+                     use_monitor=None,
+                     form='time',
+                     **kwargs):
         '''Get the setpoint value (if setpoint PV and readback PV differ)
 
         Parameters
@@ -1573,11 +1590,18 @@ class EpicsSignal(EpicsSignalBase):
         form : {'time', 'ctrl'}
             PV form to request
         '''
+        if kwargs:
+            warnings.warn('Signal.get_setpoint no longer takes keyword arguments; '
+                          'These are ignored and will be deprecated.')
         if as_string is None:
             as_string = self._string
 
+        if use_monitor is None:
+            use_monitor = self._auto_monitor
+
         info = self._get_with_timeout(
-            self._write_pv, timeout, connection_timeout, as_string, form)
+            self._write_pv, timeout, connection_timeout, as_string, form, use_monitor
+        )
 
         value = info.pop('value')
         if as_string:


### PR DESCRIPTION
This is code notes from a discussion with @prjemian and @danielballan which does to seperate things:

 - Tell EpicsMotor to automonitor more things (which should drastically speed up `mtr.read_configuration()`
 - re-threads `EpicsSignal.get(..., use_monitor=True)` back through to the control layer layer + sets a per-Signal default (which tracks auto-monitor).