### PR TITLE
Interpret num_capture=0 correctly.

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -456,7 +456,15 @@ class FileStoreHDF5(FileStorePluginBase):
                                 ])
 
     def get_frames_per_point(self):
-        return self.num_capture.get()
+        num_capture = self.num_capture.get()
+        # If num_capture is 0, then the plugin will capture however many frames
+        # it is sent. We can get how frames it will be sent (unless
+        # interrupted) by consulting num_images on the detector's camera.
+        if num_capture == 0:
+            return self.parent.cam.num_images.get()
+        # Otherwise, a nonzero num_capture will cut off capturing at the
+        # specified number.
+        return num_capture
 
     def stage(self):
         super().stage()


### PR DESCRIPTION
As explained in the comment, the `FileStoreHDF5` class has been recording its `num_capture` signal as the number of frames that will be captures for a given acquisition. The _correct_ behavior is to interpret `num_capture=0` as a special case because that means "Capture as many as you receive." In that case, our best guess (really an upper bound) is `num_images` from the detector's camera.

Closes #934 