### PR TITLE
Ophyd v2: add _exception to AsyncStatus to propagate errors through FailedStatus.

### DIFF
--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -76,8 +76,14 @@ class AsyncStatus(Status):
             for callback in self._callbacks:
                 callback(self)
 
-    @property
-    def exception(self) -> Optional[Union[Exception, asyncio.CancelledError]]:
+    def exception(
+        self, timeout: Optional[float] = 0.0
+    ) -> Optional[Union[Exception, asyncio.CancelledError]]:
+        if timeout != 0.0:
+            raise Exception(
+                "cannot honour any timeout other than 0 in an asynchronous function"
+            )
+
         if self.task.done():
             try:
                 return self.task.exception()

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -24,6 +24,7 @@ from typing import (
     Sequence,
     Set,
     TypeVar,
+    Union,
     cast,
     runtime_checkable,
 )
@@ -38,7 +39,6 @@ from bluesky.protocols import (
     Stageable,
     Status,
     Subscribable,
-    StatusException,
 )
 from bluesky.run_engine import call_in_bluesky_event_loop
 
@@ -78,7 +78,7 @@ class AsyncStatus(Status):
                 callback(self)
 
     @property
-    def exception(self) -> Optional[StatusException]:
+    def exception(self) -> Optional[Union[Exception, asyncio.CancelledError]]:
         return self._exception
 
     @property

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -91,7 +91,9 @@ class AsyncStatus(Status):
 
     @property
     def success(self) -> bool:
-        assert self.done, "Status has not completed yet"
+        if not self.done:
+            return False
+        
         try:
             self.task.result()
         except (Exception, asyncio.CancelledError):

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -93,7 +93,7 @@ class AsyncStatus(Status):
     def success(self) -> bool:
         if not self.done:
             return False
-        
+
         try:
             self.task.result()
         except (Exception, asyncio.CancelledError):

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -78,10 +78,12 @@ class AsyncStatus(Status):
 
     @property
     def exception(self) -> Optional[Union[Exception, asyncio.CancelledError]]:
-        try:
-            return self.task.exception()
-        except asyncio.CancelledError as e:
-            return e
+        if self.task.done():
+            try:
+                return self.task.exception()
+            except asyncio.CancelledError as e:
+                return e
+        return None
 
     @property
     def done(self) -> bool:

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -55,36 +55,36 @@ async def failing_coroutine(time: float):
 
 async def test_async_status_propagates_exception():
     status = AsyncStatus(failing_coroutine(0.1))
-    assert status.exception is None
+    assert status.exception() is None
 
     with pytest.raises(ValueError):
         await status
 
-    assert type(status.exception) == ValueError
+    assert type(status.exception()) == ValueError
 
 
 async def test_async_status_propagates_cancelled_error():
     status = AsyncStatus(normal_coroutine(0.1))
-    assert status.exception is None
+    assert status.exception() is None
 
     status.task.exception = Mock(side_effect=asyncio.CancelledError(""))
     await status
 
-    assert type(status.exception) == asyncio.CancelledError
+    assert type(status.exception()) == asyncio.CancelledError
 
 
 async def test_async_status_has_no_exception_if_coroutine_successful():
     status = AsyncStatus(normal_coroutine(0.1))
-    assert status.exception is None
+    assert status.exception() is None
 
     await status
 
-    assert status.exception is None
+    assert status.exception() is None
 
 
 async def test_async_status_success_if_cancelled():
     status = AsyncStatus(normal_coroutine(0.1))
-    assert status.exception is None
+    assert status.exception() is None
 
     status.task.result = Mock(side_effect=asyncio.CancelledError(""))
     await status

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -1,8 +1,9 @@
+import asyncio
 import re
 
 import pytest
 
-from ophyd.v2.core import Signal
+from ophyd.v2.core import AsyncStatus, Signal
 
 
 class MySignal(Signal):
@@ -29,3 +30,18 @@ def test_signals_equality_raises():
         match=re.escape("'>' not supported between instances of 'MySignal' and 'int'"),
     ):
         s1 > 4
+
+
+async def some_coroutine():
+    await asyncio.sleep(0.1)
+    raise ValueError()
+
+
+async def test_async_status_exception():
+    status = AsyncStatus(some_coroutine())
+    assert status.exception is None
+
+    with pytest.raises(ValueError):
+        await status
+
+    assert type(status.exception) == ValueError

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -90,3 +90,19 @@ async def test_async_status_success_if_cancelled():
     await status
 
     assert status.success is False
+
+
+async def test_async_status_wrap():
+    wrapped_coroutine = AsyncStatus.wrap(normal_coroutine)
+    status = wrapped_coroutine(0.1)
+
+    await status
+    assert status.success is True
+
+
+async def test_async_status_initialised_with_a_task():
+    normal_task = asyncio.Task(normal_coroutine(0.1))
+    status = AsyncStatus(normal_task)
+
+    await status
+    assert status.success is True

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 from ophyd.v2.core import AsyncStatus, Signal
+from unittest.mock import Mock
 
 
 class MySignal(Signal):
@@ -31,17 +32,39 @@ def test_signals_equality_raises():
     ):
         s1 > 4
 
+async def normal_coroutine(time: float):
+    await asyncio.sleep(time)
 
-async def some_coroutine():
-    await asyncio.sleep(0.1)
+async def failing_coroutine(time: float):
+    await normal_coroutine(time)
     raise ValueError()
 
+async def cancelled_coroutine(time: float):
+    await normal_coroutine(time)
+    raise asyncio.CancelledError("")
 
-async def test_async_status_exception():
-    status = AsyncStatus(some_coroutine())
+async def test_async_status_propagates_exception():
+    status = AsyncStatus(failing_coroutine(0.1))
     assert status.exception is None
 
     with pytest.raises(ValueError):
         await status
 
     assert type(status.exception) == ValueError
+
+async def test_async_status_propagates_cancelled_error():
+    status = AsyncStatus(normal_coroutine(0.1))
+    assert status.exception is None
+
+    status.task.exception = Mock(side_effect= asyncio.CancelledError(""))
+    await status
+        
+    assert type(status.exception) == asyncio.CancelledError
+
+async def test_async_status_has_no_exception_if_coroutine_successful():
+    status = AsyncStatus(normal_coroutine(0.1))
+    assert status.exception is None
+
+    await status
+
+    assert status.exception is None

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -53,11 +53,6 @@ async def failing_coroutine(time: float):
     raise ValueError()
 
 
-async def cancelled_coroutine(time: float):
-    await normal_coroutine(time)
-    raise asyncio.CancelledError("")
-
-
 async def test_async_status_propagates_exception():
     status = AsyncStatus(failing_coroutine(0.1))
     assert status.exception is None
@@ -85,3 +80,13 @@ async def test_async_status_has_no_exception_if_coroutine_successful():
     await status
 
     assert status.exception is None
+
+
+async def test_async_status_success_if_cancelled():
+    status = AsyncStatus(normal_coroutine(0.1))
+    assert status.exception is None
+
+    status.task.result = Mock(side_effect=asyncio.CancelledError(""))
+    await status
+
+    assert status.success is False

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -1,10 +1,10 @@
 import asyncio
 import re
+from unittest.mock import Mock
 
 import pytest
 
 from ophyd.v2.core import AsyncStatus, Signal
-from unittest.mock import Mock
 
 
 class MySignal(Signal):
@@ -32,16 +32,20 @@ def test_signals_equality_raises():
     ):
         s1 > 4
 
+
 async def normal_coroutine(time: float):
     await asyncio.sleep(time)
+
 
 async def failing_coroutine(time: float):
     await normal_coroutine(time)
     raise ValueError()
 
+
 async def cancelled_coroutine(time: float):
     await normal_coroutine(time)
     raise asyncio.CancelledError("")
+
 
 async def test_async_status_propagates_exception():
     status = AsyncStatus(failing_coroutine(0.1))
@@ -52,14 +56,16 @@ async def test_async_status_propagates_exception():
 
     assert type(status.exception) == ValueError
 
+
 async def test_async_status_propagates_cancelled_error():
     status = AsyncStatus(normal_coroutine(0.1))
     assert status.exception is None
 
-    status.task.exception = Mock(side_effect= asyncio.CancelledError(""))
+    status.task.exception = Mock(side_effect=asyncio.CancelledError(""))
     await status
-        
+
     assert type(status.exception) == asyncio.CancelledError
+
 
 async def test_async_status_has_no_exception_if_coroutine_successful():
     status = AsyncStatus(normal_coroutine(0.1))

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -3,6 +3,7 @@ import re
 from unittest.mock import Mock
 
 import pytest
+from bluesky.protocols import Status
 
 from ophyd.v2.core import AsyncStatus, Signal
 
@@ -31,6 +32,16 @@ def test_signals_equality_raises():
         match=re.escape("'>' not supported between instances of 'MySignal' and 'int'"),
     ):
         s1 > 4
+
+
+async def test_async_status_success():
+    st = AsyncStatus(asyncio.sleep(0.1))
+    assert isinstance(st, Status)
+    assert not st.done
+    assert not st.success
+    await st
+    assert st.done
+    assert st.success
 
 
 async def normal_coroutine(time: float):


### PR DESCRIPTION
added ._exception to AsyncStatus to match with method in v1 Status object

Solves https://github.com/bluesky/ophyd/issues/1098

This will be followed by a PR in bluesky, which will change the Status object that ophyd v2 AsyncStatus inherits from as well as how FailedStatus gets instantiated. Once I have done this, I will link it here so the changes can be viewed together.