### PR TITLE
Signal settle time

### DIFF
--- a/ophyd/serial.py
+++ b/ophyd/serial.py
@@ -1,0 +1,92 @@
+import threading
+import time
+from ophyd import Kind
+from ophyd.ophydobj import OphydObject
+import serial
+
+
+class SerialSignal(OphydObject):
+    def __init__(
+        self,
+        *,
+        name,
+        parent=None,
+        kind=Kind.hinted,
+        labels=None,
+        attr_name="",
+        **kwargs
+    ):
+
+        super().__init__(
+            name=name, parent=parent, kind=kind, labels=labels, attr_name=attr_name
+        )
+
+        self.ser = serial.Serial(**kwargs)
+
+    def _setup_uhl(self):
+        self.ser.close()
+        self.ser.open()
+
+
+class SerialDevice(OphydObject):
+    def __init__(self, ser, *, name):
+        pass
+
+
+def open_uhl():
+    # configure the serial connections (the parameters differs on the device you are connecting to)
+    ser = serial.Serial(
+        port="COM1",
+        baudrate=9600,
+        rtscts=True,
+        timeout=30,
+        parity="N",
+        stopbits=2,
+        bytesize=8,
+        # write_timeout=10
+    )
+    ser.close()
+    ser.open()
+    # initializing
+    ser.write(b"Reset\r")
+    time.sleep(0.2)
+    ser.write(b"!ctr 0 0 0\r")
+    time.sleep(0.2)
+    ser.write(b"!dim 1 1 1\r")
+    time.sleep(0.2)
+    ser.write(b"!axis 1 1 1\r")
+    time.sleep(0.2)
+    ser.write(b"!pitch 4.0 4.0 1.0\r")
+    time.sleep(0.2)
+    ser.write(b"!encperiod 0.004 0.004 0.004\r")
+    time.sleep(0.2)
+    ser.write(b"!accel 0.25 0.25 0.25\r")
+    time.sleep(0.2)
+    ser.write(b"!vel 10 10 15\r")
+    time.sleep(0.2)
+    ser.write(b"!encpos 1\r")
+    time.sleep(0.2)
+    ser.write(b"!twi 0.006 0.006 0.006\r")
+    time.sleep(0.2)
+    ser.write(b"!ctr 2 2 2\r")
+    time.sleep(0.2)
+    return ser
+
+
+def move_to_xy(ser, x, y):
+    # IMPORTANT movement here is ABSOLUTE
+    move_command = ("!moa " + str(x) + " " + str(y) + " 0\r").encode("UTF-8")
+    ser.write(move_command)
+    time.sleep(3)
+
+
+def close_uhl(ser):
+    ser.close()
+    print("UHL port closed!")
+
+
+x = 5000
+y = 5000
+ser = open_uhl()
+move_to_xy(ser, x, y)
+close_uhl(ser)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -86,7 +86,8 @@ class Signal(OphydObject):
 
     def __init__(self, *, name, value=0., timestamp=None, parent=None,
                  labels=None, kind=Kind.hinted, tolerance=None,
-                 rtolerance=None, metadata=None, cl=None, attr_name=''):
+                 rtolerance=None, metadata=None, cl=None, attr_name='',
+                 settle_time=None):
 
         super().__init__(name=name, parent=parent, kind=kind, labels=labels,
                          attr_name=attr_name)
@@ -108,6 +109,7 @@ class Signal(OphydObject):
         self._tolerance = tolerance
         # self.tolerance is a property
         self.rtolerance = rtolerance
+        self._settle_time = settle_time
 
         # Signal defaults to being connected, with full read/write access.
         # Subclasses are expected to clear these on init, if applicable.
@@ -162,6 +164,10 @@ class Signal(OphydObject):
     @tolerance.setter
     def tolerance(self, tolerance):
         self._tolerance = tolerance
+
+    @property
+    def settle_time(self):
+        return self._settle_time
 
     def _repr_info(self):
         'Yields pairs of (key, value) to generate the Signal repr'
@@ -263,6 +269,8 @@ class Signal(OphydObject):
             'set(value=%s, timeout=%s, settle_time=%s)',
             value, timeout, settle_time
         )
+
+        settle_time = settle_time or self.settle_time
 
         def set_thread():
             try:

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -72,6 +72,9 @@ class Signal(OphydObject):
         Control Layer.  Must provide 'get_pv' and 'thread_class'
     attr_name : str, optional
         The parent Device attribute name that corresponds to this Signal
+    settle_time : float, optional
+        The amount of time to wait after setting the signal to report status
+        completion.
 
     Attributes
     ----------
@@ -167,6 +170,8 @@ class Signal(OphydObject):
 
     @property
     def settle_time(self):
+        """The amount of time to wait after setting the signal to report status
+        completion."""
         return self._settle_time
 
     def _repr_info(self):


### PR DESCRIPTION
Currently settle time only exists as an attribute in Positioners and not Signals. However, `Signal.set()` uses this as a keyword argument, which obscures it from `bps.mv` or other plans. This adds `settle_time` as a property of Signal, that can be overridden in the call to `set()`. It keeps the defaults as None, and should maintain backward compatibility with existing devices. 