### PR TITLE
Add settle time as property of Signal to be referenced in set method

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -79,6 +79,9 @@ class Signal(OphydObject):
         Control Layer.  Must provide 'get_pv' and 'thread_class'
     attr_name : str, optional
         The parent Device attribute name that corresponds to this Signal
+    settle_time : float, optional
+        The amount of time to wait after setting the signal to report status
+        completion.
 
     Attributes
     ----------
@@ -105,6 +108,7 @@ class Signal(OphydObject):
         metadata=None,
         cl=None,
         attr_name="",
+        settle_time=None
     ):
 
         super().__init__(
@@ -127,6 +131,7 @@ class Signal(OphydObject):
         self._tolerance = tolerance
         # self.tolerance is a property
         self.rtolerance = rtolerance
+        self._settle_time = settle_time
 
         # Signal defaults to being connected, with full read/write access.
         # Subclasses are expected to clear these on init, if applicable.
@@ -182,6 +187,12 @@ class Signal(OphydObject):
     @tolerance.setter
     def tolerance(self, tolerance):
         self._tolerance = tolerance
+
+    @property
+    def settle_time(self):
+        """The amount of time to wait after setting the signal to report status
+        completion."""
+        return self._settle_time
 
     def _repr_info(self):
         "Yields pairs of (key, value) to generate the Signal repr"
@@ -325,6 +336,8 @@ class Signal(OphydObject):
             settle_time,
             kwargs,
         )
+
+        settle_time = settle_time or self.settle_time
 
         def set_thread():
             try:


### PR DESCRIPTION
Currently settle time only exists as an attribute in Positioners and not Signals. However, `Signal.set()` uses this as a keyword argument, which obscures it from `bps.mv` or other plans. This adds `settle_time` as a property of `Signal`, that can be overridden in the call to `set()`. It keeps the defaults as None, and should maintain backward compatibility with existing devices.