### PR TITLE
FIX: re-enable setting a Signal to None

### DIFF
--- a/ophyd/tests/test_utils.py
+++ b/ophyd/tests/test_utils.py
@@ -123,3 +123,8 @@ def test_none_signal():
     cs = CycleSignal(name='cycle', value_cycle=[0, 1, 2, None, 4])
 
     set_and_wait(cs, 4, rtol=.01, atol=.01)
+
+
+def test_set_signal_to_None():
+    s = Signal(value='0', name='bob')
+    set_and_wait(s, None, timeout=1)

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -254,7 +254,7 @@ def set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
         within_str = ''
 
     while (
-        current_value is None or
+        (val is not None and current_value is None) or
         not _compare_maybe_enum(val, current_value, enum_strings, atol, rtol)
     ):
         logger.debug("Waiting for %s to be set from %r to %r%s...",


### PR DESCRIPTION
The change in #972 (to make sure we did not accidentally feed None to numpy)
also made it impossible to set a (soft)Signal to None.

While there may or may not be a good case for doing this, it is implicitly
tested in bluesky so restore the functionality.