### PR TITLE
MNT: Wait for NullStatus to mark itself as finished

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -49,6 +49,7 @@ class NullStatus(StatusBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.set_finished()
+        self.wait()
 
 
 class EnumSignal(Signal):


### PR DESCRIPTION
In #1044 , we found that the .set_finished() method took some time to resolve, and the returned object would not always be immediately done and successful.  

NullStatus wants to be finished upon creation, so we wait for `set_finished()` to complete at initialization.