### PR TITLE
Add simple script for helping generate boilerplate detector and cam classes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+inflection
 networkx>=2.0
 numpy
-inflection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 networkx>=2.0
 numpy
+inflection

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -12,7 +12,7 @@ def write_detector_class(boilerplate_file, dev_name, det_name, cam_name):
 
     Parameters
     ----------
-    boilerplate_file : TextIOWrapper
+    boilerplate_file : io.TextIOWrapper
         Open temporary file for writing boilerplate
     dev_name : str
         Name of device type/make. Ex. PICam, Eiger, etc.

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -2,8 +2,6 @@
 
 import argparse
 import os
-import re
-import sys
 import inflection
 import logging
 
@@ -88,7 +86,7 @@ def parse_pv_structure(driver_dir):
                 # identify any lines that start with 'record'
                 if line.startswith('record'):
                     # Get the name of the PV.
-                    # Ex: 
+                    # Ex:
                     # record(stringin, "$(P)$(R)Description_RBV") Splits into
                     # ['record(stringin, "$(P', '$(R', 'Description_RBV"', '']
                     # The PV name is the 3rd element, so array index 2, and we remove the last character, '"'
@@ -166,7 +164,7 @@ class {cam_name}(CamBase{file_base}):
 
         # Generate attribute name from PV name. Uses inflection library
         attribute_name = inflection.underscore(pv_name)
-        #attribute_name = re.sub('(?<!^)(?=[A-Z])', '_', pv_name).lower()
+        # attribute_name = re.sub('(?<!^)(?=[A-Z])', '_', pv_name).lower()
         boilerplate_file.write(f"    {attribute_name} = ADCpt({pv_to_signal_mapping[pv]}, '{pv}')\n")
 
 

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -96,7 +96,7 @@ def write_cam_class(boilerplate_file, pv_to_signal_mapping, include_file_base, d
     This works in most cases, but may require minor edits to certain names.
 
     Examples:
-    
+
     EnableCallbacks -> enable_callbacks
     EVTLoadGainFile -> e_v_t_load_gain_file
     """
@@ -116,7 +116,7 @@ class {cam_name}(CamBase{file_base}):
     )
 ''')
 
-    # Write appropriate attribute for 
+    # Write appropriate attribute for
     for pv in pv_to_signal_mapping.keys():
         pv_name = pv
         if pv_name.endswith('_RBV'):

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -10,7 +10,7 @@ import logging
 def write_detector_class(tempfile, dev_name, det_name, cam_name):
 
     tempfile.write(
-f'''
+        f'''
 class {det_name}(DetectorBase):
     _html_docs = ['{dev_name}Doc.html']
     cam = C(cam.{cam_name}, 'cam1:')
@@ -24,7 +24,7 @@ def parse_pv_structure(driver_dir):
             template_dir = os.path.join(template_dir, dir, 'Db')
             break
     logging.debug(f'Found template dir: {template_dir}')
-    
+
     template_files = []
     for file in os.listdir(template_dir):
         if file.endswith('.template'):
@@ -36,7 +36,7 @@ def parse_pv_structure(driver_dir):
     for file in template_files:
         logging.debug(f'Collecting pv info from {os.path.basename(file)}')
         fp = open(file, 'r')
-        
+
         lines = fp.readlines()
         for line in lines:
             if line.startswith('include "NDFile.template"'):
@@ -66,7 +66,7 @@ def write_cam_class(tempfile, driver_template, include_file, dev_name, det_name,
     if include_file:
         file = ', FileBase'
     tempfile.write(
-f'''
+        f'''
 class {cam_name}(CamBase{file}):
     _html_docs = ['{dev_name}Doc.html']
     _default_configuration_attrs = (
@@ -75,15 +75,18 @@ class {cam_name}(CamBase{file}):
 ''')
 
     for pv in driver_template.keys():
-        pv_var_name = re.sub( '(?<!^)(?=[A-Z])', '_', pv ).lower()
+        pv_name = pv
+        if pv_name.endswith('_RBV'):
+            pv_name = pv[:-4]
+        pv_var_name = re.sub('(?<!^)(?=[A-Z])', '_', pv_name).lower()
         tempfile.write(f"    {pv_var_name} = ADCpt({driver_template[pv]}, '{pv}')\n")
-
 
 
 def parse_args():
 
     parser = argparse.ArgumentParser(description='Utility for creating boilerplate ophyd classes')
-    parser.add_argument('-t', '--target', help='Location of locally installed areaDetector driver folder structure.')
+    parser.add_argument(
+        '-t', '--target', help='Location of locally installed areaDetector driver folder structure.')
     parser.add_argument('-d', '--debug', action='store_true', help='Enable debug loogging for the script.')
 
     args = vars(parser.parse_args())
@@ -110,7 +113,8 @@ if __name__ == '__main__':
 
     driver_name = os.path.basename(driver_dir)
     if not driver_name.startswith('AD'):
-        logging.error(f'Specified driver directory {driver_name} could not be identified as an areaDetector driver!')
+        logging.error(
+            f'Specified driver directory {driver_name} could not be identified as an areaDetector driver!')
         exit(-1)
 
     dev_name = driver_name[2:]

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -38,6 +38,18 @@ def parse_pv_structure(driver_dir):
     to the appropriate EPICS signal class in ophyd
 
     Also determines if the Cam class should extend the FileBase class as well.
+
+    Parameters
+    ----------
+    driver_dir : PathLike
+        Path to the areaDetector driver
+
+    Returns
+    -------
+    pv_to_signal_mapping : dict
+        Dict mapping PVs to the EPICS signal they fall under
+    include_file_base : bool
+        True if the NDFile.template file is included, otherwise False
     """
 
     # Find the template directory following the standard areaDetector project format
@@ -107,15 +119,28 @@ def write_cam_class(boilerplate_file, pv_to_signal_mapping, include_file_base, d
     Function that writes the boilerplate cam class. This includes the default configuration
     attributes, along with all the attributes extracted from the template file.
 
-    This function is not perfect, as extracting a good attribute name from a PV name is not
-    always straightforward, since PV names are far from standard. Currently, the solution simply
-    adds an _ character before any capital letter, and then makes everything lowercase.
-    This works in most cases, but may require minor edits to certain names.
+    This function uses the inflection library's `underscore` function to convert a PV name
+    into an attribute name
 
     Examples:
 
     EnableCallbacks -> enable_callbacks
-    EVTLoadGainFile -> e_v_t_load_gain_file
+    EVTLoadGainFile -> evt_load_gain_file
+
+    Parameters
+    ----------
+    boilerplate_file : io.TextIOWrapper
+        Open boilerplate file
+    pv_to_signal_mapping : dict
+        Dictionary mapping PVs to the EPICS signal they fall under
+    include_file_base : bool
+        If true, we extend the FileBase class, otherwise we don't
+    dev_name : str
+        Name of device type/make. Ex. PICam, Eiger, etc.
+    det_name : str
+        Name of detector class, ex. PICamDetector, EigerDetector, etc.
+    cam_name : str
+        Name of cam class, ex. PICamDetectorCam, EigerDetectorCam, etc.
     """
 
     # Extend from FileBase class as well if necessary

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -100,6 +100,7 @@ def parse_args():
 
 if __name__ == '__main__':
 
+    print()
     driver_dir, log_level = parse_args()
     if not os.path.exists(driver_dir) or not os.path.isdir(driver_dir):
         logging.error(f'Input {driver_dir} does not exist or is not a directory!')
@@ -122,3 +123,5 @@ if __name__ == '__main__':
     driver_template, include_file = parse_pv_structure(driver_dir)
     write_cam_class(tempfile, driver_template, include_file, dev_name, det_name, cam_name)
     tempfile.close()
+
+    print(f'Done. Temporary boilerplate file saved to {det_name}_boilerplate.py')

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -223,10 +223,11 @@ if __name__ == '__main__':
     cam_name = f'{det_name}Cam'
     logging.debug(f'Creating boilerplate for {dev_name}, with classes {det_name} and {cam_name}')
 
-    boilerplate_file_name = f'{det_name}_boilerplate'
+    # Create boilerplate file with .py extension for syntax highlighting
+    boilerplate_file_name = f'{det_name}_boilerplate.py'
 
     # Create boilerplate temp file
-    with open(f'{det_name}_boilerplate', 'w') as boilerplate_file:
+    with open(boilerplate_file_name, 'w') as boilerplate_file:
 
         # Create the detector class for ophyd/areadetector/detectors
         write_detector_class(boilerplate_file, dev_name, det_name, cam_name)

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+
+import logging
+
+
+def write_detector_class(tempfile, dev_name, det_name, cam_name):
+
+    tempfile.write(
+f'''
+class {det_name}(DetectorBase):
+    _html_docs = ['{dev_name}Doc.html']
+    cam = C(cam.{cam_name}, 'cam1:')
+''')
+
+
+def parse_pv_structure(driver_dir):
+    template_dir = driver_dir
+    for dir in os.listdir(driver_dir):
+        if dir.endswith('App'):
+            template_dir = os.path.join(template_dir, dir, 'Db')
+            break
+    logging.debug(f'Found template dir: {template_dir}')
+    
+    template_files = []
+    for file in os.listdir(template_dir):
+        if file.endswith('.template'):
+            template_files.append(os.path.join(template_dir, file))
+            logging.debug(f'Found template file {file}')
+
+    output = {}
+    include_file = False
+    for file in template_files:
+        logging.debug(f'Collecting pv info from {os.path.basename(file)}')
+        fp = open(file, 'r')
+        
+        lines = fp.readlines()
+        for line in lines:
+            if line.startswith('include "NDFile.template"'):
+                logging.debug(f'Driver AD{dev_name} uses the NDFile.template file.')
+                include_file = True
+
+            if line.startswith('record'):
+                pv_name = line.split(')')[2][:-1]
+                if pv_name.endswith('_RBV'):
+                    if pv_name[:-4] in output.keys():
+                        logging.debug(f'Identified {pv_name[:-4]} as a record w/ RBV')
+                        output[pv_name[:-4]] = 'SignalWithRBV'
+                    else:
+                        logging.debug(f'Identified read-only record {pv_name}')
+                        output[pv_name] = 'EpicsSignalRO'
+                else:
+                    logging.debug(f'Found record {pv_name}')
+                    output[pv_name] = 'EpicsSignal'
+
+        fp.close()
+
+    return output, include_file
+
+
+def write_cam_class(tempfile, driver_template, include_file, dev_name, det_name, cam_name):
+    file = ''
+    if include_file:
+        file = ', FileBase'
+    tempfile.write(
+f'''
+class {cam_name}(CamBase{file}):
+    _html_docs = ['{dev_name}Doc.html']
+    _default_configuration_attrs = (
+        CamBase._default_configuration_attrs
+    )
+''')
+
+    for pv in driver_template.keys():
+        pv_var_name = re.sub( '(?<!^)(?=[A-Z])', '_', pv ).lower()
+        tempfile.write(f"    {pv_var_name} = ADCpt({driver_template[pv]}, '{pv}')\n")
+
+
+
+def parse_args():
+
+    parser = argparse.ArgumentParser(description='Utility for creating boilerplate ophyd classes')
+    parser.add_argument('-t', '--target', help='Location of locally installed areaDetector driver folder structure.')
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug loogging for the script.')
+
+    args = vars(parser.parse_args())
+
+    log_level = logging.ERROR
+    if args['debug']:
+        log_level = logging.DEBUG
+
+    if args['target'] is None:
+        return os.path.abspath('.'), log_level
+    else:
+        return args['target'], log_level
+
+
+if __name__ == '__main__':
+
+    driver_dir, log_level = parse_args()
+    if not os.path.exists(driver_dir) or not os.path.isdir(driver_dir):
+        logging.error(f'Input {driver_dir} does not exist or is not a directory!')
+        exit(-1)
+
+    logging.basicConfig(level=log_level)
+
+    driver_name = os.path.basename(driver_dir)
+    if not driver_name.startswith('AD'):
+        logging.error(f'Specified driver directory {driver_name} could not be identified as an areaDetector driver!')
+        exit(-1)
+
+    dev_name = driver_name[2:]
+    det_name = f'{dev_name}Detector'
+    cam_name = f'{det_name}Cam'
+    logging.debug(f'Creating boilerplate for {dev_name}, with classes {det_name} and {cam_name}')
+
+    tempfile = open(f'{det_name}_boilerplate.py', 'w')
+    write_detector_class(tempfile, dev_name, det_name, cam_name)
+    driver_template, include_file = parse_pv_structure(driver_dir)
+    write_cam_class(tempfile, driver_template, include_file, dev_name, det_name, cam_name)
+    tempfile.close()

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -7,9 +7,12 @@ import re
 import logging
 
 
-def write_detector_class(tempfile, dev_name, det_name, cam_name):
+def write_detector_class(boilerplate_file, dev_name, det_name, cam_name):
+    """
+    Writes boilerplater 'Detector' class for ophyd/areadetector/detectors
+    """
 
-    tempfile.write(
+    boilerplate_file.write(
         f'''
 class {det_name}(DetectorBase):
     _html_docs = ['{dev_name}Doc.html']
@@ -18,6 +21,14 @@ class {det_name}(DetectorBase):
 
 
 def parse_pv_structure(driver_dir):
+    """
+    Reads all .template files in the specified driver directory and maps them
+    to the appropriate EPICS signal class in ophyd
+
+    Also determines if the Cam class should extend the FileBase class as well.
+    """
+
+    # Find the template directory following the standard areaDetector project format
     template_dir = driver_dir
     for dir in os.listdir(driver_dir):
         if dir.endswith('App'):
@@ -25,64 +36,108 @@ def parse_pv_structure(driver_dir):
             break
     logging.debug(f'Found template dir: {template_dir}')
 
+    # Create a list of file paths to all template files.
     template_files = []
     for file in os.listdir(template_dir):
         if file.endswith('.template'):
             template_files.append(os.path.join(template_dir, file))
             logging.debug(f'Found template file {file}')
 
-    output = {}
-    include_file = False
+    # Dict mapping pv name to appropriate EPICS signal, based on typical
+    # PV and PV_RBV format for areaDetector
+    pv_to_signal_mapping = {}
+    include_file_base = False
+
     for file in template_files:
         logging.debug(f'Collecting pv info from {os.path.basename(file)}')
         fp = open(file, 'r')
 
         lines = fp.readlines()
         for line in lines:
+
+            # If NDFile.template is included, we need to extend FileBase as well.
             if line.startswith('include "NDFile.template"'):
                 logging.debug(f'Driver AD{dev_name} uses the NDFile.template file.')
-                include_file = True
+                include_file_base = True
 
+            # identify any lines that start with 'record
             if line.startswith('record'):
+                # Get the name of the PV.
                 pv_name = line.split(')')[2][:-1]
+
+                # Check if it is a readback PV
                 if pv_name.endswith('_RBV'):
-                    if pv_name[:-4] in output.keys():
+                    # If it has a partner PV, switch the signal to SignalWithRBV
+                    if pv_name[:-4] in pv_to_signal_mapping.keys():
                         logging.debug(f'Identified {pv_name[:-4]} as a record w/ RBV')
-                        output[pv_name[:-4]] = 'SignalWithRBV'
+                        pv_to_signal_mapping[pv_name[:-4]] = 'SignalWithRBV'
+                    # Otherwise, it is a read only PV, so use EpicsSignalRO
                     else:
                         logging.debug(f'Identified read-only record {pv_name}')
-                        output[pv_name] = 'EpicsSignalRO'
+                        pv_to_signal_mapping[pv_name] = 'EpicsSignalRO'
                 else:
+                    # Otherwise, use the default EpicsSignal
                     logging.debug(f'Found record {pv_name}')
-                    output[pv_name] = 'EpicsSignal'
+                    pv_to_signal_mapping[pv_name] = 'EpicsSignal'
 
         fp.close()
 
-    return output, include_file
+    return pv_to_signal_mapping, include_file_base
 
 
-def write_cam_class(tempfile, driver_template, include_file, dev_name, det_name, cam_name):
-    file = ''
-    if include_file:
-        file = ', FileBase'
-    tempfile.write(
+def write_cam_class(boilerplate_file, pv_to_signal_mapping, include_file_base, dev_name, det_name, cam_name):
+    """
+    Function that writes the boilerplate cam class. This includes the default configuration
+    attributes, along with all the attributes extracted from the template file.
+
+    This function is not perfect, as extracting a good attribute name from a PV name is not
+    always straightforward, since PV names are far from standard. Currently, the solution simply
+    adds an _ character before any capital letter, and then makes everything lowercase.
+    This works in most cases, but may require minor edits to certain names.
+
+    Examples:
+    
+    EnableCallbacks -> enable_callbacks
+    EVTLoadGainFile -> e_v_t_load_gain_file
+    """
+
+    # Extend from FileBase class as well if necessary
+    file_base = ''
+    if include_file_base:
+        file_base = ', FileBase'
+
+    # Write class boilerplate
+    boilerplate_file.write(
         f'''
-class {cam_name}(CamBase{file}):
+class {cam_name}(CamBase{file_base}):
     _html_docs = ['{dev_name}Doc.html']
     _default_configuration_attrs = (
         CamBase._default_configuration_attrs
     )
 ''')
 
-    for pv in driver_template.keys():
+    # Write appropriate attribute for 
+    for pv in pv_to_signal_mapping.keys():
         pv_name = pv
         if pv_name.endswith('_RBV'):
             pv_name = pv[:-4]
         pv_var_name = re.sub('(?<!^)(?=[A-Z])', '_', pv_name).lower()
-        tempfile.write(f"    {pv_var_name} = ADCpt({driver_template[pv]}, '{pv}')\n")
+        boilerplate_file.write(f"    {pv_var_name} = ADCpt({pv_to_signal_mapping[pv]}, '{pv}')\n")
 
 
 def parse_args():
+    """
+    usage: collect_ad_boilerplate.py [-h] [-t TARGET] [-d]
+
+    Utility for creating boilerplate ophyd classes
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -t TARGET, --target TARGET
+                            Location of locally installed areaDetector driver
+                            folder structure.
+      -d, --debug           Enable debug loogging for the script.
+    """
 
     parser = argparse.ArgumentParser(description='Utility for creating boilerplate ophyd classes')
     parser.add_argument(
@@ -91,6 +146,7 @@ def parse_args():
 
     args = vars(parser.parse_args())
 
+    # Set logging level
     log_level = logging.ERROR
     if args['debug']:
         log_level = logging.DEBUG
@@ -104,6 +160,8 @@ def parse_args():
 if __name__ == '__main__':
 
     print()
+
+    # Check if input is valid
     driver_dir, log_level = parse_args()
     if not os.path.exists(driver_dir) or not os.path.isdir(driver_dir):
         logging.error(f'Input {driver_dir} does not exist or is not a directory!')
@@ -111,21 +169,32 @@ if __name__ == '__main__':
 
     logging.basicConfig(level=log_level)
 
+    # Check if specified target is an areaDetector driver
     driver_name = os.path.basename(driver_dir)
     if not driver_name.startswith('AD'):
         logging.error(
             f'Specified driver directory {driver_name} could not be identified as an areaDetector driver!')
         exit(-1)
 
+    # Collect device, detector, and cam names
     dev_name = driver_name[2:]
     det_name = f'{dev_name}Detector'
     cam_name = f'{det_name}Cam'
     logging.debug(f'Creating boilerplate for {dev_name}, with classes {det_name} and {cam_name}')
 
-    tempfile = open(f'{det_name}_boilerplate.py', 'w')
-    write_detector_class(tempfile, dev_name, det_name, cam_name)
-    driver_template, include_file = parse_pv_structure(driver_dir)
-    write_cam_class(tempfile, driver_template, include_file, dev_name, det_name, cam_name)
-    tempfile.close()
+    # Create boilerplate temp file
+    boilerplate_file = open(f'{det_name}_boilerplate', 'w')
 
-    print(f'Done. Temporary boilerplate file saved to {det_name}_boilerplate.py')
+    # Create the detector class for ophyd/areadetector/detectors
+    write_detector_class(boilerplate_file, dev_name, det_name, cam_name)
+
+    # Collect PV information from detector driver
+    driver_template, include_file_base = parse_pv_structure(driver_dir)
+
+    # Create boilerplate cam class for ophyd/areadetector/cam
+    write_cam_class(boilerplate_file, driver_template, include_file_base, dev_name, det_name, cam_name)
+
+    # Close file
+    boilerplate_file.close()
+
+    print(f'Done. Temporary boilerplate file saved to {det_name}_boilerplate')


### PR DESCRIPTION
I'm not sure if this should live in this ophyd repository, but essentially this script allows for generating a bunch of boilerplate for new Detector and Cam classes by simply parsing the `.template` files for a specified areaDetector driver. To get an idea of what it does, you can take a look at a PR I am making adding the generated classes (with some minor hand-done fixes after) to add ADPICam detector and cam classes.

The ADPICam driver: https://github.com/areaDetector/ADPICam

I think long term this script will be replaced by some other, better, solution, like utilizing [PVI](https://pvi.readthedocs.io/en/latest/) from Diamond, but for now this should really simplify adding support for any new drivers.