### PR TITLE
Do not assume TRACE is unused.

### DIFF
--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -2,8 +2,6 @@ import io
 import logging
 import logging.handlers
 
-import pytest
-
 import ophyd.log as log
 from ophyd.ophydobj import OphydObject
 from ophyd.status import Status

--- a/ophyd/tests/test_log.py
+++ b/ophyd/tests/test_log.py
@@ -17,9 +17,6 @@ def test_validate_level():
     log.validate_level("DEBUG")
     log.validate_level("NOTSET")
 
-    with pytest.raises(ValueError):
-        log.validate_level("TRACE")
-
 
 def test_default_config_ophyd_logging():
     log.config_ophyd_logging()


### PR DESCRIPTION
Per @jklynch this test was meant to check that we have scrubbed `TRACE`-level logs from ophyd. But now one of our upstream deps _is_ using `TRACE`, which causes this test to fail.

I think it's fine to remove this: we shouldn't test against shared global state not under ophyd's control.