### PR TITLE
Make default values of set_defaults consistent.

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -824,10 +824,10 @@ class EpicsSignalBase(Signal):
     @classmethod
     def set_defaults(cls,
                      *,
-                     timeout=2.0,
-                     connection_timeout=1.0,
-                     write_timeout=2,
-                     auto_monitor=False):
+                     timeout=__default_timeout,
+                     connection_timeout=__default_connection_timeout,
+                     write_timeout=__default_write_timeout,
+                     auto_monitor=__default_auto_monitor):
         """
         Set class-wide defaults for EPICS CA communications
 
@@ -860,6 +860,12 @@ class EpicsSignalBase(Signal):
             Total time budget (seconds) for reading, not including connection time.
         write_timeout: float, optional
             Time (seconds) allocated for writing, not including connection time.
+            The write_timeout is very different than the connection and read timeouts
+            above. It relates to how long an action takes to complete. Any
+            default value we choose here is likely to cause problems---either
+            by being too short and giving up too early on a lengthy action or
+            being too long and delaying the report of a failure. The default,
+            None, waits forever.
 
         Raises
         ------


### PR DESCRIPTION
The "factory default" of `write_timeout`, set at import time, is `None`. In the signature of `set_defaults(...)` the default value of `write_timeout` is, arbitrarily, `2`. This means that calling

```py
EpicsSignalBase.set_defaults()
```

with no arguments changes the default value of `write_timeout` from `None` to `2`. This doesn't feel right. I have changed the signature to `set_defaults(..., write_timeout=__default_write_timeout)` and so on for the other parameters. That way, if we change the factory defaults someday, everything will stay in sync.

Note that, as usual, the docstring shows the concrete values, so the user can easily see what the default values actually are:

```
In [4]: EpicsSignalBase.set_defaults?
Signature:
EpicsSignalBase.set_defaults(
    *,
    timeout=2.0,
    connection_timeout=1.0,
    write_timeout=None,
    auto_monitor=False,
)
Docstring:
Set class-wide defaults for EPICS CA communications
...
```