### PR TITLE
Adjust signal logging

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -211,7 +211,7 @@ class Signal(OphydObject):
             Check the value prior to setting it, defaults to False
 
         '''
-        self.log.debug(
+        self.control_layer_log.debug(
             'put(value=%s, timestamp=%s, force=%s, metadata=%s)',
             value, timestamp, force, metadata
         )

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1082,12 +1082,12 @@ class EpicsSignalBase(Signal):
                 f"within {connection_timeout:.2f} sec") from err
         # Pyepics returns None when a read request times out.  Raise a
         # TimeoutError on its behalf.
-        self.control_layer_log.info(
+        self.control_layer_log.debug(
             'pv[%s].get_with_metadata(as_string=%s, form=%s, timeout=%s)',
             pv.pvname, as_string, form, timeout
         )
         info = pv.get_with_metadata(as_string=as_string, form=form, timeout=timeout)
-        self.control_layer_log.info('pv[%s].get_with_metadata(...) returned', pv.pvname)
+        self.control_layer_log.debug('pv[%s].get_with_metadata(...) returned', pv.pvname)
 
         if info is None:
             raise ReadTimeoutError(
@@ -1669,7 +1669,7 @@ class EpicsSignal(EpicsSignalBase):
         if not self.write_access:
             raise ReadOnlyError('No write access to underlying EPICS PV')
 
-        self.control_layer_log.info(
+        self.control_layer_log.debug(
             '_write_pv.put(value=%s, use_complete=%s, callback=%s, kwargs=%s)',
             value, use_complete, callback, kwargs
         )

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -138,7 +138,6 @@ class SynSignal(Signal):
             connected=True,
         )
 
-        self.log.info(self)
 
     def describe(self):
         res = super().describe()

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -147,12 +147,9 @@ class SynSignal(Signal):
         return res
 
     def trigger(self):
-        self.log.info('trigger %s', self)
-
         st = DeviceStatus(device=self)
         delay_time = self.exposure_time
         if delay_time:
-            self.log.info('%s delay_time is %d', self, delay_time)
 
             def sleep_and_finish():
                 self.log.info('sleep_and_finish %s', self)

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -138,7 +138,6 @@ class SynSignal(Signal):
             connected=True,
         )
 
-
     def describe(self):
         res = super().describe()
         # There should be only one key here, but for the sake of generality....


### PR DESCRIPTION
Ophyd is very noisy at the INFO logging level, including at import time. In the last week, both Michael Sutherland (a user) and @tacaswell have bumped into this and been thrown by it. Quick comments:

* At beamlines we don't generally put INFO-level logging in the stderr, but it's apparently not uncommon for users or beamline staff to do this, so INFO level (or higher) should be used with discretion.
* The intent of the `control_layer_log` is to do the logging that we _wish_ pyepics did. (Eventually we'll add that pyepics, perhaps.) It's in a separate logger so that it can be separately filtered. In this PR, I move something from `log` to `control_layer_log` and turn the level of all `control_layer_log` calls to DEBUG.
* For some reason `SynSignal` logged aggressively --- including messages to note that `__init__` or `trigger` had been called. I don't think that are very helpful for debugging, so I have removed them. I left logging calls in the callbacks, which are more useful because those are not called directly by the user.