### PR TITLE
MNT #964 apply consistency to update_rate & auto_count_update_rate

### DIFF
--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -48,8 +48,8 @@ class EpicsScaler(Device):
     gates = DDCpt(_scaler_fields(EpicsSignal, 'gate', '.G', range(1, 33),
                                  kind=Kind.omitted))
 
-    update_rate = Cpt(EpicsSignal, '.RATE', kind=Kind.config)
-    auto_count_update_rate = Cpt(EpicsSignal, '.RAT1', kind=Kind.config)
+    update_rate = Cpt(EpicsSignal, '.RATE', kind=Kind.omitted)
+    auto_count_update_rate = Cpt(EpicsSignal, '.RAT1', kind=Kind.omitted)
 
     egu = Cpt(EpicsSignal, '.EGU', kind=Kind.config)
 


### PR DESCRIPTION
For the scaler attributes `update_rate` & `auto_count_update_rate`, apply consistency to the setting of their `kind` kwarg.  Per discussion, this change will close #964, applying `omitted` to creation of these attributes.

Affects `EpicsScaler and `ScalerCH` classes.