### PR TITLE
Add status repr to WaitTimeoutError message

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -399,7 +399,7 @@ class StatusBase:
             when this method was called, not from the beginning of the action).
         """
         if not self._event.wait(timeout=timeout):
-            raise WaitTimeoutError("Status has not completed yet.")
+            raise WaitTimeoutError(f"Status {self!r} has not completed yet.")
         return self._exception
 
     def wait(self, timeout=None):
@@ -429,7 +429,7 @@ class StatusBase:
             from ``WaitTimeoutError`` above.
         """
         if not self._event.wait(timeout=timeout):
-            raise WaitTimeoutError("Status has not completed yet.")
+            raise WaitTimeoutError(f"Status {self!r} has not completed yet.")
         if self._exception is not None:
             raise self._exception
 


### PR DESCRIPTION
In a similar situation to #1086 , we had an issue where the error message `Status has failed to complete` was not very illuminating as to which status that was, so I have added this information to the `raise WaitTimeoutError` calls in the same manner as it is added to other exception messages in `status.py`. This would be really helpful to us in avoiding wrapping every `wait()` with try/except to record what we are waiting on or subclassing every kind of status we have to modify `wait()` and I hope it might be useful to others too.