### PR TITLE
ENH: Upstream helpful PV Positioners, add wait_for_value util

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -80,7 +80,8 @@ from .signal import (Signal, SignalRO, EpicsSignal, EpicsSignalRO, DerivedSignal
 # Positioners
 from .positioner import (PositionerBase, SoftPositioner)  # noqa: F401, F402, E402
 from .epics_motor import EpicsMotor, MotorBundle  # noqa: F401, F402, E402
-from .pv_positioner import (PVPositioner, PVPositionerPC)  # noqa: F401, F402, E402
+from .pv_positioner import (PVPositioner, PVPositionerPC,  # noqa: F401, F402, E402
+                            PVPositionerIsClose, PVPositionerDone)  # noqa: F401, F402, E402
 from .pseudopos import (PseudoPositioner, PseudoSingle)  # noqa: F401, F402, E402
 
 # Devices

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -309,8 +309,7 @@ class PVPositionerComparator(PVPositioner):
 
     The done state is set by a comparison function defined in the class body.
     The comparison function takes two arguments, readback and setpoint,
-    returning True if we are close enough to be considered done or False if we
-    are too far away.
+    returning True if we are considered done or False if we are not.
 
     This class is intended to support `PVPositionerIsClose`, but exists to
     allow some flexibility if we want to use other metrics for deciding if

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -324,13 +324,13 @@ class PVPositionerComparator(PVPositioner):
     done_value = 1
 
     def __init__(self, prefix: str, *, name: str, **kwargs):
+        self._last_readback = None
+        self._last_setpoint = None
+        super().__init__(prefix, name=name, **kwargs)
         if None in (self.setpoint, self.readback):
             raise NotImplementedError('PVPositionerComparator requires both '
                                       'a setpoint and a readback signal to '
                                       'compare!')
-        self._last_readback = None
-        self._last_setpoint = None
-        super().__init__(prefix, name=name, **kwargs)
 
     def __init_subclass__(cls, **kwargs):
         """Set up callbacks in subclass."""

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -367,7 +367,9 @@ class PVPositionerComparator(PVPositioner):
         if None not in (self._last_readback, self._last_setpoint):
             is_done = self.done_comparator(self._last_readback,
                                            self._last_setpoint)
-            self.done.put(int(is_done), internal=True)
+            done_value = int(is_done)
+            if done_value != self.done.get():
+                self.done.put(done_value, internal=True)
 
 
 class PVPositionerIsClose(PVPositionerComparator):

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -438,7 +438,7 @@ class PVPositionerDone(PVPositioner):
     positioner, but the truth is that it is just a PV.
 
     When the user asks for a move, set done to 0 and then back to 1.
-    This simluates the normal positioner behavior.
+    This simulates the normal positioner behavior.
     """
     setpoint = Cpt(EpicsSignal, '', kind='hinted')
 

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -2,11 +2,15 @@
 
 import logging
 
+import numpy as np
+
 from .utils.epics_pvs import fmt_time
 
+from .device import Component as Cpt
 from .device import (Device, required_for_connection)
 from .ophydobj import Kind
 from .positioner import PositionerBase
+from .signal import InternalSignal
 from .status import wait as status_wait
 
 logger = logging.getLogger(__name__)
@@ -296,3 +300,140 @@ class PVPositionerPC(PVPositioner):
         else:
             self.setpoint.put(position, wait=False,
                               callback=done_moving)
+
+
+class PVPositionerComparator(PVPositioner):
+    """
+    PV Positioner with a software done signal.
+    The done state is set by a comparison function defined in the class body.
+    The comparison function takes two arguments, readback and setpoint,
+    returning True if we are close enough to be considered done or False if we
+    are too far away.
+    """
+
+    # Override setpoint, readback in subclass
+    setpoint = None
+    readback = None
+
+    done = Cpt(InternalSignal, value=0)
+    done_value = 1
+
+    # Optionally override limits to a 2-element tuple in subclass
+    limits = None
+
+    def __init__(self, prefix, *, name, **kwargs):
+        self._last_readback = None
+        self._last_setpoint = None
+        super().__init__(prefix, name=name, **kwargs)
+        if None in (self.setpoint, self.readback):
+            raise NotImplementedError('PVPositionerComparator requires both '
+                                      'a setpoint and a readback signal to '
+                                      'compare!')
+
+    def done_comparator(self, readback, setpoint):
+        """Override done_comparator in subclass."""
+        raise NotImplementedError('Must implement a done comparator!')
+
+    def __init_subclass__(cls, **kwargs):
+        """Set up callbacks in subclass."""
+        super().__init_subclass__(**kwargs)
+        if None not in (cls.setpoint, cls.readback):
+            cls.setpoint.sub_value(cls._update_setpoint)
+            cls.readback.sub_value(cls._update_readback)
+
+    def _update_setpoint(self, *args, value, **kwargs):
+        """Callback to cache the setpoint and update done state."""
+        self._last_setpoint = value
+        # Always set done to False when a move is requested
+        # This means we always get a rising edge when finished moving
+        # Even if the move distance is under our done moving tolerance
+        self.done.put(0, internal=True)
+        self._update_done()
+
+    def _update_readback(self, *args, value, **kwargs):
+        """Callback to cache the readback and update done state."""
+        self._last_readback = value
+        self._update_done()
+
+    def _update_done(self):
+        """Update our status to done if we pass the comparator."""
+        if None not in (self._last_readback, self._last_setpoint):
+            is_done = self.done_comparator(self._last_readback,
+                                           self._last_setpoint)
+            self.done.put(int(is_done), internal=True)
+
+
+class PVPositionerIsClose(PVPositionerComparator):
+    """
+    PV Positioner that updates done state based on np.isclose.
+    The arguments atol and rtol can be set as class attributes or passed as
+    initialization arguments.
+    """
+
+    atol = None
+    rtol = None
+
+    def __init__(self, prefix, *, name, atol=None, rtol=None, **kwargs):
+        if atol is not None:
+            self.atol = atol
+        if rtol is not None:
+            self.rtol = rtol
+        super().__init__(prefix, name=name, **kwargs)
+
+    def done_comparator(self, readback, setpoint):
+        kwargs = {}
+        if self.atol is not None:
+            kwargs['atol'] = self.atol
+        if self.rtol is not None:
+            kwargs['rtol'] = self.rtol
+        return np.isclose(readback, setpoint, **kwargs)
+
+
+class PVPositionerDone(PVPositioner):
+    """
+    PV Positioner with no readback that reports done immediately.
+    Optionally, this PV positioner can be configured to skip small moves,
+    e.g. moves that are smaller than the atol value.
+    Parameters
+    ----------
+    prefix: str
+        PV prefix for the request setpoint. This should always be a hutch name.
+    name: str, required keyword
+        Name to use for this device in log messages, data streams, etc.
+    skip_small_moves: bool, optional
+        Defaults to False. If True, ignores move requests that are smaller
+        than the atol factor.
+        This can be very useful for synchronized energy scans where the ACR
+        side of the process can be very slow, but does not necessarily need to
+        happen at every step. Rather than design complicated scan patterns, we
+        can skip the small moves here and move the monochromater and beam
+        request devices in parallel.
+    atol: int, optional
+        Absolute tolerance that determines when the move is done and when to
+        skip moves using the skip_small_moves parameter.
+    """
+
+    atol = 0
+
+    setpoint = None
+
+    done = Cpt(InternalSignal, value=0)
+    done_value = 1
+
+    def __init__(self, prefix, *, name, skip_small_moves=False, **kwargs):
+        self.skip_small_moves = skip_small_moves
+        super().__init__(prefix, name=name, **kwargs)
+
+    def _setup_move(self, position):
+        """Skip the move part of the move if below the tolerance."""
+        if self.skip_small_moves and abs(position - self.position) < self.atol:
+            self.log.debug('Skipping small move of %s', self.name)
+            self._toggle_done()
+        else:
+            self.log.debug('Doing pv positioner move of %s', self.name)
+            super()._setup_move(position)
+            self._toggle_done()
+
+    def _toggle_done(self):
+        self.done.put(0, internal=True)
+        self.done.put(1, internal=True)

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -317,6 +317,43 @@ class PVPositionerComparator(PVPositioner):
 
     Internally, this will subscribe to both the `setpoint` and `readback`
     signals, updating `done` as appropriate.
+
+    Parameters
+    ----------
+    prefix : str, optional
+        The device prefix used for all sub-positioners. This is optional as it
+        may be desirable to specify full PV names for PVPositioners.
+    limits : 2-element sequence, optional
+        (low_limit, high_limit)
+    name : str
+        The device name
+    egu : str, optional
+        The engineering units (EGU) for the position
+    settle_time : float, optional
+        The amount of time to wait after moves to report status completion
+    timeout : float, optional
+        The default timeout to use for motion requests, in seconds.
+
+    Attributes
+    ----------
+    setpoint : Signal
+        The setpoint (request) signal
+    readback : Signal or None
+        The readback PV (e.g., encoder position PV)
+    actuate : Signal or None
+        The actuation PV to set when movement is requested
+    actuate_value : any, optional
+        The actuation value, sent to the actuate signal when motion is
+        requested
+    stop_signal : Signal or None
+        The stop PV to set when motion should be stopped
+    stop_value : any, optional
+        The value sent to stop_signal when a stop is requested
+    put_complete : bool, optional
+        If set, the specified PV should allow for asynchronous put completion
+        to indicate motion has finished.  If `actuate` is specified, it will be
+        used for put completion.  Otherwise, the `setpoint` will be used.  See
+        the `-c` option from `caput` for more information.
     """
 
     done = Cpt(InternalSignal, value=0)
@@ -390,6 +427,55 @@ class PVPositionerIsClose(PVPositionerComparator):
     able to deviate from the goal position by up to 10% of its value. This
     is useful for small quantities. For example, defining an atol for a
     positioner that ranges from 1e-8 to 2e-8 could be somewhat awkward.
+
+    Parameters
+    ----------
+    prefix : str, optional
+        The device prefix used for all sub-positioners. This is optional as it
+        may be desirable to specify full PV names for PVPositioners.
+    limits : 2-element sequence, optional
+        (low_limit, high_limit)
+    name : str
+        The device name
+    egu : str, optional
+        The engineering units (EGU) for the position
+    settle_time : float, optional
+        The amount of time to wait after moves to report status completion
+    timeout : float, optional
+        The default timeout to use for motion requests, in seconds.
+    atol : float, optional
+        A measure of absolute tolerance. If atol is 0.1, then you'd be
+        able to be up to 0.1 units away and still count as done.
+    rtol : float, optional
+        A measure of relative tolerance. If rtol is 0.1, then you'd be
+        able to deviate from the goal position by up to 10% of its value
+
+    Attributes
+    ----------
+    setpoint : Signal
+        The setpoint (request) signal
+    readback : Signal or None
+        The readback PV (e.g., encoder position PV)
+    actuate : Signal or None
+        The actuation PV to set when movement is requested
+    actuate_value : any, optional
+        The actuation value, sent to the actuate signal when motion is
+        requested
+    stop_signal : Signal or None
+        The stop PV to set when motion should be stopped
+    stop_value : any, optional
+        The value sent to stop_signal when a stop is requested
+    put_complete : bool, optional
+        If set, the specified PV should allow for asynchronous put completion
+        to indicate motion has finished.  If `actuate` is specified, it will be
+        used for put completion.  Otherwise, the `setpoint` will be used.  See
+        the `-c` option from `caput` for more information.
+    atol : float, optional
+        A measure of absolute tolerance. If atol is 0.1, then you'd be
+        able to be up to 0.1 units away and still count as done.
+    rtol : float, optional
+        A measure of relative tolerance. If rtol is 0.1, then you'd be
+        able to deviate from the goal position by up to 10% of its value
     """
 
     atol: Optional[float] = None
@@ -439,6 +525,39 @@ class PVPositionerDone(PVPositioner):
 
     When the user asks for a move, set done to 0 and then back to 1.
     This simulates the normal positioner behavior.
+
+    Parameters
+    ----------
+    prefix : str, optional
+        The device prefix used for all sub-positioners. This is optional as it
+        may be desirable to specify full PV names for PVPositioners.
+    limits : 2-element sequence, optional
+        (low_limit, high_limit)
+    name : str
+        The device name
+    egu : str, optional
+        The engineering units (EGU) for the position
+    settle_time : float, optional
+        The amount of time to wait after moves to report status completion
+    timeout : float, optional
+        The default timeout to use for motion requests, in seconds.
+
+    Attributes
+    ----------
+    actuate : Signal or None
+        The actuation PV to set when movement is requested
+    actuate_value : any, optional
+        The actuation value, sent to the actuate signal when motion is
+        requested
+    stop_signal : Signal or None
+        The stop PV to set when motion should be stopped
+    stop_value : any, optional
+        The value sent to stop_signal when a stop is requested
+    put_complete : bool, optional
+        If set, the specified PV should allow for asynchronous put completion
+        to indicate motion has finished.  If `actuate` is specified, it will be
+        used for put completion.  Otherwise, the `setpoint` will be used.  See
+        the `-c` option from `caput` for more information.
     """
     setpoint = Cpt(EpicsSignal, '', kind='hinted')
 

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -435,6 +435,9 @@ class PVPositionerDone(PVPositioner):
 
     This is for the case where you'd like a PV to look like a
     positioner, but the truth is that it is just a PV.
+
+    When the user asks for a move, set done to 0 and then back to 1.
+    This simluates the normal positioner behavior.
     """
     setpoint = Cpt(EpicsSignal, '', kind='hinted')
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -723,8 +723,7 @@ class InternalSignal(InternalSignalMixin, Signal):
 
     Some more concrete use-cases would be things like soft "status" type
     signals that should be read-only except that the class needs to edit it,
-    or EPICS signals that should be written to by the class but are likely to
-    cause issues for external writes due to behavior complexity.
+    or calculated "done" signals for positioner classes.
     """
 
 

--- a/ophyd/tests/test_pvpositioner.py
+++ b/ophyd/tests/test_pvpositioner.py
@@ -261,14 +261,18 @@ def test_hints(fake_motor_ioc):
     assert motor.hints['fields'] == f_hints
 
 
-def test_pv_positioner_is_close(fake_motor_ioc):
+def test_pv_positioner_is_close(signal_test_ioc):
     class MyPositioner(PVPositionerIsClose):
-        setpoint = Cpt(EpicsSignal, fake_motor_ioc.pvs['setpoint'])
-        readback = Cpt(EpicsSignal, fake_motor_ioc.pvs['readback'])
+        setpoint = Cpt(EpicsSignal, signal_test_ioc.pvs['read_write'])
+        readback = Cpt(EpicsSignal, signal_test_ioc.pvs['pair_set'])
 
         atol = 0.1
 
     motor = MyPositioner('', name='pv_pos_is_close_fake_motor')
+    setpoint_status = motor.setpoint.set(0)
+    readback_status = motor.readback.set(0)
+    setpoint_status.wait(timeout=0.5)
+    readback_status.wait(timeout=0.5)
     goal = motor.position + 10
     status = motor.set(goal)
     wait_for_value(motor.setpoint, goal, atol=0.01)
@@ -284,13 +288,15 @@ def test_pv_positioner_is_close(fake_motor_ioc):
     assert motor.done.get() == 1
 
 
-def test_pv_positioner_done(fake_motor_ioc):
+def test_pv_positioner_done(signal_test_ioc):
     # Catch done going to 0 and back to 1
-    motor = PVPositionerDone(fake_motor_ioc.pvs['setpoint'], name='pv_pos_done_fake_motor')
+    motor = PVPositionerDone(signal_test_ioc.pvs['read_write'], name='pv_pos_done_fake_motor')
+    motor.setpoint.set(0).wait(timeout=0.5)
     done_values = []
 
     def accumulate_done_values(value, **kwargs):
         done_values.append(value)
 
+    motor.done.subscribe(accumulate_done_values, run=False)
     motor.set(motor.position + 10).wait()
     assert done_values == [0, 1]

--- a/ophyd/tests/test_pvpositioner.py
+++ b/ophyd/tests/test_pvpositioner.py
@@ -6,7 +6,7 @@ from copy import copy
 from ophyd import (PVPositioner, PVPositionerPC, EpicsSignal, EpicsSignalRO,
                    Component as Cpt, get_cl, Kind, PVPositionerIsClose,
                    PVPositionerDone)
-from ophyd.utils import wait_for_value
+from ophyd.utils.epics_pvs import _wait_for_value
 
 logger = logging.getLogger(__name__)
 
@@ -275,13 +275,13 @@ def test_pv_positioner_is_close(signal_test_ioc):
     readback_status.wait(timeout=1)
     goal = motor.position + 10
     status = motor.set(goal)
-    wait_for_value(motor.setpoint, goal, atol=0.01, timeout=1)
-    wait_for_value(motor.done, 0, timeout=1)
+    _wait_for_value(motor.setpoint, goal, atol=0.01, timeout=1)
+    _wait_for_value(motor.done, 0, timeout=1)
     with pytest.raises(TimeoutError):
-        wait_for_value(motor.done, 1, timeout=1)
+        _wait_for_value(motor.done, 1, timeout=1)
     motor.readback.put(goal / 2)
     with pytest.raises(TimeoutError):
-        wait_for_value(motor.done, 1, timeout=1)
+        _wait_for_value(motor.done, 1, timeout=1)
     motor.readback.put(goal + motor.atol / 2)
     status.wait(timeout=1)
     assert status.done

--- a/ophyd/tests/test_pvpositioner.py
+++ b/ophyd/tests/test_pvpositioner.py
@@ -271,16 +271,17 @@ def test_pv_positioner_is_close(signal_test_ioc):
     motor = MyPositioner('', name='pv_pos_is_close_fake_motor')
     setpoint_status = motor.setpoint.set(0)
     readback_status = motor.readback.set(0)
-    setpoint_status.wait(timeout=0.5)
-    readback_status.wait(timeout=0.5)
+    setpoint_status.wait(timeout=1)
+    readback_status.wait(timeout=1)
     goal = motor.position + 10
     status = motor.set(goal)
-    wait_for_value(motor.setpoint, goal, atol=0.01)
+    wait_for_value(motor.setpoint, goal, atol=0.01, timeout=1)
+    wait_for_value(motor.done, 0, timeout=1)
     with pytest.raises(TimeoutError):
-        wait_for_value(motor.done, 1, timeout=0.5)
+        wait_for_value(motor.done, 1, timeout=1)
     motor.readback.put(goal / 2)
     with pytest.raises(TimeoutError):
-        wait_for_value(motor.done, 1, timeout=0.5)
+        wait_for_value(motor.done, 1, timeout=1)
     motor.readback.put(goal + motor.atol / 2)
     status.wait(timeout=1)
     assert status.done
@@ -291,7 +292,7 @@ def test_pv_positioner_is_close(signal_test_ioc):
 def test_pv_positioner_done(signal_test_ioc):
     # Catch done going to 0 and back to 1
     motor = PVPositionerDone(signal_test_ioc.pvs['read_write'], name='pv_pos_done_fake_motor')
-    motor.setpoint.set(0).wait(timeout=0.5)
+    motor.setpoint.set(0).wait(timeout=1)
     done_values = []
 
     def accumulate_done_values(value, **kwargs):

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -15,6 +15,7 @@ __all__ = ['split_record_field',
            'strip_field',
            'record_field',
            'set_and_wait',
+           'wait_for_value',
            'AlarmStatus',
            'AlarmSeverity',
            'fmt_time'
@@ -232,6 +233,34 @@ def _set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
     TimeoutError if timeout is exceeded
     """
     signal.put(val, **kwargs)
+    wait_for_value(signal, val, poll_time=poll_time, timeout=timeout, rtol=rtol, atol=atol)
+
+
+def wait_for_value(signal, val, poll_time=0.01, timeout=10, rtol=None,
+                   atol=None):
+    """Wait for a signal to match a value.
+
+    For floating point values, it is strongly recommended to set a tolerance.
+    If tolerances are unset, the values will be compared exactly.
+
+    Parameters
+    ----------
+    signal : EpicsSignal (or any object with `get` and `put`)
+    val : object
+        value to wait for
+    poll_time : float, optional
+        how soon to check whether the value matches
+    timeout : float, optional
+        maximum time to wait for value to match
+    rtol : float, optional
+        allowed relative tolerance between the readback and setpoint values
+    atol : float, optional
+        allowed absolute tolerance between the readback and setpoint values
+
+    Raises
+    ------
+    TimeoutError if timeout is exceeded
+    """
     expiration_time = ttime.time() + timeout if timeout is not None else None
     current_value = signal.get()
 

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -15,7 +15,6 @@ __all__ = ['split_record_field',
            'strip_field',
            'record_field',
            'set_and_wait',
-           'wait_for_value',
            'AlarmStatus',
            'AlarmSeverity',
            'fmt_time'
@@ -233,11 +232,11 @@ def _set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
     TimeoutError if timeout is exceeded
     """
     signal.put(val, **kwargs)
-    wait_for_value(signal, val, poll_time=poll_time, timeout=timeout, rtol=rtol, atol=atol)
+    _wait_for_value(signal, val, poll_time=poll_time, timeout=timeout, rtol=rtol, atol=atol)
 
 
-def wait_for_value(signal, val, poll_time=0.01, timeout=10, rtol=None,
-                   atol=None):
+def _wait_for_value(signal, val, poll_time=0.01, timeout=10, rtol=None,
+                    atol=None):
     """Wait for a signal to match a value.
 
     For floating point values, it is strongly recommended to set a tolerance.


### PR DESCRIPTION
Part of the May 2022 EPICS codeathon effort
Relies on the `InternalSignal` from #1045, which would need to be merged first

- Adds `PVPositionerIsClose`, a helpful PV positioner for when your IOC doesn't supply a `done` signal.
- Adds `PVPositionerDone`, a dummy class for when the user wants their signal to "look like" a motor and cannot be dissuaded.
- split out the "waiting" part of `ophyd.utils.epics_pvs._set_and_wait` into its own standalone utility, `wait_for_value` because I needed it to write a reasonable test