### PR TITLE
Do not log where EventDispatch queues are empty.

### DIFF
--- a/ophyd/_dispatch.py
+++ b/ophyd/_dispatch.py
@@ -142,8 +142,7 @@ class EventDispatcher:
             ]
             if status:
                 debug_monitor_log.debug(' / '.join(status))
-            else:
-                debug_monitor_log.debug('All EventDispatch queues are empty.')
+            # Else, all EventDispatch queues are empty.
             time.sleep(self.debug_monitor_interval)
 
     def __repr__(self):


### PR DESCRIPTION
This removes a log message that I added and have since regretted.

The use of this message is to detect if event-proessing queues
are getting backed up, more or less akin to when caproto logs "high load"
messages. It is not necessary to log "low load"; omission is sufficient.

I added this in the first place because I wanted to ensure that the loop
was _running_ but that kind of debug activity is better handled by prints
as needed and should not have been merged into the main branch.