### PR TITLE
AD: add "create_directory" component to stage_sigs

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -390,6 +390,8 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
 class FileStorePluginBase(FileStoreBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if hasattr(self, "create_directory"):
+            self.stage_sigs.update({"create_directory": -3})
         self.stage_sigs.update([('auto_increment', 'Yes'),
                                 ('array_counter', 0),
                                 ('auto_save', 'Yes'),


### PR DESCRIPTION
This PR adds the `create_directory` component to the `stage_sigs` of the `FileStorePluginBase` class, so that the requested directory can be created by the AreaDetector. See https://github.com/NSLS-II-SIX/profile_collection/pull/36 for the original implementation, ported to upstream here.