### PR TITLE
Make DeviceStatus report a fraction 0 rather than 1 once complete

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -625,7 +625,7 @@ class DeviceStatus(StatusBase):
     def _settled(self):
         '''Hook for when status has completed and settled'''
         for watcher in self._watchers:
-            watcher(name=self.device.name, fraction=1)
+            watcher(name=self.device.name, fraction=0.)
 
     __repr__ = __str__
 

--- a/ophyd/tests/test_epicsmotor.py
+++ b/ophyd/tests/test_epicsmotor.py
@@ -274,7 +274,7 @@ def test_watchers(motor):
     st.add_callback(callback)
     ev.wait()
     assert collector
-    assert collector[-1] == 1
+    assert collector[-1] == 0.
     assert len(collector) > 1
 
 


### PR DESCRIPTION
`MoveStatus` reports a `fraction` starting at 1 and tending towards 0 as the underlying operation progresses toward its goal. You would expect a `MoveStatus` to report a final fraction of 0, but instead it reports a 1. This is because it inherits from `DeviceStatus`, which reports a fraction of 1 as part of its `_settled` hook. 

One class treats `fraction` as "how far have we come?". The other treats it as "how far do we have to go?". This PR takes the behaviour of `MoveStatus` as canonical and modifies `DeviceStatus` in accordance. 