### PR TITLE
ENH: add unit conversion derived signal from pcdsdevices

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1212,6 +1212,9 @@ class FakeEpicsSignal(SynSignal):
     We can emulate EpicsSignal features here. We currently emulate the put
     limits and some enum handling.
     """
+
+    _metadata_keys = EpicsSignal._metadata_keys
+
     def __init__(self, read_pv, write_pv=None, *, put_complete=False,
                  string=False, limits=False, auto_monitor=False, name=None,
                  **kwargs):
@@ -1334,7 +1337,7 @@ class FakeEpicsSignalRO(SynSignalRO, FakeEpicsSignal):
     """
     Read-only FakeEpicsSignal
     """
-    pass
+    _metadata_keys = EpicsSignalRO._metadata_keys
 
 
 class FakeEpicsSignalWithRBV(FakeEpicsSignal):
@@ -1342,6 +1345,9 @@ class FakeEpicsSignalWithRBV(FakeEpicsSignal):
     FakeEpicsSignal with PV and PV_RBV; used in the AreaDetector PV naming
     scheme
     """
+
+    _metadata_keys = EpicsSignalWithRBV._metadata_keys
+
     def __init__(self, prefix, **kwargs):
         super().__init__(prefix + '_RBV', write_pv=prefix, **kwargs)
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1261,9 +1261,22 @@ class FakeEpicsSignal(SynSignal):
                 return str(value)
         return value
 
-    def put(self, value, *args, **kwargs):
+    def put(self, value, *args,
+            connection_timeout=0.0,
+            callback=None,
+            use_complete=None,
+            timeout=0.0,
+            wait=True,
+            **kwargs):
         """
         Implement putting as enum strings and put functions
+
+        Notes
+        -----
+        FakeEpicsSignal varies in subtle ways from the real class.
+
+        * put-completion callback will _not_ be called.
+        * connection_timeout, use_complete, wait, and timeout are ignored.
         """
         if self.enum_strs is not None:
             if value in self.enum_strs:

--- a/ophyd/tests/test_units.py
+++ b/ophyd/tests/test_units.py
@@ -1,0 +1,79 @@
+import threading
+import unittest.mock
+
+import pytest
+
+import ophyd.sim
+import ophyd.units
+
+
+class MockCallbackHelper:
+    """
+    Simple helper for getting a callback, setting an event, and checking args.
+
+    Use __call__ as the hook and inspect/verify ``mock`` or ``call_kwargs``.
+    """
+
+    def __init__(self):
+        self.event = threading.Event()
+        self.mock = unittest.mock.Mock()
+
+    def __call__(self, *args, **kwargs):
+        self.mock(*args, **kwargs)
+        self.event.set()
+
+    def wait(self, timeout=1.0):
+        """Wait for the callback to be called."""
+        self.event.wait(timeout)
+
+    @property
+    def call_kwargs(self):
+        """Call keyword arguments."""
+        _, kwargs = self.mock.call_args
+        return kwargs
+
+
+@pytest.fixture(scope='function')
+def unit_conv_signal():
+    orig = ophyd.sim.FakeEpicsSignal('sig', name='orig')
+    assert 'units' in orig.metadata_keys
+
+    orig.sim_put(5)
+
+    return ophyd.units.UnitConversionDerivedSignal(
+        derived_from=orig,
+        original_units='m',
+        derived_units='mm',
+        name='converted',
+    )
+
+
+def test_unit_conversion_signal_units(unit_conv_signal):
+    assert unit_conv_signal.original_units == 'm'
+    assert unit_conv_signal.derived_units == 'mm'
+    assert unit_conv_signal.describe()[unit_conv_signal.name]['units'] == 'mm'
+
+
+def test_unit_conversion_signal_get_put(unit_conv_signal):
+    assert unit_conv_signal.get() == 5_000
+    unit_conv_signal.put(10_000, wait=True)
+    assert unit_conv_signal.derived_from.get() == 10
+
+
+def test_unit_conversion_signal_value_sub(unit_conv_signal):
+    helper = MockCallbackHelper()
+    unit_conv_signal.subscribe(helper, run=False)
+    unit_conv_signal.derived_from.put(20, wait=True)
+    helper.wait(1)
+    helper.mock.assert_called_once()
+
+    assert helper.call_kwargs['value'] == 20_000
+    assert unit_conv_signal.get() == 20_000
+
+
+def test_unit_conversion_signal_metadata_sub(unit_conv_signal):
+    helper = MockCallbackHelper()
+    unit_conv_signal.subscribe(helper, run=True, event_type='meta')
+    helper.wait(1)
+    helper.mock.assert_called_once()
+    assert helper.call_kwargs['units'] == 'mm'

--- a/ophyd/units.py
+++ b/ophyd/units.py
@@ -116,14 +116,18 @@ class UnitConversionDerivedSignal(DerivedSignal):
     def forward(self, value):
         '''Compute derived signal value -> original signal value'''
         if self.user_offset is None:
-            raise ValueError(f'{self.name} must be set to a non-None value.')
+            raise ValueError(
+                f'{self.name}.user_offset must be set to a non-None value.'
+            )
         return convert_unit(value - self.user_offset,
                             self.derived_units, self.original_units)
 
     def inverse(self, value):
         '''Compute original signal value -> derived signal value'''
         if self.user_offset is None:
-            raise ValueError(f'{self.name} must be set to a non-None value.')
+            raise ValueError(
+                f'{self.name}.user_offset must be set to a non-None value.'
+            )
         return convert_unit(value, self.original_units,
                             self.derived_units) + self.user_offset
 

--- a/ophyd/units.py
+++ b/ophyd/units.py
@@ -1,0 +1,206 @@
+import numbers
+from typing import Any, Optional, Tuple
+
+import pint
+
+from .signal import DerivedSignal
+
+_global_unit_registry = None
+
+
+def convert_unit(value: float, from_units: str, to_units: str):
+    """
+    Convert ``value`` from ``from_units`` to ``to_units`` using ``pint``.
+
+    Parameters
+    ----------
+    value : float
+        The starting value for the conversion.
+
+    from_units : str
+        The starting unit of the provided value.
+
+    to_units : str
+        The desired unit to convert the value to.
+
+    Returns
+    -------
+    new_value : float
+        The starting value, but converted to the new unit.
+    """
+
+    global _global_unit_registry
+    if _global_unit_registry is None:
+        # NOTE: Instantiating the unit registry is a heavy operation and should
+        # not be performed repeatedly.
+        _global_unit_registry = pint.UnitRegistry()
+
+    expr = _global_unit_registry.parse_expression(from_units)
+    return (value * expr).to(to_units).magnitude
+
+
+class UnitConversionDerivedSignal(DerivedSignal):
+    """
+    A DerivedSignal which performs unit conversion.
+
+    Custom units may be specified for the original signal, or if specified, the
+    original signal's units may be retrieved upon first connection.
+
+    Parameters
+    ----------
+    derived_from : Signal or str
+        The signal from which this one is derived.  This may be a string
+        attribute name that indicates a sibling to use.  When used in a
+        ``Device``, this is then simply the attribute name of another
+        ``Component``.
+
+    derived_units : str
+        The desired units to use for this signal.  These can also be referred
+        to as the "user-facing" units.
+
+    original_units : str, optional
+        The units from the original signal.  If not specified, control system
+        information regarding units will be retrieved upon first connection.
+
+    user_offset : any, optional
+        An optional user offset that will be *subtracted* when updating the
+        original signal, and *added* when calculating the derived value.
+        This offset should be supplied in ``derived_units`` and not
+        ``original_units``.
+
+        For example, if the original signal updates to a converted value of
+        500 ``derived_units`` and the ``user_offset`` is set to 100, this
+        ``DerivedSignal`` will show a value of 600.  When providing a new
+        setpoint, the ``user_offset`` will be subtracted.
+
+    write_access : bool, optional
+        Write access may be disabled by setting this to ``False``, regardless
+        of the write access of the underlying signal.
+
+    name : str, optional
+        The signal name.
+
+    parent : Device, optional
+        The parent device.  Required if ``derived_from`` is an attribute name.
+
+    limits : 2-tuple, optional
+        Ophyd signal-level limits in derived units.  DerivedSignal defaults
+        to converting the original signal's limits, but these may be overridden
+        here without modifying the original signal.
+
+    **kwargs :
+        Keyword arguments are passed to the superclass.
+    """
+
+    derived_units: str
+    original_units: str
+
+    def __init__(self, derived_from, *,
+                 derived_units: str,
+                 original_units: Optional[str] = None,
+                 user_offset: Optional[numbers.Real] = 0,
+                 limits: Optional[Tuple[numbers.Real, numbers.Real]] = None,
+                 **kwargs):
+        self.derived_units = derived_units
+        self.original_units = original_units
+        self._user_offset = user_offset
+        self._custom_limits = limits
+        super().__init__(derived_from, **kwargs)
+        self._metadata['units'] = derived_units
+
+        # Ensure that we include units in metadata callbacks, even if the
+        # original signal does not include them.
+        if 'units' not in self._metadata_keys:
+            self._metadata_keys = self._metadata_keys + ('units', )
+
+    def forward(self, value):
+        '''Compute derived signal value -> original signal value'''
+        if self.user_offset is None:
+            raise ValueError(f'{self.name} must be set to a non-None value.')
+        return convert_unit(value - self.user_offset,
+                            self.derived_units, self.original_units)
+
+    def inverse(self, value):
+        '''Compute original signal value -> derived signal value'''
+        if self.user_offset is None:
+            raise ValueError(f'{self.name} must be set to a non-None value.')
+        return convert_unit(value, self.original_units,
+                            self.derived_units) + self.user_offset
+
+    @property
+    def limits(self):
+        '''
+        Defaults to limits from the original signal (low, high).
+
+        Limit values may be reversed such that ``low <= value <= high`` after
+        performing the calculation.
+
+        Limits may also be overridden here without affecting the original
+        signal.
+        '''
+        if self._custom_limits is not None:
+            return self._custom_limits
+
+        # Fall back to the superclass derived_from limits:
+        return tuple(
+            sorted(self.inverse(v) for v in self._derived_from.limits)
+        )
+
+    @limits.setter
+    def limits(self, value):
+        if value is None:
+            self._custom_limits = None
+            return
+
+        if len(value) != 2 or value[0] >= value[1]:
+            raise ValueError('Custom limits must be a 2-tuple (low, high)')
+
+        self._custom_limits = tuple(value)
+
+    @property
+    def user_offset(self) -> Optional[Any]:
+        """A user-specified offset in *derived*, user-facing units."""
+        return self._user_offset
+
+    @user_offset.setter
+    def user_offset(self, offset):
+        offset_change = -self._user_offset + offset
+        self._user_offset = offset
+        self._recalculate_position()
+        if self._custom_limits is not None:
+            self._custom_limits = (
+                self._custom_limits[0] + offset_change,
+                self._custom_limits[1] + offset_change,
+            )
+
+    def _recalculate_position(self):
+        """
+        Recalculate the derived position and send subscription updates.
+
+        No-operation if the original signal is not connected.
+        """
+        if not self._derived_from.connected:
+            return
+
+        value = self._derived_from.get()
+        if value is not None:
+            # Note: no kwargs here; no metadata updates
+            self._derived_value_callback(value)
+
+    def _derived_metadata_callback(self, *, connected, **kwargs):
+        if connected and 'units' in kwargs:
+            if self.original_units is None:
+                self.original_units = kwargs['units']
+        # Do not pass through units, as we have our own.
+        kwargs['units'] = self.derived_units
+        super()._derived_metadata_callback(connected=connected, **kwargs)
+
+    def describe(self):
+        full_desc = super().describe()
+        desc = full_desc[self.name]
+        desc['units'] = self.derived_units
+        # Note: this should be handled in ophyd:
+        for key in ('lower_ctrl_limit', 'upper_ctrl_limit'):
+            if key in desc:
+                desc[key] = self.inverse(desc[key])
+        return full_desc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 networkx>=2.0
 numpy
+pint


### PR DESCRIPTION
Summary
----------
* Fixes metadata keys on `FakeEpicsSignal`
* Fixes `put()` kwargs on `FakeEpicsSignal` to avoid frustratingly-common deprecation warnings
* Adds `UnitConversionDerivedSignal` with small test suite.

Closes #894 

Example
---------

This can be used as a device component like follows:

```python
    # component_name_to_convert_from = Cpt(Signal, value=0.)
    setpoint = Cpt(UnitConversionDerivedSignal,
                   derived_from='component_name_to_convert_from',
                   derived_units='s',
                   original_units='ns',
                   kind='hinted',
                   doc='Setpoint which handles the conversion.',
                   limits=(-10e-6, 10e-6),
                   )
```

What does this do?
* The above would use `self.component_name_to_convert_from` and proxy methods such as `.read()`, `.describe()`, and value/metadata subscriptions (as does the original `DerivedSignal` for those unaware).
* The instantiated signal would apply unit conversion from nanoseconds to seconds when reading from `setpoint`, and seconds to nanoseconds when writing back to `setpoint` (and then the original signal).
* This signal may have its own user-configurable limits. The default is to take the limits of the original signal (with unit conversion, of course)

This is in use in pcdsdevices currently.