### PR TITLE
Added timeout arguments to FakeEpicsSignal

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1217,6 +1217,7 @@ class FakeEpicsSignal(SynSignal):
 
     def __init__(self, read_pv, write_pv=None, *, put_complete=False,
                  string=False, limits=False, auto_monitor=False, name=None,
+                 timeout=None, write_timeout=None, connection_timeout=None,
                  **kwargs):
         """
         Mimic EpicsSignal signature

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -127,7 +127,7 @@ class SampleNested(Device):
 
 class Sample(Device):
     egg = Cpt(SampleNested, ':EGG')
-    butter = Cpt(EpicsSignal, ':BUTTER')
+    butter = Cpt(EpicsSignal, ':BUTTER', timeout=10.0, write_timeout=10.0, connection_timeout=10.0)
     flour = Cpt(EpicsSignalRO, ':FLOUR')
     baster = FCpt(EpicsSignal, '{self.drawer}:BASTER')
     sink = FCpt(EpicsSignal, '{self.sink_location}:SINK')


### PR DESCRIPTION
Whilst writing some unit tests against devices at DLS I found that `make_fake_device` was failing against `Devices` where I had specified timeouts on creating `EpicsSignals`. Adding the timeouts arguments to `FakeEpicsSignal` fixes this. The modified test should fail on master but pass on this branch.