### PR TITLE
Update MockFlyer in sim.py to return self.name in describe_collect

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -765,7 +765,7 @@ class MockFlyer:
         dd = dict()
         dd.update(self._mot.describe())
         dd.update(self._detector.describe())
-        return {'stream_name': dd}
+        return {self.name: dd}
 
     def complete(self):
         if self._completion_status is None:


### PR DESCRIPTION
Return `self.name`(instead of 'stream_name')  in MockFlyer `describe_collect` method. This will show the flyer name and prevent ambiguation when running multiple flyers.