### PR TITLE
MNT: motor record limits switch states are read-only

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -59,8 +59,8 @@ class EpicsMotor(Device, PositionerBase):
     # motor status
     motor_is_moving = Cpt(EpicsSignalRO, ".MOVN", kind="omitted", auto_monitor=True)
     motor_done_move = Cpt(EpicsSignalRO, ".DMOV", kind="omitted", auto_monitor=True)
-    high_limit_switch = Cpt(EpicsSignal, ".HLS", kind="omitted", auto_monitor=True)
-    low_limit_switch = Cpt(EpicsSignal, ".LLS", kind="omitted", auto_monitor=True)
+    high_limit_switch = Cpt(EpicsSignalRO, ".HLS", kind="omitted", auto_monitor=True)
+    low_limit_switch = Cpt(EpicsSignalRO, ".LLS", kind="omitted", auto_monitor=True)
     high_limit_travel = Cpt(EpicsSignal, ".HLM", kind="omitted", auto_monitor=True)
     low_limit_travel = Cpt(EpicsSignal, ".LLM", kind="omitted", auto_monitor=True)
     direction_of_travel = Cpt(EpicsSignal, ".TDIR", kind="omitted", auto_monitor=True)


### PR DESCRIPTION
Very small thing I noticed today: `HLS` and `LLS` use `EpicsSignal` when they should be using `EpicsSignalRO`. This was found when `typhos` confusingly decided to make writable widgets for limit hit state.

Ref: https://epics.anl.gov/bcda/synApps/motor/motorRecord.html#Fields_limit