### PR TITLE
AD's FilePath PV **must** end with a path delimiter specific to the IOC's OS

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -267,12 +267,15 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
         rootp = self.reg_root
         if self.path_semantics == 'posix':
             ret = PurePosixPath(self._write_path_template)
+            delimiter = "/"
         elif self.path_semantics == 'windows':
             ret = PureWindowsPath(self._write_path_template)
+            delimiter = "\\"
         elif self.path_semantics is None:
             # We are forced to guess which path semantics to use.
             # Guess that the AD driver is running on the same OS as this client.
             ret = PurePath(self._write_path_template)
+            delimiter = pathlib.os.sep
         else:
             # This should never happen, but just for the sake of future-proofing...
             raise ValueError(f"Cannot handle path_semantics={self.path_semantics}")
@@ -285,7 +288,7 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
                     ('root: {!r} in not consistent with '
                      'read_path_template: {!r}').format(rootp, ret))
 
-        return str(ret)
+        return f"{ret}{delimiter}"  # per AD IOC code, MUST end with delimiter
 
     @write_path_template.setter
     def write_path_template(self, val):


### PR DESCRIPTION
- FIX #1037