### PR TITLE
FIX: protect against a failed reading in set_and_wait

### DIFF
--- a/ophyd/tests/test_utils.py
+++ b/ophyd/tests/test_utils.py
@@ -107,3 +107,19 @@ def test_array_into_softsignal():
     s = Signal(name='np.array')
     set_and_wait(s, data)
     assert np.all(s.get() == data)
+
+
+def test_none_signal():
+    import itertools
+
+    class CycleSignal(Signal):
+        def __init__(self, *args, value_cycle, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._value_cycle = itertools.cycle(value_cycle)
+
+        def get(self):
+            return next(self._value_cycle)
+
+    cs = CycleSignal(name='cycle', value_cycle=[0, 1, 2, None, 4])
+
+    set_and_wait(cs, 4, rtol=.01, atol=.01)

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -253,8 +253,10 @@ def set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
     else:
         within_str = ''
 
-    while not _compare_maybe_enum(val, current_value, enum_strings, atol,
-                                  rtol):
+    while (
+        current_value is None or
+        not _compare_maybe_enum(val, current_value, enum_strings, atol, rtol)
+    ):
         logger.debug("Waiting for %s to be set from %r to %r%s...",
                      signal.name, current_value, val, within_str)
         ttime.sleep(poll_time)


### PR DESCRIPTION
If `signal.get` returns None (which pyepics will sometimes do) and tolerances
are in use, passing `None` through to numpy will cause numpy to choke.

We were already implicitly re-trying in the non-tolerance case.

Encountered this in the wild at PDF over the weekend.