### PR TITLE
Resolve TypeError when using EpicsSignalBase.set_defaults()

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = 'pytester'

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1222,6 +1222,10 @@ class EpicsSignalBase(Signal):
         metadata = self._metadata_changed(self.pvname, kwargs, update=False,
                                           require_timestamp=True,
                                           from_monitor=True)
+
+        if self._string and "char_value" in kwargs:
+            value = kwargs["char_value"]
+
         # super().put updates self._readback and runs SUB_VALUE
         super().put(value=value, timestamp=metadata.pop('timestamp'),
                     metadata=metadata, force=True)

--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -11,7 +11,6 @@ from ophyd.utils.epics_pvs import (AlarmSeverity, AlarmStatus)
 
 logger = logging.getLogger(__name__)
 
-pytest_plugins = 'pytester'
 
 @pytest.fixture()
 def hw(tmpdir):

--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -11,6 +11,7 @@ from ophyd.utils.epics_pvs import (AlarmSeverity, AlarmStatus)
 
 logger = logging.getLogger(__name__)
 
+pytest_plugins = 'pytester'
 
 @pytest.fixture()
 def hw(tmpdir):

--- a/ophyd/tests/test_issue944.py
+++ b/ophyd/tests/test_issue944.py
@@ -1,0 +1,176 @@
+"""Issue 944:  TypeError: No conversion path for dtype: dtype('<U1')."""
+
+from .config import motor_recs
+
+pv_base = motor_recs[0]
+
+
+def run_test_code(testdir, code):
+    testdir.makepyfile(code)
+    result = testdir.runpytest_subprocess()
+    result.stdout.fnmatch_lines(["* 1 passed in *"])
+
+
+def test_local_without_defaults_no_string(testdir):
+    from ophyd import EpicsSignal
+
+    signal = EpicsSignal(f"{pv_base}.SCAN", name="signal")
+    signal.wait_for_connection()
+    desc = signal.describe()
+    assert not signal.as_string
+    assert desc["signal"]["dtype"] == "integer"
+
+
+def test_without_defaults_no_string(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal")
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert not signal.as_string
+        assert desc["signal"]["dtype"] == "integer"
+    """ % pv_base)
+
+
+def test_without_defaults_as_string(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal", string=True)
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert signal.as_string
+        assert desc["signal"]["dtype"] == "string"
+    """ % pv_base)
+
+
+def test_with_all_defaults_no_string(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+    from ophyd.signal import EpicsSignalBase
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        EpicsSignalBase.set_defaults(
+            auto_monitor=True,
+            connection_timeout=1,
+            timeout=60,
+            write_timeout=60,
+        )
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal")
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert not signal.as_string
+        assert desc["signal"]["dtype"] == "integer"
+    """ % pv_base)
+
+
+def test_with_all_defaults_as_string(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+    from ophyd.signal import EpicsSignalBase
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        EpicsSignalBase.set_defaults(
+            auto_monitor=True,
+            connection_timeout=1,
+            timeout=60,
+            write_timeout=60,
+        )
+
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal", string=True)
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert signal.as_string
+        assert desc["signal"]["dtype"] == "string"
+    """ % pv_base)
+
+
+def test_with_all_defaults_auto_monitor(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+    from ophyd.signal import EpicsSignalBase
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        EpicsSignalBase.set_defaults(
+            auto_monitor=True,
+        )
+
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal", string=True)
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert signal.as_string
+        assert desc["signal"]["dtype"] == "string"
+    """ % pv_base)
+
+
+def test_with_all_defaults_connection_timeout(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+    from ophyd.signal import EpicsSignalBase
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        EpicsSignalBase.set_defaults(
+            connection_timeout=1,
+        )
+
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal", string=True)
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert signal.as_string
+        assert desc["signal"]["dtype"] == "string"
+    """ % pv_base)
+
+
+def test_with_all_defaults_timeout(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+    from ophyd.signal import EpicsSignalBase
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        EpicsSignalBase.set_defaults(
+            timeout=60,
+        )
+
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal", string=True)
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert signal.as_string
+        assert desc["signal"]["dtype"] == "string"
+    """ % pv_base)
+
+
+def test_with_all_defaults_write_timeout(testdir):
+    run_test_code(testdir, """
+    from ophyd import EpicsSignal
+    from ophyd.signal import EpicsSignalBase
+
+    pv_base = "%s"
+
+    def test_without_defaults_no_string():
+        EpicsSignalBase.set_defaults(
+            write_timeout=60,
+        )
+
+        signal = EpicsSignal(f"{pv_base}.SCAN", name="signal", string=True)
+        signal.wait_for_connection()
+        desc = signal.describe()
+        assert signal.as_string
+        assert desc["signal"]["dtype"] == "string"
+    """ % pv_base)

--- a/ophyd/tests/test_issue944.py
+++ b/ophyd/tests/test_issue944.py
@@ -1,4 +1,15 @@
-"""Issue 944:  TypeError: No conversion path for dtype: dtype('<U1')."""
+"""
+Issue 944:  TypeError: No conversion path for dtype: dtype('<U1').
+
+Since the tests include different configurations of
+EpicsSignalBase.set_defaults(), and that code must be called
+before creating any instance of EpicsSignalBase (or subclasses),
+most tests need to be run as a separate process.
+
+Needs this set in the top-most conftest.py file to enable 'testdir':
+
+    echo "pytest_plugins = 'pytester'" >> conftest.py
+"""
 
 from .config import motor_recs
 


### PR DESCRIPTION
EpicsSignal with `string=True` kwarg should result in `dtype='string'` from `.describe()` method, to fix #944.