### PR TITLE
Test pod

### DIFF
--- a/scripts/epics_docker.sh
+++ b/scripts/epics_docker.sh
@@ -3,9 +3,9 @@
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $SCRIPTS_DIR/epics_exports.sh
 
-MOTOR_DOCKERIMAGE="nsls2/epics-docker:latest"
-PE_DOCKERIMAGE="nsls2/pyepics-docker:latest"
-AD_DOCKERIMAGE="prjemian/synapps-6.1-ad-3.7:latest"
+MOTOR_DOCKERIMAGE="docker.io/nsls2/epics-docker:latest"
+PE_DOCKERIMAGE="docker.io/nsls2/pyepics-docker:latest"
+AD_DOCKERIMAGE="docker.io/prjemian/synapps-6.1-ad-3.7:latest"
 
 docker pull ${MOTOR_DOCKERIMAGE}
 docker pull ${PE_DOCKERIMAGE}

--- a/scripts/epics_pod.sh
+++ b/scripts/epics_pod.sh
@@ -1,0 +1,46 @@
+#! /usr/bin/bash
+set -e
+set -o xtrace
+
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+MOTOR_DOCKERIMAGE="docker.io/nsls2/epics-docker:latest"
+PE_DOCKERIMAGE="docker.io/nsls2/pyepics-docker:latest"
+AD_DOCKERIMAGE="docker.io/prjemian/synapps-6.1-ad-3.7:latest"
+
+podman pull ${MOTOR_DOCKERIMAGE}
+podman pull ${PE_DOCKERIMAGE}
+podman pull ${AD_DOCKERIMAGE}
+
+podman pod stop ophyd_testing || true
+podman pod rm ophyd_testing || true
+
+# create the testing pod, do not expose anything
+podman pod create -n ophyd_testing
+
+# TODO do this with volumes
+# set up directories for AD
+mkdir -p /tmp/ophyd_AD_test/
+# Create YYYY/MM/DD subdirectories.
+# This is required because the images use a version of AD which
+# does not create missing directories.
+python $SCRIPTS_DIR/create_directories.py /tmp/ophyd_AD_test/data1
+
+podman run --pod ophyd_testing --name=sim_motor  --rm -d ${MOTOR_DOCKERIMAGE}
+podman run --pod ophyd_testing --name=area-detector --rm -dit -v /tmp/ophyd_AD_test:/tmp/ophyd_AD_test/ -e AD_PREFIX="ADSIM:" ${AD_DOCKERIMAGE} /bin/bash
+sleep 1  # Probably not needed?
+podman exec area-detector iocSimDetector/simDetector.sh start
+podman run --pod ophyd_testing --name=pyepics-container --rm -d ${PE_DOCKERIMAGE}
+
+# make testing container
+podman run --pod ophyd_testing --name test_target --rm -dit -v `pwd`:'/app' -w '/app' fedora bash
+# make testing env
+podman exec test_target python3 -m venv /test
+podman exec test_target /test/bin/python -m pip install --upgrade pip
+# install system deps
+podman exec test_target yum install python3-devel gcc -y
+# install python testing deps
+podman exec test_target /test/bin/python -m pip install -r requirements-test.txt
+# install (editable) ophyd
+podman exec test_target /test/bin/python -m pip install -ve .

--- a/scripts/test_in_pod.sh
+++ b/scripts/test_in_pod.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/bash
+set -e
+set -o xtrace
+
+podman exec -it test_target /test/bin/python -m pytest $@


### PR DESCRIPTION
To get this to work the subgid/subuid ranges need to be at least 70,000 (!!) because there in a 65k something gid for `nobody` and screen produces permission errors out of screen (which is used to run the AD ioc)

To run this

1. `scripts/epics_pod.sh` which will clean up any existing pods, pull down the test IOCs and start up a container with a source installed ophyd
2. `scritpts/test_in_pod.sh` which will pass all the CLI through to pytest, but run it inside a container in the pod

The nice thing about this is that none of the epics networking leaks out of the pod
