### PR TITLE
DOC #591 add ScalerCH docs

### DIFF
--- a/docs/source/reference/builtin-devices.rst
+++ b/docs/source/reference/builtin-devices.rst
@@ -40,6 +40,8 @@ This must be sub-classed (like :class:`~ophyd.device.Device`) to be useful.
    ophyd.epics_motor.EpicsMotor
    ophyd.epics_motor.MotorBundle
 
+.. _built_in.EpicsScaler:
+
 EpicsScaler
 -----------
 
@@ -51,13 +53,16 @@ Create an ``EpicsScaler`` to control an EPICS `scaler record
     from ophyd import EpicsScaler
     scaler = EpicsScaler('XF:28IDC-ES:1{Sclr:1}', name='tth')
 
-Note that :ref:`ScalerCH` is an alternative ``ophyd`` representation of
-the EPICS `scaler record.
+Note that :ref:`built_in.ScalerCH` is an alternative ``ophyd`` representation of
+the EPICS `scaler record
+<https://htmlpreview.github.io/?https://github.com/epics-modules/scaler/blob/master/documentation/scalerRecord.html>`_.
 
 .. autosummary::
    :toctree: ../generated
 
    ophyd.scaler.EpicsScaler
+
+.. _built_in.ScalerCH:
 
 ScalerCH
 --------
@@ -77,12 +82,12 @@ An important difference between the `ScalerCH` and the `EpicsScaler` is
 in how the channels names are represented.  See this table for a
 comparison:
 
-==================  =======================================  ====================================================
-class               channel naming                           examples
-==================  =======================================  ====================================================
-:ref:`EpicsScaler`  numbered                                 ``scaler_channels_chan2``, ``scaler_channels_chan3``
-:ref:`ScalerCH`     EPICS scaler record channel name fields  ``I0``, ``diode``
-==================  =======================================  ====================================================
+===========================  =======================================  ====================================================
+class                        channel naming                           examples
+===========================  =======================================  ====================================================
+:ref:`built_in.EpicsScaler`  numbered                                 ``scaler_channels_chan2``, ``scaler_channels_chan3``
+:ref:`built_in.ScalerCH`     EPICS scaler record channel name fields  ``I0``, ``diode``
+===========================  =======================================  ====================================================
 
 .. autosummary::
    :toctree: ../generated

--- a/docs/source/reference/builtin-devices.rst
+++ b/docs/source/reference/builtin-devices.rst
@@ -1,14 +1,14 @@
 Devices with Built-in Support
 =============================
 
-These devices are have ready-made classes in Python. To configure them, the
+These devices have ready-made classes in Python. To configure them, the
 user need only provide a PV prefix and a name.
 
-EpicsMotor
-----------
+EPICS motor
+-----------
 
-Create an ``EpicsMotor`` to communicate with a single `EPICS motor record
-<http://www.aps.anl.gov/bcda/synApps/motor/>`_:
+The EPICS `motor record <http://www.aps.anl.gov/bcda/synApps/motor/>`_
+is supported by the ``EpicsMotor`` object in ``ophyd``:
 
 .. code-block:: python
 
@@ -40,22 +40,38 @@ This must be sub-classed (like :class:`~ophyd.device.Device`) to be useful.
    ophyd.epics_motor.EpicsMotor
    ophyd.epics_motor.MotorBundle
 
+.. _built_in.Epics.Scaler.record:
+
+EPICS Scaler
+------------
+
+The EPICS ``scaler`` record ([#scaler]_) is supported by two alternative
+``ophyd`` Devices.  (You need only choose one of these two.)  An important
+difference between the :ref:`built_in.EpicsScaler` and the :ref:`built_in.ScalerCH`
+Devices is in how each channel's names is represented, as summarized 
+in the next table:
+
+===========================  =======================================  ====================================================
+class                        channel naming                           examples
+===========================  =======================================  ====================================================
+:ref:`built_in.EpicsScaler`  numbered                                 ``scaler_channels_chan2``, ``scaler_channels_chan3``
+:ref:`built_in.ScalerCH`     EPICS scaler record channel name fields  ``I0``, ``diode``
+===========================  =======================================  ====================================================
+
+.. [#scaler] EPICS ``scaler`` documentation:
+   https://htmlpreview.github.io/?https://github.com/epics-modules/scaler/blob/master/documentation/scalerRecord.html
+
 .. _built_in.EpicsScaler:
 
 EpicsScaler
------------
++++++++++++
 
-Create an ``EpicsScaler`` to control an EPICS `scaler record
-<https://htmlpreview.github.io/?https://github.com/epics-modules/scaler/blob/master/documentation/scalerRecord.html>`_:
+Create an ``EpicsScaler`` object to control an EPICS ``scaler`` record ([#scaler]_).
 
 .. code-block:: python
 
     from ophyd import EpicsScaler
-    scaler = EpicsScaler('XF:28IDC-ES:1{Sclr:1}', name='tth')
-
-Note that :ref:`built_in.ScalerCH` is an alternative ``ophyd`` representation of
-the EPICS `scaler record
-<https://htmlpreview.github.io/?https://github.com/epics-modules/scaler/blob/master/documentation/scalerRecord.html>`_.
+    scaler = EpicsScaler('XF:28IDC-ES:1{Sclr:1}', name='scaler')
 
 .. autosummary::
    :toctree: ../generated
@@ -65,29 +81,14 @@ the EPICS `scaler record
 .. _built_in.ScalerCH:
 
 ScalerCH
---------
+++++++++
 
-Create a ``ScalerCH`` to control an EPICS `scaler record
-<https://htmlpreview.github.io/?https://github.com/epics-modules/scaler/blob/master/documentation/scalerRecord.html>`_:
+Create a ``ScalerCH`` object to control an EPICS ``scaler`` record ([#scaler]_).
 
 .. code-block:: python
 
-    from ophyd import ScalerCH
-    scaler = ScalerCH('XF:28IDC-ES:1{Sclr:1}', name='tth')
-
-Note that :ref:`EpicsScaler` is an alternative ``ophyd`` representation of
-the EPICS `scaler record.
-
-An important difference between the `ScalerCH` and the `EpicsScaler` is
-in how the channels names are represented.  See this table for a
-comparison:
-
-===========================  =======================================  ====================================================
-class                        channel naming                           examples
-===========================  =======================================  ====================================================
-:ref:`built_in.EpicsScaler`  numbered                                 ``scaler_channels_chan2``, ``scaler_channels_chan3``
-:ref:`built_in.ScalerCH`     EPICS scaler record channel name fields  ``I0``, ``diode``
-===========================  =======================================  ====================================================
+    from ophyd.scaler import ScalerCH
+    scaler = ScalerCH('XF:28IDC-ES:1{Sclr:1}', name='scaler')
 
 .. autosummary::
    :toctree: ../generated
@@ -98,7 +99,7 @@ class                        channel naming                           examples
 EpicsMCA and EpicsDXP
 ---------------------
 
-`MCA records <http://cars9.uchicago.edu/software/epics/mcaRecord.html>`_ and
+EPICS `MCA records <http://cars9.uchicago.edu/software/epics/mcaRecord.html>`_ and
 DXP-based devices are also supported, through the ``EpicsMCA`` and ``EpicsDXP``
 devices.
 

--- a/docs/source/reference/builtin-devices.rst
+++ b/docs/source/reference/builtin-devices.rst
@@ -8,7 +8,7 @@ EPICS motor
 -----------
 
 The EPICS `motor record <http://www.aps.anl.gov/bcda/synApps/motor/>`_
-is supported by the ``EpicsMotor`` object in ``ophyd``:
+is supported by the :class:`~ophyd.epics_motor.EpicsMotor` Device in ``ophyd``:
 
 .. code-block:: python
 
@@ -66,7 +66,7 @@ class                        channel naming                           examples
 EpicsScaler
 +++++++++++
 
-Create an ``EpicsScaler`` object to control an EPICS ``scaler`` record ([#scaler]_).
+Create an :class:`~ophyd.scaler.EpicsScaler` object to control an EPICS ``scaler`` record ([#scaler]_).
 
 .. code-block:: python
 
@@ -83,7 +83,7 @@ Create an ``EpicsScaler`` object to control an EPICS ``scaler`` record ([#scaler
 ScalerCH
 ++++++++
 
-Create a ``ScalerCH`` object to control an EPICS ``scaler`` record ([#scaler]_).
+Create a :class:`~ophyd.scaler.ScalerCH` object to control an EPICS ``scaler`` record ([#scaler]_).
 
 .. code-block:: python
 

--- a/docs/source/reference/builtin-devices.rst
+++ b/docs/source/reference/builtin-devices.rst
@@ -44,17 +44,50 @@ EpicsScaler
 -----------
 
 Create an ``EpicsScaler`` to control an EPICS `scaler record
-<http://www.aps.anl.gov/bcda/synApps/std/scalerRecord.html>`_:
+<https://htmlpreview.github.io/?https://github.com/epics-modules/scaler/blob/master/documentation/scalerRecord.html>`_:
 
 .. code-block:: python
 
     from ophyd import EpicsScaler
     scaler = EpicsScaler('XF:28IDC-ES:1{Sclr:1}', name='tth')
 
+Note that :ref:`ScalerCH` is an alternative ``ophyd`` representation of
+the EPICS `scaler record.
+
 .. autosummary::
    :toctree: ../generated
 
    ophyd.scaler.EpicsScaler
+
+ScalerCH
+--------
+
+Create a ``ScalerCH`` to control an EPICS `scaler record
+<https://htmlpreview.github.io/?https://github.com/epics-modules/scaler/blob/master/documentation/scalerRecord.html>`_:
+
+.. code-block:: python
+
+    from ophyd import ScalerCH
+    scaler = ScalerCH('XF:28IDC-ES:1{Sclr:1}', name='tth')
+
+Note that :ref:`EpicsScaler` is an alternative ``ophyd`` representation of
+the EPICS `scaler record.
+
+An important difference between the `ScalerCH` and the `EpicsScaler` is
+in how the channels names are represented.  See this table for a
+comparison:
+
+==================  =======================================  ====================================================
+class               channel naming                           examples
+==================  =======================================  ====================================================
+:ref:`EpicsScaler`  numbered                                 ``scaler_channels_chan2``, ``scaler_channels_chan3``
+:ref:`ScalerCH`     EPICS scaler record channel name fields  ``I0``, ``diode``
+==================  =======================================  ====================================================
+
+.. autosummary::
+   :toctree: ../generated
+
+   ophyd.scaler.ScalerCH
 
 
 EpicsMCA and EpicsDXP

--- a/docs/source/reference/builtin-devices.rst
+++ b/docs/source/reference/builtin-devices.rst
@@ -48,7 +48,7 @@ EPICS Scaler
 The EPICS ``scaler`` record ([#scaler]_) is supported by two alternative
 ``ophyd`` Devices.  (You need only choose one of these two.)  An important
 difference between the :ref:`built_in.EpicsScaler` and the :ref:`built_in.ScalerCH`
-Devices is in how each channel's names is represented, as summarized 
+Devices is in how each channel's name is represented, as summarized 
 in the next table:
 
 ===========================  =======================================  ====================================================


### PR DESCRIPTION
Fix #591 (from 2018) and finally reveal the `ScalerCH` class in the documentation.  Also update the URLs to the EPICS synApps `scaler`, since in the interim, it has been moved out of the synApps `std` module.