### PR TITLE
fix ophyd's most frustratingly unhelpful error message

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1567,8 +1567,8 @@ class EpicsSignal(EpicsSignalBase):
             return
 
         if not (low_limit <= value <= high_limit):
-            raise LimitError('Value {} outside of range: [{}, {}]'
-                             .format(value, low_limit, high_limit))
+            raise LimitError('{}: value {} outside of range: [{}, {}]'
+                             .format(self.name, value, low_limit, high_limit))
 
     def get_setpoint(self, *,
                      as_string=None,


### PR DESCRIPTION
In many of my plans at BMM, I move many motors with a single `mv()` command.  Without identifying the motor in question, it is very hard to know which motor is the one triggering the outside-of-limits message.  This adds `self.name` to the error message.  Still not  perfect solution in that it adds the name of the user setpoint PV rather than name of the ophyd object that setpoint is attached to.  But it makes for a 1,000,000 % more useful error message.