### PR TITLE
Rename dispatch -> generate_datum

### DIFF
--- a/docs/source/explanations/area-detector.rst
+++ b/docs/source/explanations/area-detector.rst
@@ -224,6 +224,7 @@ Area Detector Trigger dispatching
 
    ~detectors.DetectorBase
    ~detectors.DetectorBase.dispatch
+   ~detectors.DetectorBase.generate_datum
    ~detectors.DetectorBase.make_data_key
 
 The translation between the :meth:`~ophyd.device.BlueskyInterface.trigger` and triggering

--- a/docs/source/reference/release_notes.rst
+++ b/docs/source/reference/release_notes.rst
@@ -13,6 +13,9 @@ Changes
   determine if the signal is set as requested when used in a plan (via
   ``yield from bps.abs_set(...)`` or ``yield from bps.mv(...)``) as from
   within ophyd methods.
+* Deprecate ``DetectorBase.dispatch`` in favor of newly added
+  ``DetectorBase.generate_datum``
+
 
 
 1.6.4 (2022-04-08)

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -48,11 +48,13 @@ class DetectorBase(ADBase):
     Note that Plugin also inherits from ADBase.
     This adds some AD-specific methods that are not shared by the plugins.
     """
+
     _default_configuration_attrs = (ADBase._default_configuration_attrs +
                                     ('cam', ))
 
-    def dispatch(self, key, timestamp):
-        """Notify plugins of acquisition being complete.
+    def generate_datum(self, key, timestamp, datum_kwargs=None):
+        """
+        Notify plugins of acquisition being complete.
 
         When a new acquisition is started, this method is called with a
         key which is a label like 'light', 'dark', or 'gain8'.
@@ -67,12 +69,29 @@ class DetectorBase(ADBase):
            def generate_datum(key: str, timestamp: float, datum_kwargs: dict):
               ...
 
+        Parameters
+        ----------
+        key : str
+            The label for the datum that should be generated
+
+        timestamp : float
+            The time of the trigger
+
+        datum_kwargs : Dict[str, Any], optional
+            Any datum kwargs that should go to all children.
         """
+        if datum_kwargs is None:
+            datum_kwargs = {}
         file_plugins = [s for s in self._signals.values() if
                         hasattr(s, 'generate_datum')]
         for p in file_plugins:
             if p.enable.get():
-                p.generate_datum(key, timestamp, {})
+                p.generate_datum(key, timestamp, datum_kwargs)
+
+    def dispatch(self, key, timestamp):
+        return self.generate_datum(key, timestamp, {})
+
+    dispatch.__doc__ = generate_datum.__doc__
 
     def make_data_key(self):
         source = 'PV:{}'.format(self.prefix)

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -5,6 +5,7 @@
 
 .. _areaDetector: https://areadetector.github.io/master/index.html
 '''
+import warnings
 
 from .base import (ADBase, ADComponent as C)
 from . import cam
@@ -89,6 +90,11 @@ class DetectorBase(ADBase):
                 p.generate_datum(key, timestamp, datum_kwargs)
 
     def dispatch(self, key, timestamp):
+        warnings.warn(
+            ".dispatch is deprecated, use .generate_datum instead",
+            stacklevel=2
+        )
+
         return self.generate_datum(key, timestamp, {})
 
     dispatch.__doc__ = generate_datum.__doc__

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -133,7 +133,7 @@ class SingleTrigger(TriggerBase):
 
         self._status = self._status_type(self)
         self._acquisition_signal.put(1, wait=False)
-        self.dispatch(self._image_name, ttime.time())
+        self.generate_datum(self._image_name, ttime.time(), {})
         return self._status
 
     def _acquire_changed(self, value=None, old_value=None, **kwargs):
@@ -258,7 +258,7 @@ class MultiTrigger(TriggerBase):
         logger.debug('Configuring signals for acquisition labeled %r', key)
         for sig, val in signals_settings.items():
             sig.set(val).wait()
-        self.dispatch(key, ttime.time())
+        self.generate_datum(key, ttime.time(), {})
         self._acquisition_signal.put(1, wait=False)
 
     def _acquire_changed(self, value=None, old_value=None, **kwargs):


### PR DESCRIPTION
While talking through how to implement a new area detector (the exspress3 community IOC) in Ophyd, we realized that it would be a lot clearer if we renamed `dispatch` -> `generate_datum`.

If we do not want to deprecate the old name I can drop the last commit.