### PR TITLE
ENH: Upstream InternalSignal, allow passing of put arguments through set

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -670,6 +670,22 @@ class DerivedSignal(Signal):
             yield ('derived_from', self._derived_from)
 
 
+class InternalSignal(SignalRO):
+    """
+    Class Signal that stores info but should only be updated by the class.
+    SignalRO can be updated with _readback, but this does not process
+    callbacks. For the signal to behave normally, we need to bypass the put
+    override.
+    To put to one of these signals, simply call put with force=True
+    """
+
+    def put(self, value, *, timestamp=None, force=False):
+        return Signal.put(self, value, timestamp=timestamp, force=force)
+
+    def set(self, value, *, timestamp=None, force=False):
+        return Signal.set(self, value, timestamp=timestamp, force=force)
+
+
 class EpicsSignalBase(Signal):
     '''A read-only EpicsSignal -- that is, one with no `write_pv`
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -252,7 +252,7 @@ class Signal(OphydObject):
         self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value,
                        value=value, **md_for_callback)
 
-    def _set_and_wait(self, value, timeout):
+    def _set_and_wait(self, value, timeout, **kwargs):
         '''
         Overridable hook for subclasses to override :meth:`.set` functionality.
 
@@ -269,9 +269,10 @@ class Signal(OphydObject):
         return _set_and_wait(self, value,
                              timeout=timeout,
                              atol=self.tolerance,
-                             rtol=self.rtolerance)
+                             rtol=self.rtolerance,
+                             **kwargs)
 
-    def set(self, value, *, timeout=None, settle_time=None):
+    def set(self, value, *, timeout=None, settle_time=None, **kwargs):
         '''
         Set the value of the Signal and return a Status object.
 
@@ -282,30 +283,30 @@ class Signal(OphydObject):
             case of basic soft Signals
         '''
         self.log.info(
-            'set(value=%s, timeout=%s, settle_time=%s)',
-            value, timeout, settle_time
+            'set(value=%s, timeout=%s, settle_time=%s, kwargs=%s)',
+            value, timeout, settle_time, kwargs
         )
 
         def set_thread():
             try:
-                self._set_and_wait(value, timeout)
+                self._set_and_wait(value, timeout, **kwargs)
             except TimeoutError:
                 success = False
                 self.log.warning(
-                    '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
-                    self.name, value, timeout, self.tolerance, self.rtolerance
+                    '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s, kwargs=%s)',
+                    self.name, value, timeout, self.tolerance, self.rtolerance, kwargs
                 )
             except Exception:
                 success = False
                 self.log.exception(
-                    '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s)',
-                    self.name, value, timeout, self.tolerance, self.rtolerance
+                    '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s, kwargs=%s)',
+                    self.name, value, timeout, self.tolerance, self.rtolerance, kwargs
                 )
             else:
                 success = True
                 self.log.info(
-                    '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s) succeeded => %s',
-                    self.name, value, timeout, self.tolerance, self.rtolerance, self._readback)
+                    '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s, kwargs=%s) succeeded => %s',
+                    self.name, value, timeout, self.tolerance, self.rtolerance, kwargs, self._readback)
 
                 if settle_time is not None:
                     self.log.info('settling for %d seconds', settle_time)
@@ -706,7 +707,7 @@ class InternalSignalMixin:
         """
         if not internal:
             raise InternalSignalError()
-        return super().set(*args, **kwargs)
+        return super().set(*args, internal=internal, **kwargs)
 
 
 class InternalSignal(InternalSignalMixin, Signal):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -675,7 +675,7 @@ class InternalSignalMixin:
     Mix-in class for adding the `InternalSignal` behavior to any signal class.
 
     A signal class with this mixin will reject all sets and puts unless
-    force=True is passed as an argument.
+    internal=True is passed as an argument.
 
     The intended use for this is to signify that a signal is for internal use
     by the class only. That is, it would be a mistake to try to cause puts to
@@ -686,27 +686,27 @@ class InternalSignalMixin:
     or EPICS signals that should be written to by the class but are likely to
     cause issues for external writes due to behavior complexity.
     """
-    def put(self, *args, force: bool = False, **kwargs):
+    def put(self, *args, internal: bool = False, **kwargs):
         """
         Write protection for an internal signal.
 
         This method is not intended to be used from outside of the device
-        that defined this signal. All writes must be done with force=True.
+        that defined this signal. All writes must be done with internal=True.
         """
-        if not force:
+        if not internal:
             raise InternalSignalError()
-        return super().put(*args, force=force, **kwargs)
+        return super().put(*args, **kwargs)
 
-    def set(self, *args, force: bool = False, **kwargs):
+    def set(self, *args, internal: bool = False, **kwargs):
         """
         Write protection for an internal signal.
 
         This method is not intended to be used from outside of the device
-        that defined this signal. All writes must be done with force=True.
+        that defined this signal. All writes must be done with internal=True.
         """
-        if not force:
+        if not internal:
             raise InternalSignalError()
-        return super().set(*args, force=force, **kwargs)
+        return super().set(*args, **kwargs)
 
 
 class InternalSignal(InternalSignalMixin, Signal):
@@ -714,7 +714,7 @@ class InternalSignal(InternalSignalMixin, Signal):
     A soft Signal that stores data but should only be updated by the Device.
 
     Unlike SignalRO, which will unilaterally block all writes, this will
-    allow writes with force=True.
+    allow writes with internal=True.
 
     The intended use for this is to signify that a signal is for internal use
     by the class only. That is, it would be a mistake to try to cause puts to
@@ -737,7 +737,7 @@ class InternalSignalError(ReadOnlyError):
                 'This signal is for internal use only. '
                 'You should not be writing to it from outside '
                 'the parent class. If you do need to write to '
-                'this signal, you can use force=True.'
+                'this signal, you can use signal.put(value, internal=True).'
             )
         super().__init__(message)
 

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -168,13 +168,13 @@ def test_signal_describe_fail():
     assert "failed to describe 'the_none_signal' with value 'None'" in str(excinfo.value)
 
 
-def test_internalsignal_write_with_force():
+def test_internalsignal_write_from_internal():
     test_signal = InternalSignal(name='test_signal')
     for value in range(10):
-        test_signal.put(value, force=True)
+        test_signal.put(value, internal=True)
         assert test_signal.get() == value
     for value in range(10):
-        test_signal.set(value, force=True)
+        test_signal.set(value, internal=True).wait()
         assert test_signal.get() == value
 
 

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -5,7 +5,8 @@ import pytest
 import threading
 
 from ophyd import get_cl
-from ophyd.signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)
+from ophyd.signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal,
+                          InternalSignal, InternalSignalError)
 from ophyd.utils import (ReadOnlyError, AlarmStatus, AlarmSeverity)
 from ophyd.status import wait
 from ophyd.areadetector.paths import EpicsPathSignal
@@ -165,6 +166,25 @@ def test_signal_describe_fail():
     with pytest.raises(ValueError) as excinfo:
         signal.describe()
     assert "failed to describe 'the_none_signal' with value 'None'" in str(excinfo.value)
+
+
+def test_internalsignal_write_with_force():
+    test_signal = InternalSignal(name='test_signal')
+    for value in range(10):
+        test_signal.put(value, force=True)
+        assert test_signal.get() == value
+    for value in range(10):
+        test_signal.set(value, force=True)
+        assert test_signal.get() == value
+
+
+def test_internalsignal_write_protection():
+    test_signal = InternalSignal(name='test_signal')
+    for value in range(10):
+        with pytest.raises(InternalSignalError):
+            test_signal.put(value)
+        with pytest.raises(InternalSignalError):
+            test_signal.set(value)
 
 
 def test_epicssignal_readonly(cleanup, signal_test_ioc):

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -204,7 +204,7 @@ def raise_if_disconnected(fcn):
 
 
 def _set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
-                  atol=None):
+                  atol=None, **kwargs):
     """Set a signal to a value and wait until it reads correctly.
 
     For floating point values, it is strongly recommended to set a tolerance.
@@ -223,12 +223,15 @@ def _set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
         allowed relative tolerance between the readback and setpoint values
     atol : float, optional
         allowed absolute tolerance between the readback and setpoint values
+    kwargs :
+        additional keyword arguments will be passed directly into the
+        underlying "signal.put" call.
 
     Raises
     ------
     TimeoutError if timeout is exceeded
     """
-    signal.put(val)
+    signal.put(val, **kwargs)
     expiration_time = ttime.time() + timeout if timeout is not None else None
     current_value = signal.get()
 


### PR DESCRIPTION
- Add `InternalSignal` from downstream `pcdsdevices`. This is a utility signal class to be used by devices that want to store data in soft signals but want other code to avoid putting to these signals. We can't prevent other code from interfering, but we can make the intent very clear by declaring that signal as an `InternalSignal` and require an extra `internal=True` kwarg to put or set a new value. I've used this in the past to create in-software `done` signals for positioner classes and `status`-like signals that would be read-only if in EPICS, but cannot be read-only because the device itself does need to be able to update them from python.
- In order to make this work for `set`, I needed to be able to pass the `internal=True` kwarg into `set_and_wait`. This necessitated a cascade of `**kwargs` passing through the set chain all the way down to `put`.
- Basic tests have been added for the `InternalSignal` class

This is part of the EPICS Codeathon effort for May 2022.