### PR TITLE
API: deprecated use of set_and_wait function

### DIFF
--- a/docs/source/reference/release_notes.rst
+++ b/docs/source/reference/release_notes.rst
@@ -2,6 +2,18 @@
  Release History
 =================
 
+1.7.0 (????-??-??)
+==================
+
+Changes
+-------
+
+* Deprecated ``ophyd.utils.epics_pv.set_and_wait(obj, val)`` in favor of
+  ``obj.set(val).wait()``.  This ensures that the same logic is used to
+  determine if the signal is set as requested when used in a plan (via
+  ``yield from bps.abs_set(...)`` or ``yield from bps.mv(...)``) as from
+  within ophyd methods.
+
 
 1.6.4 (2022-04-08)
 ==================

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -31,7 +31,6 @@ from collections import defaultdict
 from itertools import count
 
 from ..device import GenerateDatumInterface, BlueskyInterface, Staged
-from ..utils import set_and_wait
 
 logger = logging.getLogger(__name__)
 
@@ -427,13 +426,13 @@ class FileStorePluginBase(FileStoreBase):
 
         # Ensure we do not have an old file open.
         if self.file_write_mode != 'Single':
-            set_and_wait(self.capture, 0)
+            self.capture.set(0).wait()
         # These must be set before parent is staged (specifically
         # before capture mode is turned on. They will not be reset
         # on 'unstage' anyway.
         self.file_path.set(write_path).wait()
-        set_and_wait(self.file_name, filename)
-        set_and_wait(self.file_number, 0)
+        self.file_name.set(filename).wait()
+        self.file_number.set(0).wait()
         super().stage()
 
         # AD does this same templating in C, but we can't access it

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -35,7 +35,7 @@ from .base import (ADBase, ADComponent as Cpt,
 from .. import (Device, Component, FormattedComponent as FCpt)
 from ..signal import (EpicsSignalRO, EpicsSignal, ArrayAttributeSignal)
 from ..device import GenerateDatumInterface
-from ..utils import enum, set_and_wait
+from ..utils import enum
 from ..utils.errors import (PluginMisconfigurationError, DestroyedError, UnprimedPlugin)
 from .paths import EpicsPathSignal
 
@@ -922,7 +922,7 @@ class HDF5Plugin(FilePlugin, version=(1, 9, 1), version_type='ADCore'):
         The plugin has to 'see' one acquisition before it is ready to capture.
         This sets the array size, etc.
         """
-        set_and_wait(self.enable, 1)
+        self.enable.set(1).wait()
         sigs = OrderedDict([(self.parent.cam.array_callbacks, 1),
                             (self.parent.cam.image_mode, 'Single'),
                             (self.parent.cam.trigger_mode, 'Internal'),
@@ -935,13 +935,13 @@ class HDF5Plugin(FilePlugin, version=(1, 9, 1), version_type='ADCore'):
 
         for sig, val in sigs.items():
             ttime.sleep(0.1)  # abundance of caution
-            set_and_wait(sig, val)
+            sig.set(val).wait()
 
         ttime.sleep(2)  # wait for acquisition
 
         for sig, val in reversed(list(original_vals.items())):
             ttime.sleep(0.1)
-            set_and_wait(sig, val)
+            sig.set(val).wait()
 
     def stage(self):
         if np.array(self.array_size.get()).sum() == 0:

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -15,7 +15,6 @@ import itertools
 
 from ..status import DeviceStatus
 from ..device import BlueskyInterface, Staged
-from ..utils import set_and_wait
 
 logger = logging.getLogger(__name__)
 
@@ -258,7 +257,7 @@ class MultiTrigger(TriggerBase):
             return
         logger.debug('Configuring signals for acquisition labeled %r', key)
         for sig, val in signals_settings.items():
-            set_and_wait(sig, val)
+            sig.set(val).wait()
         self.dispatch(key, ttime.time())
         self._acquisition_signal.put(1, wait=False)
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -15,7 +15,7 @@ from collections import (OrderedDict, namedtuple)
 from .ophydobj import OphydObject, Kind
 from .signal import Signal
 from .status import DeviceStatus, StatusBase
-from .utils import (ExceptionBundle, set_and_wait, RedundantStaging,
+from .utils import (ExceptionBundle, RedundantStaging,
                     doc_annotation_forwarder, underscores_to_camel_case,
                     getattrs)
 
@@ -547,7 +547,7 @@ class BlueskyInterface:
                 self.log.debug("Setting %s to %r (original value: %r)",
                                self.name,
                                val, original_vals[sig])
-                set_and_wait(sig, val)
+                sig.set(val).wait()
                 # It worked -- now add it to this list of sigs to unstage.
                 self._original_vals[sig] = original_vals[sig]
             devices_staged.append(self)
@@ -603,7 +603,7 @@ class BlueskyInterface:
             self.log.debug("Setting %s back to its original value: %r)",
                            self.name,
                            val)
-            set_and_wait(sig, val)
+            sig.set(val).wait()
             self._original_vals.pop(sig)
         devices_unstaged.append(self)
 
@@ -1422,7 +1422,7 @@ class Device(BlueskyInterface, OphydObject):
                     raise ValueError("%s is not one of the "
                                      "configuration_fields, so it cannot be "
                                      "changed using configure" % key)
-            set_and_wait(getattr(self, key), val)
+            getattr(self, key).set(val).wait()
         new = self.read_configuration()
         return old, new
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1632,26 +1632,7 @@ def required_for_connection(func=None, *, description=None, device=None):
 def _wait_for_connection_context(value, doc):
     @contextlib.contextmanager
     def wrapped(dev):
-        f'''Context manager which changes the wait behavior of lazy signal instantiation
 
-        By default, upon instantiation of a lazy signal, `wait_for_connection`
-        is called.  While a common source of confusion, this is done
-        intentionally and for good reason: without this functionality in place,
-        any new lazy signal will generally take a finite amount of time to
-        connect. This then requires that the user manually call
-        `wait_for_connection` each time before using the signal.
-
-        In certain cases, it can be desirable to override this behavior. For
-        instance, when instantiating multiple lazy signals or instantiating a
-        signal just so that a subscription can be added.
-
-        {doc}
-
-        Parameters
-        ----------
-        dev : Device
-            The device to temporarily change
-        '''
         orig = dev.lazy_wait_for_connection
         dev.lazy_wait_for_connection = value
         try:
@@ -1659,6 +1640,26 @@ def _wait_for_connection_context(value, doc):
         finally:
             dev.lazy_wait_for_connection = orig
 
+    wrapped.__doc__ = f'''Context manager which changes the wait behavior of lazy signal instantiation
+
+By default, upon instantiation of a lazy signal, `wait_for_connection`
+is called.  While a common source of confusion, this is done
+intentionally and for good reason: without this functionality in place,
+any new lazy signal will generally take a finite amount of time to
+connect. This then requires that the user manually call
+`wait_for_connection` each time before using the signal.
+
+In certain cases, it can be desirable to override this behavior. For
+instance, when instantiating multiple lazy signals or instantiating a
+signal just so that a subscription can be added.
+
+{doc}
+
+Parameters
+----------
+dev : Device
+    The device to temporarily change
+'''
     return wrapped
 
 

--- a/ophyd/tests/test_utils.py
+++ b/ophyd/tests/test_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import tempfile
 
 from ophyd.utils import epics_pvs as epics_utils
-from ophyd.utils import (make_dir_tree, makedirs, set_and_wait)
+from ophyd.utils import make_dir_tree, makedirs
 from ophyd import Signal
 
 
@@ -105,7 +105,7 @@ def test_valid_pvname():
 def test_array_into_softsignal():
     data = np.array([1, 2, 3])
     s = Signal(name='np.array')
-    set_and_wait(s, data)
+    s.set(data).wait()
     assert np.all(s.get() == data)
 
 
@@ -120,11 +120,15 @@ def test_none_signal():
         def get(self):
             return next(self._value_cycle)
 
-    cs = CycleSignal(name='cycle', value_cycle=[0, 1, 2, None, 4])
+    cs = CycleSignal(
+        name='cycle',
+        value_cycle=[0, 1, 2, None, 4],
+        tolerance=.01, rtolerance=0.1
+    )
 
-    set_and_wait(cs, 4, rtol=.01, atol=.01)
+    cs.set(4).wait()
 
 
 def test_set_signal_to_None():
     s = Signal(value='0', name='bob')
-    set_and_wait(s, None, timeout=1)
+    s.set(None).wait(timeout=1)

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -6,6 +6,8 @@ import functools
 import numpy as np
 import typing
 
+import warnings
+
 from .errors import DisconnectedError, OpException
 
 
@@ -201,8 +203,8 @@ def raise_if_disconnected(fcn):
     return wrapper
 
 
-def set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
-                 atol=None):
+def _set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
+                  atol=None):
     """Set a signal to a value and wait until it reads correctly.
 
     For floating point values, it is strongly recommended to set a tolerance.
@@ -267,6 +269,16 @@ def set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
             raise TimeoutError("Attempted to set %r to value %r and timed "
                                "out after %r seconds. Current value is %r." %
                                (signal, val, timeout, current_value))
+
+
+@functools.wraps(_set_and_wait)
+def set_and_wait(*args, **kwargs):
+    warnings.warn(
+        "The function `set_and_wait` has been made private, prefer to use"
+        "`obj.set(value).wait(timeout)` rather than "
+        "`set_and_wait(obj, value)`",
+        stacklevel=2)
+    return _set_and_wait(*args, **kwargs)
 
 
 def _compare_maybe_enum(a, b, enums, atol, rtol):


### PR DESCRIPTION
The functionality of the free function `set_and_wait(obj, val)` can be better
accomplished via `obj.set(val).wait()` and the existence of this function leads
to confusion.