### PR TITLE
ENH: Added FakeEpicsPathSignal for testing

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -17,6 +17,7 @@ from tempfile import mkdtemp
 
 from .signal import Signal, EpicsSignal, EpicsSignalRO
 from .areadetector.base import EpicsSignalWithRBV
+from .areadetector.paths import EpicsPathSignal
 from .status import DeviceStatus, StatusBase
 from .device import (Device, Component as Cpt,
                      DynamicDeviceComponent as DDCpt, Kind)
@@ -1366,9 +1367,21 @@ class FakeEpicsSignalWithRBV(FakeEpicsSignal):
         super().__init__(prefix + '_RBV', write_pv=prefix, **kwargs)
 
 
+class FakeEpicsPathSignal(FakeEpicsSignal):
+    """
+    FakeEpicsPathSignal; used in AreaDetector for interacting with paths
+    """
+
+    _metadata_keys = EpicsPathSignal._metadata_keys
+
+    def __init__(self, prefix, path_semantics, **kwargs):
+        super().__init__(prefix + "_RBV", write_pv=prefix, **kwargs)
+
+
 fake_device_cache = {EpicsSignal: FakeEpicsSignal,
                      EpicsSignalRO: FakeEpicsSignalRO,
                      EpicsSignalWithRBV: FakeEpicsSignalWithRBV,
+                     EpicsPathSignal: FakeEpicsPathSignal,
                      }
 
 

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -1,11 +1,13 @@
 from ophyd.sim import (SynGauss, Syn2DGauss, SynAxis, make_fake_device,
                        FakeEpicsSignal, FakeEpicsSignalRO,
-                       FakeEpicsSignalWithRBV, clear_fake_device,
-                       instantiate_fake_device, SynSignalWithRegistry)
+                       FakeEpicsSignalWithRBV, FakeEpicsPathSignal,
+                       clear_fake_device, instantiate_fake_device,
+                       SynSignalWithRegistry)
 from ophyd.device import (Device, Component as Cpt, FormattedComponent as FCpt,
                           DynamicDeviceComponent as DDCpt)
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
 from ophyd.areadetector.base import EpicsSignalWithRBV
+from ophyd.areadetector.paths import EpicsPathSignal
 from ophyd.utils import ReadOnlyError, LimitError, DisconnectedError
 import numpy as np
 import pytest
@@ -146,6 +148,7 @@ def test_make_fake_device():
     assert make_fake_device(EpicsSignal) == FakeEpicsSignal
     assert make_fake_device(EpicsSignalRO) == FakeEpicsSignalRO
     assert make_fake_device(EpicsSignalWithRBV) == FakeEpicsSignalWithRBV
+    assert make_fake_device(EpicsPathSignal) == FakeEpicsPathSignal
 
     FakeSample = make_fake_device(Sample)
     my_fake = FakeSample('KITCHEN', name='kitchen')


### PR DESCRIPTION
See #1041 

* Adds a `FakeEpicsPathSignal` to allow for testing device logic that references an `EpicsPathSignal`