### PR TITLE
Fix #990: Import 'SignalRO' with 'ophyd'

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -75,7 +75,7 @@ from .ophydobj import (Kind, select_version,  # noqa: F401, F402, E402
                        register_instances_keyed_on_name)
 
 # Signals
-from .signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)  # noqa: F401, F402, E402
+from .signal import (Signal, SignalRO, EpicsSignal, EpicsSignalRO, DerivedSignal)  # noqa: F401, F402, E402
 
 # Positioners
 from .positioner import (PositionerBase, SoftPositioner)  # noqa: F401, F402, E402

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -592,3 +592,21 @@ def test_posix_paths(paths, path_signal):
 def test_path_semantics_exception():
     with pytest.raises(ValueError):
         EpicsPathSignal('TEST', path_semantics='not_a_thing')
+
+        
+@pytest.fixture(scope="module")
+def imported_ro_signal_class_from_pkg():
+    from ophyd import SignalRO
+    return SignalRO
+
+
+@pytest.fixture(scope="module")
+def imported_ro_signal_class_from_module():
+    from ophyd.signal import SignalRO
+    return SignalRO
+
+
+def test_import_ro_signal_class(
+        imported_ro_signal_class_from_pkg, 
+        imported_ro_signal_class_from_module):
+    assert imported_ro_signal_class_from_pkg == imported_ro_signal_class_from_module

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -593,9 +593,9 @@ def test_path_semantics_exception():
     with pytest.raises(ValueError):
         EpicsPathSignal('TEST', path_semantics='not_a_thing')
 
-        
+
 def test_import_ro_signal_class():
     from ophyd import SignalRO as SignalRoFromPkg
     from ophyd.signal import SignalRO as SignalRoFromModule
-    
+
     assert SignalRoFromPkg is SignalRoFromModule

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -594,19 +594,8 @@ def test_path_semantics_exception():
         EpicsPathSignal('TEST', path_semantics='not_a_thing')
 
         
-@pytest.fixture(scope="module")
-def imported_ro_signal_class_from_pkg():
-    from ophyd import SignalRO
-    return SignalRO
-
-
-@pytest.fixture(scope="module")
-def imported_ro_signal_class_from_module():
-    from ophyd.signal import SignalRO
-    return SignalRO
-
-
-def test_import_ro_signal_class(
-        imported_ro_signal_class_from_pkg, 
-        imported_ro_signal_class_from_module):
-    assert imported_ro_signal_class_from_pkg == imported_ro_signal_class_from_module
+def test_import_ro_signal_class():
+    from ophyd import SignalRO as SignalRoFromPkg
+    from ophyd.signal import SignalRO as SignalRoFromModule
+    
+    assert SignalRoFromPkg is SignalRoFromModule

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,5 +3,5 @@ ipython
 ipywidgets
 matplotlib
 numpydoc
-sphinx==1.6.7
+sphinx>=1.8.1,!=2.0.0
 sphinx_rtd_theme


### PR DESCRIPTION
`SignalRO` is now imported by 'ophyd.__init__.py' 
so that it is available when importing `ophyd`

```python
from ophyd import SignalRO  # This now works
from ophyd import *  # ...so does this
```