### PR TITLE
MNT: set_current_position basic error handling

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -199,8 +199,10 @@ class EpicsMotor(Device, PositionerBase):
 
         '''
         self.set_use_switch.put(1, wait=True)
-        self.user_setpoint.put(pos, wait=True, force=True)
-        self.set_use_switch.put(0, wait=True)
+        try:
+            self.user_setpoint.put(pos, wait=True, force=True)
+        finally:
+            self.set_use_switch.put(0, wait=True)
 
     @raise_if_disconnected
     def home(self, direction, wait=True, **kwargs):


### PR DESCRIPTION
If the user puts in a bad value to `EpicsMotor.set_current_position`, this method can abort before restoring the `.SET` field (`set_use_switch`) to the normal value of `0` (`Use`), leaving it at the value of `1` (`Set`). This can cause confusion when someone tries to move a motor manually later, only for the position to be set instead of used.

This is just a simple try/finally block, we still raise the exception caused by the bad input but we clean up after ourselves.