### PR TITLE
make AD Eiger SequenceId a writeable PV

### DIFF
--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -354,7 +354,7 @@ class EigerDetectorCam(CamBase, FileBase):
     file_owner_grp = ADCpt(SignalWithRBV, 'FileOwnerGrp')
     file_perms = ADCpt(EpicsSignal, 'FilePerms')
     flatfield_applied = ADCpt(SignalWithRBV, 'FlatfieldApplied')
-    sequence_id = ADCpt(EpicsSignalRO, 'SequenceId')
+    sequence_id = ADCpt(EpicsSignal, 'SequenceId')
     photon_energy = ADCpt(SignalWithRBV, 'PhotonEnergy')
     armed = ADCpt(EpicsSignalRO, 'Armed')
     chi_start = ADCpt(SignalWithRBV, 'ChiStart')


### PR DESCRIPTION
-  this is a writeable PV when probed with `cainfo`, so it should not be RO

Example from FMX at NSLS-II:
```bash
$ cainfo XF:17IDC-ES:FMX{Det:Eig16M}cam1:SequenceId
XF:17IDC-ES:FMX{Det:Eig16M}cam1:SequenceId
    State:            connected
    Host:             xf17id2-ioc2-1723.nsls2.bnl.local:41309
    Access:           read, write
    Native data type: DBF_LONG
    Request type:     DBR_LONG
    Element count:    1
```