### PR TITLE
PKG: move `inflection` package from requirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+inflection

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ databroker>=1.0.0b1
 epics-pypdb
 flake8
 h5py
+inflection
 matplotlib
 pyepics>=3.4.2
 pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,6 @@ databroker>=1.0.0b1
 epics-pypdb
 flake8
 h5py
-inflection
 matplotlib
 pyepics>=3.4.2
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-inflection
 networkx>=2.0
 numpy
 pint

--- a/scripts/collect_ad_boilerplate.py
+++ b/scripts/collect_ad_boilerplate.py
@@ -8,7 +8,11 @@ import logging
 
 def write_detector_class(boilerplate_file, dev_name, det_name, cam_name):
     """
-    Writes boilerplater 'Detector' class for ophyd/areadetector/detectors
+    Writes boilerplate 'Detector' class for ophyd/areadetector/detectors.
+
+    This script automates the creation of ophyd classes for areaDetector
+    drivers by scraping their *.template files. It is called by developers as
+    needed.
 
     Parameters
     ----------


### PR DESCRIPTION
We don't have `requirements-dev.txt` file in this repo, so I moved it to the best match `requirements-test.txt`.

Closes https://github.com/bluesky/ophyd/issues/1011.