### PR TITLE
EpicsSignal.set() timeout should default to EpicsSignal.timeout

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -888,8 +888,12 @@ class EpicsSignalBase(Signal):
         # properties?
 
     @classmethod
-    def set_default_timeout(cls, *, **kwargs):
-        warnings.warn('Use set_defaults() instead.  Command ignored.')
+    def set_default_timeout(cls, **kwargs):
+        warnings.warn(
+            "set_default_timeout() will be removed "
+            "in a future release. Use set_defaults() instead."
+        )
+        cls.set_defaults(**kwargs)
 
     @property
     def connection_timeout(self):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -287,19 +287,19 @@ class Signal(OphydObject):
             except TimeoutError:
                 success = False
                 self.log.warning(
-                    'set_and_wait(name=%s, value=%s, timeout=%s, atol=%s, rtol=%s)',
+                    '%s: set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
                     self.name, value, timeout, self.tolerance, self.rtolerance
                 )
             except Exception:
                 success = False
                 self.log.exception(
-                    'set_and_wait(name=%s, value=%s, timeout=%s, atol=%s, rtol=%s)',
+                    '%s: set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
                     self.name, value, timeout, self.tolerance, self.rtolerance
                 )
             else:
                 success = True
                 self.log.info(
-                    'set_and_wait(name=%s, value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
+                    '%s: set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
                     self.name, value, timeout, self.tolerance, self.rtolerance, self._readback)
 
                 if settle_time is not None:

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1685,7 +1685,7 @@ class EpicsSignal(EpicsSignalBase):
             self._run_subs(sub_type=self.SUB_SETPOINT, old_value=old_value,
                            value=value, timestamp=timestamp)
 
-    def set(self, value, *, timeout=None, settle_time=None):
+    def set(self, value, *, timeout=DEFAULT_WRITE_TIMEOUT, settle_time=None):
         '''Set is like `EpicsSignal.put`, but is here for bluesky compatibility
 
         If put completion is used for this EpicsSignal, the status object will

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1711,6 +1711,9 @@ class EpicsSignal(EpicsSignalBase):
         --------
         Signal.set
         '''
+        if timeout is None:
+            timeout = self.timeout
+
         if not self._put_complete:
             return super().set(value, timeout=timeout, settle_time=settle_time)
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -816,7 +816,7 @@ class EpicsSignalBase(Signal):
 
     @classmethod
     def set_default_timeout(cls, *, timeout=2.0, connection_timeout=1.0,
-                            write_timeout=None):):
+                            write_timeout=None):
         """
         Set the class-wide defaults for timeouts
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1711,8 +1711,10 @@ class EpicsSignal(EpicsSignalBase):
         --------
         Signal.set
         '''
-        if timeout is None:
-            timeout = self.timeout
+        if timeout is DEFAULT_WRITE_TIMEOUT:
+            timeout = self.write_timeout
+            if timeout is None:
+                timeout = self.timeout
 
         if not self._put_complete:
             return super().set(value, timeout=timeout, settle_time=settle_time)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -887,6 +887,10 @@ class EpicsSignalBase(Signal):
         # TODO Is there a good reason to prohibit setting these three timeout
         # properties?
 
+    @classmethod
+    def set_default_timeout(cls, *, **kwargs):
+        warnings.warn('Use set_defaults() instead.  Command ignored.')
+
     @property
     def connection_timeout(self):
         return self._connection_timeout

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -287,20 +287,20 @@ class Signal(OphydObject):
             except TimeoutError:
                 success = False
                 self.log.warning(
-                    'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
-                    value, timeout, self.tolerance, self.rtolerance
+                    'set_and_wait(name=%s, value=%s, timeout=%s, atol=%s, rtol=%s)',
+                    self.name, value, timeout, self.tolerance, self.rtolerance
                 )
             except Exception:
                 success = False
                 self.log.exception(
-                    'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
-                    value, timeout, self.tolerance, self.rtolerance
+                    'set_and_wait(name=%s, value=%s, timeout=%s, atol=%s, rtol=%s)',
+                    self.name, value, timeout, self.tolerance, self.rtolerance
                 )
             else:
                 success = True
                 self.log.info(
-                    'set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
-                    value, timeout, self.tolerance, self.rtolerance, self._readback)
+                    'set_and_wait(name=%s, value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
+                    self.name, value, timeout, self.tolerance, self.rtolerance, self._readback)
 
                 if settle_time is not None:
                     self.log.info('settling for %d seconds', settle_time)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1716,8 +1716,6 @@ class EpicsSignal(EpicsSignalBase):
         '''
         if timeout is DEFAULT_WRITE_TIMEOUT:
             timeout = self.write_timeout
-            if timeout is None:
-                timeout = self.timeout
 
         if not self._put_complete:
             return super().set(value, timeout=timeout, settle_time=settle_time)


### PR DESCRIPTION
Changes to fix #925.  Expected the `EpicsSignal.set()` method to use the signal's `timeout` attribute.  This PR will make that happen.