### PR TITLE
Define last_status_object property in Signal class

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -85,6 +85,7 @@ class Signal(OphydObject):
     _default_sub = SUB_VALUE
     _metadata_keys = None
     _core_metadata_keys = ('connected', 'read_access', 'write_access', 'timestamp')
+    _status = None
 
     def __init__(self, *, name, value=0., timestamp=None, parent=None,
                  labels=None, kind=Kind.hinted, tolerance=None,

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -85,7 +85,6 @@ class Signal(OphydObject):
     _default_sub = SUB_VALUE
     _metadata_keys = None
     _core_metadata_keys = ('connected', 'read_access', 'write_access', 'timestamp')
-    _status = None
 
     def __init__(self, *, name, value=0., timestamp=None, parent=None,
                  labels=None, kind=Kind.hinted, tolerance=None,
@@ -326,6 +325,11 @@ class Signal(OphydObject):
         self._set_thread.daemon = True
         self._set_thread.start()
         return self._status
+
+    @property
+    def last_status_object(self):
+        '''The most recent status object, if available, or ``None``.'''
+        return getattr(self, "_status", None)
 
     @property
     def value(self):

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -601,13 +601,13 @@ def test_import_ro_signal_class():
     assert SignalRoFromPkg is SignalRoFromModule
 
 
-def test_last_status_object():
+def test_signal_last_status_object():
     signal = Signal(name="signal", value=1)
     assert not hasattr(signal, "_status")
     assert signal.last_status_object is None
 
     signal.put(0)
-    assert hasattr(signal, "_status")
+    assert not hasattr(signal, "_status")
 
     signal.set(2)
     assert hasattr(signal, "_status")

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -599,3 +599,14 @@ def test_import_ro_signal_class():
     from ophyd.signal import SignalRO as SignalRoFromModule
 
     assert SignalRoFromPkg is SignalRoFromModule
+
+
+def test_last_status_object():
+    signal = Signal(name="signal", value=1)
+    assert not hasattr(signal, "_status")
+    assert signal.last_status_object is None
+
+    signal.put(0)
+    assert hasattr(signal, "_status")
+    assert signal.last_status_object is not None
+    assert signal.last_status_object == signal._status

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -608,5 +608,8 @@ def test_last_status_object():
 
     signal.put(0)
     assert hasattr(signal, "_status")
+
+    signal.set(2)
+    assert hasattr(signal, "_status")
     assert signal.last_status_object is not None
     assert signal.last_status_object == signal._status


### PR DESCRIPTION
FIX #993 by adding a `last_status_object ` property (to provide access to the internal `_status` attribute, if it exists).