### PR TITLE
Fix tutorial typos

### DIFF
--- a/docs/source/tutorials/device.rst
+++ b/docs/source/tutorials/device.rst
@@ -14,8 +14,8 @@ We'll start two simulated devices that implement a `random walk`_.
 
 .. code:: bash
 
-   python -m caproto.ioc_examples_random_walk --prefix="random-walk:horiz:" --list-pvs
-   python -m caproto.ioc_examples_random_walk --prefix="random-walk:vert:" --list-pvs
+   python -m caproto.ioc_examples.random_walk --prefix="random-walk:horiz:" --list-pvs
+   python -m caproto.ioc_examples.random_walk --prefix="random-walk:vert:" --list-pvs
 
 .. ipython:: python
    :suppress:

--- a/docs/source/tutorials/single-PV.rst
+++ b/docs/source/tutorials/single-PV.rst
@@ -16,7 +16,7 @@ walker.
 
 .. code:: bash
 
-   python -m caproto.ioc_examples_random_walk --list-pvs
+   python -m caproto.ioc_examples.random_walk --list-pvs
 
 .. ipython:: python
    :suppress:


### PR DESCRIPTION
In the tutorial, I replaced three instances of `caproto.ioc_examples_random_walk` with `caproto.ioc_examples.random_walk` (changed the underscore between "examples" and "random" to a period).