### PR TITLE
MNT: pin networkx >= 2.5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
       fail-fast: false
     env:
       TEST_CL: pyepics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 inflection
-networkx>=2.0
+networkx>=2.5
 numpy
 pint

--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,6 @@ setup(name='ophyd',
           "Development Status :: 5 - Production/Stable",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9",
       ])


### PR DESCRIPTION
versions of networkx earlier than 2.5 fail at import in Python 3.9