### PR TITLE
Tweak stage_sigs DEBUG logging

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -545,7 +545,7 @@ class BlueskyInterface:
         try:
             for sig, val in stage_sigs.items():
                 self.log.debug("Setting %s to %r (original value: %r)",
-                               self.name,
+                               sig.name,
                                val, original_vals[sig])
                 sig.set(val).wait()
                 # It worked -- now add it to this list of sigs to unstage.
@@ -600,8 +600,8 @@ class BlueskyInterface:
 
         # Restore original values.
         for sig, val in reversed(list(self._original_vals.items())):
-            self.log.debug("Setting %s back to its original value: %r)",
-                           self.name,
+            self.log.debug("Setting %s back to its original value: %r",
+                           sig.name,
                            val)
             sig.set(val).wait()
             self._original_vals.pop(sig)


### PR DESCRIPTION
This PR proposes a minute change to the DEBUG log output for `stage_sigs` in `BlueskyInterface.stage()` and `BlueskyInterface.unstage()`.

Presently the log output looks like this:
```
2022-05-25 13:17:27,860 - ophyd.objects - device.py:524 - DEBUG - Staging xs3_hdf5plugin
2022-05-25 13:17:28,073 - ophyd.objects - device.py:547 - DEBUG - Setting xs3_hdf5plugin to 1 (original value: 'Enabled')
2022-05-25 13:17:28,075 - ophyd.objects - device.py:547 - DEBUG - Setting xs3_hdf5plugin to 'Yes' (original value: 'Yes')
2022-05-25 13:17:28,076 - ophyd.objects - device.py:547 - DEBUG - Setting xs3_hdf5plugin to 1 (original value: 1.0)
...
2022-05-25 13:17:28,453 - ophyd.objects - device.py:603 - DEBUG - Setting xs3_hdf5plugin back to its original value: 1.0)
2022-05-25 13:17:28,456 - ophyd.objects - device.py:603 - DEBUG - Setting xs3_hdf5plugin back to its original value: 'Yes')
2022-05-25 13:17:28,459 - ophyd.objects - device.py:603 - DEBUG - Setting xs3_hdf5plugin back to its original value: 'Enabled')
```
The proposed change is to log `sig.name` on `stage()` and `unstage()` and remove the un-paired `)` from the `unstage()` log:
```
2022-05-25 13:43:33,262 - ophyd.objects - device.py:524 - DEBUG - Staging xs3_hdf5plugin
2022-05-25 13:43:33,469 - ophyd.objects - device.py:547 - DEBUG - Setting xs3_hdf5plugin_enable to 1 (original value: 'Enabled')
2022-05-25 13:43:33,472 - ophyd.objects - device.py:547 - DEBUG - Setting xs3_hdf5plugin_blocking_callbacks to 'Yes' (original value: 'Yes')
2022-05-25 13:43:33,474 - ophyd.objects - device.py:547 - DEBUG - Setting xs3_cam_array_callbacks to 1 (original value: 1.0)
...
2022-05-25 13:43:33,892 - ophyd.objects - device.py:603 - DEBUG - Setting xs3_cam_array_callbacks back to its original value: 1.0
2022-05-25 13:43:33,906 - ophyd.objects - device.py:603 - DEBUG - Setting xs3_hdf5plugin_blocking_callbacks back to its original value: 'Yes'
2022-05-25 13:43:33,921 - ophyd.objects - device.py:603 - DEBUG - Setting xs3_hdf5plugin_enable back to its original value: 'Enabled'
```