### PR TITLE
clarified source of an error message

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -2056,7 +2056,7 @@ class EpicsSignal(EpicsSignalBase):
             use_complete = self._put_complete
 
         if not self.write_access:
-            raise ReadOnlyError("No write access to underlying EPICS PV")
+            raise ReadOnlyError(f"No write access to underlying EPICS PV : {self.name}")
 
         self.control_layer_log.debug(
             "_write_pv.put(value=%s, use_complete=%s, callback=%s, kwargs=%s)",


### PR DESCRIPTION
in the put method to the EpicsSignal class, there is a check to be sure that the signal can be written to, i.e. that self.write_access is true.  that error message results in an unhelpful traceback in that it provides no information identifying the PV triggering the message.  in the case of a deeply nested signal, this error message is unilluminating.  this commit adds self.name to the error message.

-----

This is, in my opinion, an example of a common anti-pattern in ophyd.  There are many error messages that do a poor job identifying the prima causa of the error, simply resulting in a lengthy traceback that is hard to parse for someone not well versed in ophyd's internals.  

In my case, I was, with a lot of poking and prodding, able to identify the source of the error.  Had the error message included the name (as in `self.name`) of the ophyd object, it would have been a much shorter path to identifying the problem.

My solution was to simply append `self.name` to the error message.  Not a perfect solution, but it would at least point the human doing the debugging in the right direction.

I have a hard time believing this is simply a problem for someone like me, who is writing beamline code without also having a deep understanding of Ophyd.  I cannot believe that a context-free error message could be helpful even to Ophyd's main developers.  

Were I king of the world (or at least of DSSI), I would call for a full audit of ophyd to find all examples of context-free messages like this one. I would then call for agreement on a convention for making better, more helpful, better contextualized error messages.

All right!  Rant is not finished. Thanks for humoring me :grin: 