### PR TITLE
Fix enum py310

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -32,7 +32,17 @@ def select_version(cls, version):
     return all_versions[matched_version]
 
 
-class Kind(IntFlag):
+if sys.version_info < (3, 10, 0, 'alpha', 5):
+    IFBase = IntFlag
+else:
+    from enum import KEEP
+
+
+    class IFBase(IntFlag, boundary=KEEP):
+        ...
+
+
+class Kind(IFBase):
     """
     This is used in the .kind attribute of all OphydObj (Signals, Devices).
 

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -8,7 +8,6 @@ from itertools import count
 from logging import LoggerAdapter, getLogger
 
 
-
 from .log import control_layer_logger
 
 
@@ -36,7 +35,6 @@ if sys.version_info < (3, 10, 0, 'alpha', 5):
     IFBase = IntFlag
 else:
     from enum import KEEP
-
 
     class IFBase(IntFlag, boundary=KEEP):
         ...

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -1,9 +1,13 @@
-from enum import IntFlag
 import functools
-from itertools import count
-from logging import LoggerAdapter, getLogger
+import sys
 import time
 import weakref
+
+from enum import IntFlag
+from itertools import count
+from logging import LoggerAdapter, getLogger
+
+
 
 from .log import control_layer_logger
 


### PR DESCRIPTION
We may want to take this as an opportunity to re-think the Kind enum? 

Python 3.10 makes a number of changes to Enum and its sub-classes.  Under the new default behavior of IntFlag the fact that we have `0b1b1` as a flag, but not `0b100` is considered a class definition time error (preventing import of ophyd).

This opts back into allowing our (unorthodox) definition to import again and hides the new features behind a version gate.

python/cpython#24215