### PR TITLE
report signal name on ValueError in Signal.describe()

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -410,9 +410,13 @@ class Signal(OphydObject):
         else:
             val = self._readback
         try:
-            return {self.name: {'source': 'SIM:{}'.format(self.name),
-                            'dtype': data_type(val),
-                            'shape': data_shape(val)}}
+            return {
+                self.name: {
+                    'source': 'SIM:{}'.format(self.name),
+                    'dtype': data_type(val),
+                    'shape': data_shape(val)
+                }
+            }
         except ValueError as ve:
             # data_type(val) raises ValueError if type(val) is not bluesky-friendly
             # help the humans by reporting self.name in the exception chain

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -409,9 +409,14 @@ class Signal(OphydObject):
             val = self.get()
         else:
             val = self._readback
-        return {self.name: {'source': 'SIM:{}'.format(self.name),
+        try:
+            return {self.name: {'source': 'SIM:{}'.format(self.name),
                             'dtype': data_type(val),
                             'shape': data_shape(val)}}
+        except ValueError as ve:
+            # data_type(val) raises ValueError if type(val) is not bluesky-friendly
+            # help the humans by reporting self.name in the exception chain
+            raise ValueError(f"failed to describe '{self.name}' with value '{val}'") from ve
 
     def read_configuration(self):
         'Dictionary mapping names to value dicts with keys: value, timestamp'

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -156,6 +156,17 @@ def test_signal_copy():
     assert signal.timestamp == sig_copy.timestamp
 
 
+def test_signal_describe_fail():
+    """
+    Test Signal.describe() exception handling in the
+    case where a Signal's value is not bluesky-friendly.
+    """
+    signal = Signal(name="the_none_signal", value=None)
+    with pytest.raises(ValueError) as excinfo:
+        signal.describe()
+    assert "failed to describe 'the_none_signal' with value 'None'" in str(excinfo.value)
+
+
 def test_epicssignal_readonly(cleanup, signal_test_ioc):
     signal = EpicsSignalRO(signal_test_ioc.pvs['read_only'])
     cleanup.add(signal)


### PR DESCRIPTION
In a situation such as
```
In [1]: from ophyd.signal import Signal
In [2]: signal = Signal(name="the_none_signal", value=None)
In [3]: signal.describe()
...
ValueError: Cannot determine the appropriate bluesky-friendly data type for value None of Python type <class 'NoneType'>. Supported types include: int, float, str, and iterables such as list, tuple, np.ndarray, and so on.

```

I would like the exception to report the name of the Signal having a bluesky-unfriendly value.

This PR proposes chained exception handling in `Signal.describe()` to provide that information so the user sees
```
In [1]: from ophyd.signal import Signal
In [2]: signal = Signal(name="the_none_signal", value=None)
In [3]: signal.describe()
...
ValueError: Cannot determine the appropriate bluesky-friendly data type for value None of Python type <class 'NoneType'>. Supported types include: int, float, str, and iterables such as list, tuple, np.ndarray, and so on.
...
ValueError: failed to describe 'the_none_signal' with value 'None'
```