### PR TITLE
Add optional debug info to ophydobj with inspect

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -1,3 +1,4 @@
+import os
 from enum import IntFlag
 import functools
 from itertools import count
@@ -6,6 +7,11 @@ import time
 import weakref
 
 from .log import control_layer_logger
+
+
+OPHYD_DEBUG_WITH_INSPECT = os.getenv('OPHYD_DEBUG_WITH_INSPECT')
+if OPHYD_DEBUG_WITH_INSPECT:
+    import inspect
 
 
 def select_version(cls, version):
@@ -136,6 +142,10 @@ class OphydObject:
 
     def __init__(self, *, name=None, attr_name='', parent=None, labels=None,
                  kind=None):
+
+        if OPHYD_DEBUG_WITH_INSPECT:
+            self._stack_init = inspect.stack()
+
         if labels is None:
             labels = set()
         self._ophyd_labels_ = set(labels)
@@ -216,6 +226,11 @@ class OphydObject:
     def __init_subclass__(cls, version=None, version_of=None,
                           version_type=None, **kwargs):
         'This is called automatically in Python for all subclasses of OphydObject'
+
+        if OPHYD_DEBUG_WITH_INSPECT:
+            print(f'Subclassing {cls.__name__}...')
+            cls._stack_subclass = inspect.stack()
+
         super().__init_subclass__(**kwargs)
 
         if version is None:


### PR DESCRIPTION
I am looking for a quick way to extract the information from what file an ophyd object was instantiated, and where its source code is. It can be done with `inspect.stack()`. It causes performance issues within `__init__subclass__`, so I decided to make it optional, enabled via an environment variable `OPHYD_DEBUG_WITH_INSPECT`.  That can be useful for debugging.

### Usage:
```
$ OPHYD_DEBUG_WITH_INSPECT=1 ipython --profile=collection --IPCompleter.use_jedi=False
...
In [1]: my_dev._stack_init
Out[1]:
[FrameInfo(frame=<frame at 0x7f48a8839050, file '/nsls2/users/mrakitin/src/ophyd/ophyd/ophydobj.py', line 189, code __init__>, filename='/nsls2/users/mrakitin/src/ophyd/ophyd/ophydobj.py', lineno=147, function='__init__', code_context=['            self._stack_init = inspect.stack()\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48a8aad5c0, file '/nsls2/users/mrakitin/src/ophyd/ophyd/device.py', line 414, code __init__>, filename='/nsls2/users/mrakitin/src/ophyd/ophyd/device.py', lineno=414, function='__init__', code_context=['        super().__init__(*args, **kwargs)\n'], index=0),
 FrameInfo(frame=<frame at 0x561316695e50, file '/nsls2/users/mrakitin/src/ophyd/ophyd/device.py', line 759, code __init__>, filename='/nsls2/users/mrakitin/src/ophyd/ophyd/device.py', lineno=725, function='__init__', code_context=['        super().__init__(name=name, parent=parent, kind=kind, **kwargs)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48a8825c20, file '/nsls2/users/mrakitin/.ipython/profile_collection/startup/01-devices.py', line 3, code <module>>, filename='/nsls2/users/mrakitin/.ipython/profile_collection/startup/01-devices.py', lineno=3, function='<module>', code_context=["my_dev = MyDev('', name='my_dev')\n"], index=0),
 FrameInfo(frame=<frame at 0x7f48a8879c50, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/utils/py3compat.py', line 168, code execfile>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/utils/py3compat.py', lineno=168, function='execfile', code_context=["        exec(compiler(f.read(), fname, 'exec'), glob, loc)\n"], index=0),
 FrameInfo(frame=<frame at 0x5613156e9990, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/interactiveshell.py', line 2762, code safe_execfile>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/interactiveshell.py', lineno=2742, function='safe_execfile', code_context=['                    self.compile if shell_futures else None)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48a8879a50, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', line 382, code _exec_file>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', lineno=380, function='_exec_file', code_context=['                                                 raise_exceptions=True)\n'], index=0),
 FrameInfo(frame=<frame at 0x5613157b1a20, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', line 412, code _run_startup_files>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', lineno=409, function='_run_startup_files', code_context=['                self._exec_file(fname)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48de45a810, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', line 333, code init_code>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', lineno=318, function='init_code', code_context=['        self._run_startup_files()\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48dee48210, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/terminal/ipapp.py', line 323, code initialize>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/terminal/ipapp.py', lineno=323, function='initialize', code_context=['        self.init_code()\n'], index=0),
 FrameInfo(frame=<frame at 0x5613153d4370, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', line 87, code catch_config_error>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', lineno=87, function='catch_config_error', code_context=['        return method(app, *args, **kwargs)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48dee1fad0, file '<decorator-gen-113>', line 2, code initialize>, filename='<decorator-gen-113>', lineno=2, function='initialize', code_context=None, index=None),
 FrameInfo(frame=<frame at 0x56131559a2f0, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', line 664, code launch_instance>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', lineno=663, function='launch_instance', code_context=['        app.initialize(argv)\n'], index=0),
 FrameInfo(frame=<frame at 0x5613156a15f0, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/__init__.py', line 126, code start_ipython>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/__init__.py', lineno=126, function='start_ipython', code_context=['    return launch_new_instance(argv=argv, **kwargs)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48e09cc450, file '/opt/conda_envs/collection-2021-1.0/bin/ipython', line 11, code <module>>, filename='/opt/conda_envs/collection-2021-1.0/bin/ipython', lineno=11, function='<module>', code_context=['    sys.exit(start_ipython())\n'], index=0)]

In [2]: my_dev._stack_subclass
Out[2]:
[FrameInfo(frame=<frame at 0x561316695880, file '/nsls2/users/mrakitin/src/ophyd/ophyd/ophydobj.py', line 241, code __init_subclass__>, filename='/nsls2/users/mrakitin/src/ophyd/ophyd/ophydobj.py', lineno=232, function='__init_subclass__', code_context=['            cls._stack_subclass = inspect.stack()\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48a8833050, file '/nsls2/users/mrakitin/src/ophyd/ophyd/device.py', line 839, code __init_subclass__>, filename='/nsls2/users/mrakitin/src/ophyd/ophyd/device.py', lineno=838, function='__init_subclass__', code_context=['        super().__init_subclass__(**kwargs)\n'], index=0),
 FrameInfo(frame=<frame at 0x5613157ae7e0, file '/nsls2/users/mrakitin/.ipython/profile_collection/startup/00-base.py', line 6, code <module>>, filename='/nsls2/users/mrakitin/.ipython/profile_collection/startup/00-base.py', lineno=6, function='<module>', code_context=['class MyDev(Device):\n'], index=0),
 FrameInfo(frame=<frame at 0x5613157c7f60, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/utils/py3compat.py', line 168, code execfile>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/utils/py3compat.py', lineno=168, function='execfile', code_context=["        exec(compiler(f.read(), fname, 'exec'), glob, loc)\n"], index=0),
 FrameInfo(frame=<frame at 0x5613157a9850, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/interactiveshell.py', line 2762, code safe_execfile>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/interactiveshell.py', lineno=2742, function='safe_execfile', code_context=['                    self.compile if shell_futures else None)\n'], index=0),
 FrameInfo(frame=<frame at 0x5613156ffad0, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', line 382, code _exec_file>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', lineno=380, function='_exec_file', code_context=['                                                 raise_exceptions=True)\n'], index=0),
 FrameInfo(frame=<frame at 0x5613157b1a20, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', line 412, code _run_startup_files>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', lineno=409, function='_run_startup_files', code_context=['                self._exec_file(fname)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48de45a810, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', line 333, code init_code>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/core/shellapp.py', lineno=318, function='init_code', code_context=['        self._run_startup_files()\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48dee48210, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/terminal/ipapp.py', line 323, code initialize>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/terminal/ipapp.py', lineno=323, function='initialize', code_context=['        self.init_code()\n'], index=0),
 FrameInfo(frame=<frame at 0x5613153d4370, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', line 87, code catch_config_error>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', lineno=87, function='catch_config_error', code_context=['        return method(app, *args, **kwargs)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48dee1fad0, file '<decorator-gen-113>', line 2, code initialize>, filename='<decorator-gen-113>', lineno=2, function='initialize', code_context=None, index=None),
 FrameInfo(frame=<frame at 0x56131559a2f0, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', line 664, code launch_instance>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/traitlets/config/application.py', lineno=663, function='launch_instance', code_context=['        app.initialize(argv)\n'], index=0),
 FrameInfo(frame=<frame at 0x5613156a15f0, file '/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/__init__.py', line 126, code start_ipython>, filename='/opt/conda_envs/collection-2021-1.0/lib/python3.7/site-packages/IPython/__init__.py', lineno=126, function='start_ipython', code_context=['    return launch_new_instance(argv=argv, **kwargs)\n'], index=0),
 FrameInfo(frame=<frame at 0x7f48e09cc450, file '/opt/conda_envs/collection-2021-1.0/bin/ipython', line 11, code <module>>, filename='/opt/conda_envs/collection-2021-1.0/bin/ipython', lineno=11, function='<module>', code_context=['    sys.exit(start_ipython())\n'], index=0)]
```

```bash
$ cat ~/.ipython/profile_collection/startup/00-base.py
print(f'Loading {__file__}...')

from ophyd import Device, Signal, Component as Cpt


class MyDev(Device):
    sig = Cpt(Signal)
```

```bash
$ cat ~/.ipython/profile_collection/startup/01-devices.py
print(f'Loading {__file__}...')

my_dev = MyDev('', name='my_dev')
```