### PR TITLE
Make SynAxis produce an updating MoveStatus

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -470,7 +470,7 @@ class SynAxis(Device):
         self._events_per_move = events_per_move
         self.egu = egu
 
-    def set(self, value: float) -> StatusBase:
+    def set(self, value: float) -> MoveStatus:
         old_setpoint = self.sim_state["setpoint"]
         distance = value - old_setpoint
         self.sim_state["setpoint"] = value

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -11,11 +11,6 @@ import weakref
 from collections import OrderedDict, deque
 from functools import partial
 from tempfile import mkdtemp
-
-from .signal import Signal, EpicsSignal, EpicsSignalRO
-from .areadetector.base import EpicsSignalWithRBV
-from .status import DeviceStatus, MoveStatus, StatusBase
-from .device import Device, Component as Cpt, DynamicDeviceComponent as DDCpt, Kind
 from types import SimpleNamespace
 
 import numpy as np
@@ -35,7 +30,7 @@ from .pseudopos import (
     real_position_argument,
 )
 from .signal import EpicsSignal, EpicsSignalRO, Signal
-from .status import DeviceStatus, StatusBase
+from .status import DeviceStatus, MoveStatus, StatusBase
 from .utils import LimitError, ReadOnlyError
 
 # two convenience functions 'vendored' from bluesky.utils

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -412,6 +412,10 @@ class SynAxis(Device):
         Used internally if this Signal is made part of a larger Device.
     kind : a member the Kind IntEnum (or equivalent integer), optional
         Default is Kind.normal. See Kind for options.
+    events_per_move: number of events to push to a Status object for each move. 
+        Must be at least 1, more than one will give "moving" statuses that can be
+        used for progress bars etc.
+        Default is 6.
     """
 
     readback = Cpt(_ReadbackSignal, value=0, kind="hinted")

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -466,6 +466,8 @@ class SynAxis(Device):
 
         super().__init__(name=name, parent=parent, labels=labels, kind=kind, **kwargs)
         self.readback.name = self.name
+        if events_per_move < 1:
+            raise KeyError("At least 1 event per move is required")
         self._events_per_move = events_per_move
         self.egu = egu
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -466,7 +466,7 @@ class SynAxis(Device):
         super().__init__(name=name, parent=parent, labels=labels, kind=kind, **kwargs)
         self.readback.name = self.name
         if events_per_move < 1:
-            raise KeyError("At least 1 event per move is required")
+            raise ValueError("At least 1 event per move is required")
         self._events_per_move = events_per_move
         self.egu = egu
 

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -469,7 +469,7 @@ class SynAxis(Device):
         self._events_per_move = events_per_move
         self.egu = egu
 
-    def set(self, value: float) -> None:
+    def set(self, value: float) -> StatusBase:
         old_setpoint = self.sim_state["setpoint"]
         distance = value - old_setpoint
         self.sim_state["setpoint"] = value

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -412,10 +412,10 @@ class SynAxis(Device):
         Used internally if this Signal is made part of a larger Device.
     kind : a member the Kind IntEnum (or equivalent integer), optional
         Default is Kind.normal. See Kind for options.
-    events_per_move: number of events to push to a Status object for each move. 
+    events_per_move: number of events to push to a Status object for each move.
         Must be at least 1, more than one will give "moving" statuses that can be
         used for progress bars etc.
-        Default is 6.
+        Default is 1.
     """
 
     readback = Cpt(_ReadbackSignal, value=0, kind="hinted")
@@ -440,7 +440,7 @@ class SynAxis(Device):
         parent=None,
         labels=None,
         kind=None,
-        events_per_move: int = 6,
+        events_per_move: int = 1,
         egu: str = "mm",
         **kwargs,
     ):

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -1,4 +1,3 @@
-
 import shutil
 import tempfile
 
@@ -101,7 +100,7 @@ def test_random_state_gauss2d():
 
 @pytest.mark.parametrize("events_per_move", [0, -1, -10])
 def test_synaxis_requires_at_least_1_event_per_move(events_per_move):
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         SynAxis(name="motor1", events_per_move=0)
 
 

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -1,15 +1,26 @@
-
 import shutil
 import tempfile
 
 
-from ophyd.sim import (SynGauss, Syn2DGauss, SynAxis, make_fake_device,
-                       FakeEpicsSignal, FakeEpicsSignalRO,
-                       FakeEpicsSignalWithRBV, FakeEpicsPathSignal,
-                       clear_fake_device, instantiate_fake_device,
-                       SynSignalWithRegistry)
-from ophyd.device import (Device, Component as Cpt, FormattedComponent as FCpt,
-                          DynamicDeviceComponent as DDCpt)
+from ophyd.sim import (
+    SynGauss,
+    Syn2DGauss,
+    SynAxis,
+    make_fake_device,
+    FakeEpicsSignal,
+    FakeEpicsSignalRO,
+    FakeEpicsSignalWithRBV,
+    FakeEpicsPathSignal,
+    clear_fake_device,
+    instantiate_fake_device,
+    SynSignalWithRegistry,
+)
+from ophyd.device import (
+    Device,
+    Component as Cpt,
+    FormattedComponent as FCpt,
+    DynamicDeviceComponent as DDCpt,
+)
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
 from ophyd.areadetector.base import EpicsSignalWithRBV
 from ophyd.areadetector.paths import EpicsPathSignal
@@ -111,18 +122,22 @@ def test_random_state_gauss2d():
     assert dlist[0] == dlist[1]
 
 
+@pytest.mark.parametrize("events_per_move", [0, -1, -10])
+def test_synaxis_requires_at_least_1_event_per_move(events_per_move):
+    with pytest.raises(KeyError):
+        SynAxis(name="motor1", events_per_move=0)
+
 
 @pytest.mark.parametrize("events_per_move", [1, 2, 6, 20])
 def test_synaxis_subcribe(events_per_move: int):
-    hits = dict.fromkeys(['r', 's', 'a'], 0)
-    vals = dict.fromkeys(['r', 's', 'a'], None)
+    hits = dict.fromkeys(["r", "s", "a"], 0)
+    vals = dict.fromkeys(["r", "s", "a"], None)
 
     def p1(tar, value):
         hits[tar] += 1
         vals[tar] = value
 
-
-    motor = SynAxis(name='motor1', events_per_move=events_per_move)
+    motor = SynAxis(name="motor1", events_per_move=events_per_move)
     # prime the cb cache so these run an subscription
     motor.set(0)
     motor.subscribe(lambda *, value, _tar="a", **kwargs: p1(_tar, value))

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -1,30 +1,7 @@
+
 import shutil
 import tempfile
 
-
-from ophyd.sim import (
-    SynGauss,
-    Syn2DGauss,
-    SynAxis,
-    make_fake_device,
-    FakeEpicsSignal,
-    FakeEpicsSignalRO,
-    FakeEpicsSignalWithRBV,
-    FakeEpicsPathSignal,
-    clear_fake_device,
-    instantiate_fake_device,
-    SynSignalWithRegistry,
-)
-from ophyd.device import (
-    Device,
-    Component as Cpt,
-    FormattedComponent as FCpt,
-    DynamicDeviceComponent as DDCpt,
-)
-from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
-from ophyd.areadetector.base import EpicsSignalWithRBV
-from ophyd.areadetector.paths import EpicsPathSignal
-from ophyd.utils import ReadOnlyError, LimitError, DisconnectedError
 import numpy as np
 import pytest
 

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -1,6 +1,19 @@
+
 import shutil
 import tempfile
 
+
+from ophyd.sim import (SynGauss, Syn2DGauss, SynAxis, make_fake_device,
+                       FakeEpicsSignal, FakeEpicsSignalRO,
+                       FakeEpicsSignalWithRBV, FakeEpicsPathSignal,
+                       clear_fake_device, instantiate_fake_device,
+                       SynSignalWithRegistry)
+from ophyd.device import (Device, Component as Cpt, FormattedComponent as FCpt,
+                          DynamicDeviceComponent as DDCpt)
+from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
+from ophyd.areadetector.base import EpicsSignalWithRBV
+from ophyd.areadetector.paths import EpicsPathSignal
+from ophyd.utils import ReadOnlyError, LimitError, DisconnectedError
 import numpy as np
 import pytest
 
@@ -98,15 +111,18 @@ def test_random_state_gauss2d():
     assert dlist[0] == dlist[1]
 
 
-def test_synaxis_subcribe():
-    hits = dict.fromkeys(["r", "s", "a"], 0)
-    vals = dict.fromkeys(["r", "s", "a"], None)
+
+@pytest.mark.parametrize("events_per_move", [1, 2, 6, 20])
+def test_synaxis_subcribe(events_per_move: int):
+    hits = dict.fromkeys(['r', 's', 'a'], 0)
+    vals = dict.fromkeys(['r', 's', 'a'], None)
 
     def p1(tar, value):
         hits[tar] += 1
         vals[tar] = value
 
-    motor = SynAxis(name="motor1")
+
+    motor = SynAxis(name='motor1', events_per_move=events_per_move)
     # prime the cb cache so these run an subscription
     motor.set(0)
     motor.subscribe(lambda *, value, _tar="a", **kwargs: p1(_tar, value))
@@ -125,7 +141,9 @@ def test_synaxis_subcribe():
     assert vals["a"] == motor.readback.get()
     assert vals["s"] == motor.setpoint.get()
 
-    assert all(v == 2 for v in hits.values())
+    assert hits["r"] == 1 + events_per_move
+    assert hits["a"] == 1 + events_per_move
+    assert hits["s"] == 2
 
 
 def test_synaxis_timestamps():


### PR DESCRIPTION
* Change `SynAxis` to make a `MoveStatus` rather than a `DeviceStatus`.
* Update this status periodically during motion (period is customisation with a constructor parameter, defaults to 6 times per move)
* Example use: progress bars with Bluesky