### PR TITLE
MAINT: reduce log level of spammy self.log.info log messages to debug

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -186,7 +186,7 @@ class OphydObject:
         self.control_layer_log = LoggerAdapter(control_layer_logger, {'ophyd_object_name': name})
 
         if not self.__any_instantiated:
-            self.log.info("first instance of OphydObject: id=%s", id(self))
+            self.log.debug("first instance of OphydObject: id=%s", id(self))
             OphydObject._mark_as_instantiated()
         self.__register_instance(self)
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -282,7 +282,7 @@ class Signal(OphydObject):
             This status object will be finished upon return in the
             case of basic soft Signals
         '''
-        self.log.info(
+        self.log.debug(
             'set(value=%s, timeout=%s, settle_time=%s, kwargs=%s)',
             value, timeout, settle_time, kwargs
         )
@@ -304,12 +304,12 @@ class Signal(OphydObject):
                 )
             else:
                 success = True
-                self.log.info(
+                self.log.debug(
                     '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s, kwargs=%s) succeeded => %s',
                     self.name, value, timeout, self.tolerance, self.rtolerance, kwargs, self._readback)
 
                 if settle_time is not None:
-                    self.log.info('settling for %d seconds', settle_time)
+                    self.log.debug('settling for %d seconds', settle_time)
                     time.sleep(settle_time)
             finally:
                 # keep a local reference to avoid any GC shenanigans

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -152,7 +152,7 @@ class SynSignal(Signal):
         if delay_time:
 
             def sleep_and_finish():
-                self.log.info('sleep_and_finish %s', self)
+                self.log.debug('sleep_and_finish %s', self)
                 ttime.sleep(delay_time)
                 self.put(self._func())
                 st.set_finished()


### PR DESCRIPTION
This is part of the May 2022 EPICS Codeathon effort

I've taken all of the `self.log.info` log messages and dropped them to `debug` level.
At LCLS we've instituted a log filter that drops all of these from info to debug because they are too noisy to be useful. Semantically, I take `INFO` to be equivalent to a logged `print` statement, so I claim that anything that would be annoying in a `print` statement should be dropped to `DEBUG` level.

I'm going to talk through each of these calls and why I want to reduce the log level, in case there is disagreement or misunderstanding of use cases:

- ophyd/ophydobj.py
  - "first instance of OphydObject: id=%s"
    - I'd never put something like this a print statement, it's more of a debug helper for developers. The user doesn't need to care about object ids or which ophyd object was created first.
- ophyd/signal.py
  -  'set(value=%s, timeout=%s, settle_time=%s, kwargs=%s)'
     - This is run every time we `set` any signal, which seems excessive for a print-equivalent.
  - '%s: _set_and_wait(value=%s, timeout=%s, atol=%s, rtol=%s, kwargs=%s) succeeded => %s'
    - This is run when the set succeeds, which makes it the second print-equivalent we typically see on `set`
  - 'settling for %d seconds'
    - This is run if the signal has a settling time after the set succeed, making it the third print-equivalent we can see on `set`
- ophyd/sim.py
  - 'sleep_and_finish %s'
    - This is run every time we trigger a `SynSignal`, which seems a big excessive if you're running bluesky plans, etc., it's something you'd only really want while debugging.