### PR TITLE
Added release notes for v1.6.3

### DIFF
--- a/docs/source/reference/release_notes.rst
+++ b/docs/source/reference/release_notes.rst
@@ -2,6 +2,18 @@
  Release History
 =================
 
+1.6.3 (2021-10-08)
+==================
+
+Changes
+-------
+
+* In case of a LimitError being raised by the ``mv()`` command, the error
+  message will now specify which setpoint PV triggered the limit condition.
+* Added tests which check Ophyd objects against the new Bluesky protocols.
+* The requirement for the ``inflection`` package has been removed from
+  general requirements and moved to ``requirements-dev.txt``.
+
 1.6.2 (2021-08-31)
 ==================
 


### PR DESCRIPTION
Release notes for (tentatively) 1.6.3. 

Patch-level increment proposed, since there are only a few small updates.

Release date prospectively set to Oct 8, since that's when release tagging is scheduled.