### PR TITLE
Properly propagate connection_timeout from .set_defaults()

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1061,8 +1061,10 @@ class EpicsSignalBase(Signal):
             raise TimeoutError(f'Control layer {self.cl.name} failed to send connection and '
                                f'access rights information within {float(timeout):.1f} sec')
 
-    def wait_for_connection(self, timeout=1.0):
+    def wait_for_connection(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
         '''Wait for the underlying signals to initialize or connect'''
+        if timeout is DEFAULT_CONNECTION_TIMEOUT:
+            timeout = self.connection_timeout
         try:
             self._ensure_connected(self._read_pv, timeout=timeout)
         except TimeoutError:
@@ -1485,8 +1487,10 @@ class EpicsSignal(EpicsSignalBase):
 
         return super().subscribe(callback, event_type=event_type, run=run)
 
-    def wait_for_connection(self, timeout=1.0):
+    def wait_for_connection(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
         '''Wait for the underlying signals to initialize or connect'''
+        if timeout is DEFAULT_CONNECTION_TIMEOUT:
+            timeout = self.connection_timeout
         self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
 
     @property


### PR DESCRIPTION
## Problem

We struggled quite a lot for the last couple of days of the deployment at NSLS-II, as it wasn't possible to set the connection timeouts using [`.set_defaults()`](https://github.com/bluesky/ophyd/pull/926). The monkey-patch we ended up applying was https://github.com/NSLS-II-ESM-1/profile_collection/blob/b7a67bdf181089836bd52764cf2f691b62339c3a/startup/01-base.py#L3-L27. This PR should provide a proper fix.

## Testing

The connection timeout was set via:
```py
EpicsSignalBase.set_defaults(connection_timeout=0.5)
```
in an IPython startup file.

### Before the fix
Used ophyd 1.6.0:
```py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/02-olog_templates.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/03-olog_integration.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/10-machine.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/11-undulator.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/20-motors.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/30-detectors.py
[TerminalIPythonApp] WARNING | Unknown error in handling startup files:
KeyError: 'mean_value'

During handling of the above exception, another exception occurred:
TimeoutError: Control layer pyepics failed to send connection and access rights information within 1.0 sec

...

%tb verbose
...
/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/ophyd/signal.py in wait_for_connection(self=EpicsSignalWithRBV(read_pv='XF:21IDA-BI{EM:1}EM1...nt1:MeanValue', limits=False, put_complete=False), timeout=1.0)
   1488     def wait_for_connection(self, timeout=1.0):
   1489         '''Wait for the underlying signals to initialize or connect'''
-> 1490         self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
        self._ensure_connected = <bound method EpicsSignalBase._ensure_connected of EpicsSignalWithRBV(read_pv='XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV', name='qem01_current1_mean_value', parent='qem01_current1', timestamp=1610503393.0816894, auto_monitor=False, string=False, write_pv='XF:21IDA-BI{EM:1}EM180:Current1:MeanValue', limits=False, put_complete=False)>
        self._read_pv = <PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV', count=1, type=time_double, access=read/write>
        self._write_pv = <PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue', count=1, type=time_double, access=read/write>
        timeout = 1.0
   1491
   1492     @property

/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/ophyd/signal.py in _ensure_connected(self=EpicsSignalWithRBV(read_pv='XF:21IDA-BI{EM:1}EM1...nt1:MeanValue', limits=False, put_complete=False), timeout=1.0, *pvs=(<PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV', count=1, type=time_double, access=read/write>, <PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue', count=1, type=time_double, access=read/write>))
   1059         # @raise_if_disconnected can cause issues otherwise.
   1060         if not self._signal_is_ready.wait(timeout):
-> 1061             raise TimeoutError(f'Control layer {self.cl.name} failed to send connection and '
        global TimeoutError = undefined
   1062                                f'access rights information within {float(timeout):.1f} sec')
   1063

TimeoutError: Control layer pyepics failed to send connection and access rights information within 1.0 sec
```


### After the fix

Tested on the NSLS-II ESM beamline in a conda env with the source installed PR branch, :
```py
...
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/02-olog_templates.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/03-olog_integration.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/10-machine.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/11-undulator.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/20-motors.py
[TerminalIPythonApp] Running file in user namespace: /home/mrakitin/.ipython/profile_collection/startup/30-detectors.py
[TerminalIPythonApp] WARNING | Unknown error in handling startup files:
KeyError: 'mean_value'

During handling of the above exception, another exception occurred:
TimeoutError: XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV could not connect within 0.5-second timeout.

...

%tb verbose
...
~/src/NSLS-II/ophyd/ophyd/signal.py in wait_for_connection(self=EpicsSignalWithRBV(read_pv='XF:21IDA-BI{EM:1}EM1...nt1:MeanValue', limits=False, put_complete=False), timeout=0.5)
   1492         if timeout is DEFAULT_CONNECTION_TIMEOUT:
   1493             timeout = self.connection_timeout
-> 1494         self._ensure_connected(self._read_pv, self._write_pv, timeout=timeout)
        self._ensure_connected = <bound method EpicsSignalBase._ensure_connected of EpicsSignalWithRBV(read_pv='XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV', name='qem01_current1_mean_value', parent='qem01_current1', timestamp=631152000.0, auto_monitor=False, string=False, write_pv='XF:21IDA-BI{EM:1}EM180:Current1:MeanValue', limits=False, put_complete=False)>
        self._read_pv = <PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV', count=1, type=time_double, access=read/write>
        self._write_pv = <PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue', count=1, type=time_double, access=read/write>
        timeout = 0.5
   1495
   1496     @property

~/src/NSLS-II/ophyd/ophyd/signal.py in _ensure_connected(self=EpicsSignalWithRBV(read_pv='XF:21IDA-BI{EM:1}EM1...nt1:MeanValue', limits=False, put_complete=False), timeout=0.5, *pvs=(<PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV', count=1, type=time_double, access=read/write>, <PV 'XF:21IDA-BI{EM:1}EM180:Current1:MeanValue', count=1, type=time_double, access=read/write>))
   1044         for pv in pvs:
   1045             if not pv.wait_for_connection(timeout=timeout):
-> 1046                 raise TimeoutError(f"{pv.pvname} could not connect within "
        global TimeoutError = undefined
   1047                                    f"{float(timeout):.3}-second timeout.")
   1048

TimeoutError: XF:21IDA-BI{EM:1}EM180:Current1:MeanValue_RBV could not connect within 0.5-second timeout.
```