### PR TITLE
v2: Add dict support

### DIFF
--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -19,9 +19,7 @@ from typing import (
     Generator,
     Generic,
     Iterable,
-    Iterator,
     List,
-    MutableMapping,
     Optional,
     Protocol,
     Sequence,
@@ -193,17 +191,19 @@ async def connect_children(device: Device, prefix: str, sim: bool):
             await connect_children(self, prefix + self.prefix, sim)
     """
 
-    coros = {
-        name: child_device.connect(prefix, sim)
-        for name, child_device in get_device_children(device)
-    }
+    coros = {}
+    for name, child_device in get_device_children(device):
+        if isinstance(child_device, DeviceDict):
+            coros.update(child_device.nested_connect(prefix, sim))
+        else:
+            coros.update({name: child_device.connect(prefix, sim)})
 
     await wait_for_connection(**coros)
 
 
 def get_device_children(device: Device) -> Generator[Tuple[str, Device], None, None]:
     for attr_name, attr in device.__dict__.items():
-        if isinstance(attr, Device) or isinstance(attr, DeviceDict):
+        if isinstance(attr, Device):
             yield f"{attr_name.rstrip('_')}", attr
 
 
@@ -621,73 +621,16 @@ class StandardReadable(Readable, Configurable, Stageable, Device):
 KT = TypeVar("KT")
 
 
-class DeviceDict(MutableMapping[KT, Device]):
-    def __init__(self, dictionary=None, /, **kwargs) -> None:
-        self.data: Dict[KT, Device] = {}
-        if dictionary is not None:
-            self.update(dictionary)
-        if kwargs:
-            self.update(kwargs)
-
-    def __contains__(self, key: KT) -> bool:
-        return key in self.data
-
-    def __delitem__(self, key: KT) -> None:
-        del self.data[key]
-
-    def __getitem__(self, key: KT) -> Device:
-        if key in self.data:
-            return self.data[key]
-        raise KeyError(key)
-
-    def __len__(self) -> int:
-        return len(self.data)
-
-    def __iter__(self) -> Iterator[KT]:
-        return iter(self.data)
-
-    def __setitem__(self, key: KT, value: Device) -> None:
-        self.data[key] = value
-
-    @classmethod
-    def fromkeys(cls, iterable: Iterable[KT], value: Device) -> "DeviceDict":
-        """Create a new dictionary with keys from `iterable` and values set
-        to `value`.
-
-        Args:
-            iterable: A collection of keys.
-            value: The default value. All of the values refer to just a single
-                instance, so it generally does not make sense for `value` to be a
-                mutable object such as an empty list. To get distinct values, use
-                a dict comprehension instead.
-
-        Returns:
-            A new instance of MyDict.
-        """
-        d = cls()
-        for key in iterable:
-            d[key] = value
-        return d
-
-    def update(self, other=(), /, **kwds) -> None:
-        """Updates the dictionary from an iterable or mapping object."""
-        if isinstance(other, MutableMapping):
-            for key in other:
-                self.data[key] = other[key]
-        elif hasattr(other, "keys"):
-            for key in other.keys():
-                self.data[key] = other[key]
-        else:
-            for key, value in other:
-                self.data[key] = value
-        for key, value in kwds.items():
-            self.data[key] = value
-
+class DeviceDict(Dict[KT, Device], Device):
     def set_name(self, parent_name: str):
-        for name, device in self.data.items():
+        for name, device in self.items():
             device.set_name(f"{parent_name}-{name}")
             device.parent = self
 
     async def connect(self, prefix: str, sim: bool):
-        for _, device in self.data.items():
-            await device.connect(prefix, sim)
+        coros = {str(k): d.connect(prefix, sim) for k, d in self.items()}
+        await wait_for_connection(**coros)
+
+    def nested_connect(self, prefix: str, sim: bool):
+        coros = {str(k): d.connect(prefix, sim) for k, d in self.items()}
+        return coros

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -1,7 +1,6 @@
 """Core Ophyd.v2 functionality like Device and Signal"""
 
 from __future__ import annotations
-import abc
 
 import asyncio
 import functools
@@ -621,6 +620,7 @@ class StandardReadable(Readable, Configurable, Stageable, Device):
 
 KT = TypeVar("KT")
 
+
 class DeviceDict(MutableMapping[KT, Device]):
     def __init__(self, dictionary=None, /, **kwargs) -> None:
         self.data: Dict[KT, Device] = {}
@@ -628,7 +628,7 @@ class DeviceDict(MutableMapping[KT, Device]):
             self.update(dictionary)
         if kwargs:
             self.update(kwargs)
-    
+
     def __contains__(self, key: KT) -> bool:
         return key in self.data
 
@@ -648,17 +648,17 @@ class DeviceDict(MutableMapping[KT, Device]):
 
     def __setitem__(self, key: KT, value: Device) -> None:
         self.data[key] = value
-    
+
     @classmethod
     def fromkeys(cls, iterable: Iterable[KT], value: Device) -> "DeviceDict":
-        """Create a new dictionary with keys from `iterable` and values set 
+        """Create a new dictionary with keys from `iterable` and values set
         to `value`.
 
         Args:
             iterable: A collection of keys.
-            value: The default value. All of the values refer to just a single 
-                instance, so it generally does not make sense for `value` to be a 
-                mutable object such as an empty list. To get distinct values, use 
+            value: The default value. All of the values refer to just a single
+                instance, so it generally does not make sense for `value` to be a
+                mutable object such as an empty list. To get distinct values, use
                 a dict comprehension instead.
 
         Returns:
@@ -691,7 +691,3 @@ class DeviceDict(MutableMapping[KT, Device]):
     async def connect(self, prefix: str, sim: bool):
         for _, device in self.data.items():
             await device.connect(prefix, sim)
-        
-
-    
-    

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -190,14 +190,16 @@ async def connect_children(device: Device, prefix: str, sim: bool):
         async def connect(self, prefix: str = "", sim=False):
             await connect_children(self, prefix + self.prefix, sim)
     """
+
     coros = {
-        k: c.connect(prefix, sim)
-        for k, c in device.__dict__.items()
-        if k != "parent" and isinstance(c, Device)
+        name: child_device.connect(prefix, sim)
+        for name, child_device in get_device_children(device)
     }
+
     await wait_for_connection(**coros)
 
-def get_device_children(device:Device) -> Generator[Tuple[str, Device], None, None]:
+
+def get_device_children(device: Device) -> Generator[Tuple[str, Device], None, None]:
     for attr_name, attr in device.__dict__.items():
         if isinstance(attr, Device):
             yield f"{attr_name.rstrip('_')}", attr
@@ -205,6 +207,7 @@ def get_device_children(device:Device) -> Generator[Tuple[str, Device], None, No
             for dict_key, dict_value in attr.items():
                 if isinstance(dict_value, Device):
                     yield f"{attr_name.rstrip('_')}-{dict_key}", dict_value
+
 
 class DeviceCollector:
     """Collector of top level Device instances to be used as a context manager

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+from typing import Dict, Optional, Union
 
 import pytest
 from bluesky.protocols import Status
@@ -8,6 +9,7 @@ from bluesky.run_engine import RunEngine, TransitionError
 from ophyd.v2.core import (
     AsyncStatus,
     Device,
+    DeviceDict,
     Signal,
     StandardReadable,
     get_device_children,
@@ -96,11 +98,10 @@ class Dummy(DummyDevice):
 class DummyStandardReadable(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         self.child1 = DummyDevice("device1")
-        self.dict_with_children = {
+        self.dict_with_children: Dict[Union[int, str], DummyDevice] = DeviceDict({
             "abc": DummyDevice("device2"),
             123: DummyDevice("device3"),
-        }
-        self.list_with_children = []
+        })
         super().__init__(prefix, name)
 
 

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -3,18 +3,25 @@ import re
 
 import pytest
 from bluesky.protocols import Status
-
-from ophyd.v2.core import AsyncStatus, Device, Signal, StandardReadable, get_device_children
 from bluesky.run_engine import RunEngine, TransitionError
 
-@pytest.fixture(scope='function', params=[False, True])
+from ophyd.v2.core import (
+    AsyncStatus,
+    Device,
+    Signal,
+    StandardReadable,
+    get_device_children,
+)
+
+
+@pytest.fixture(scope="function", params=[False, True])
 def RE(request):
     loop = asyncio.new_event_loop()
     loop.set_debug(True)
     RE = RunEngine({}, call_returns_result=request.param, loop=loop)
 
     def clean_event_loop():
-        if RE.state not in ('idle', 'panicked'):
+        if RE.state not in ("idle", "panicked"):
             try:
                 RE.halt()
             except TransitionError:
@@ -25,6 +32,7 @@ def RE(request):
 
     request.addfinalizer(clean_event_loop)
     return RE
+
 
 class MySignal(Signal):
     @property
@@ -61,19 +69,22 @@ async def test_async_status_success():
     assert st.done
     assert st.success
 
+
 class DummyDevice(Device):
     def __init__(self, name) -> None:
         self._name = name
+        self.connected = False
 
     @property
     def name(self):
         return self._name
-    
+
     def set_name(self, name: str = ""):
         self._name = name
 
-    async def connect(self, prefix:str = "", sim=False):
-        ...
+    async def connect(self, prefix: str = "", sim=False):
+        self.connected = True
+
 
 class Dummy(DummyDevice):
     def __init__(self, name) -> None:
@@ -81,14 +92,17 @@ class Dummy(DummyDevice):
         self.child2 = DummyDevice("device2")
         super().__init__(name)
 
+
 class DummyStandardReadable(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         self.child1 = DummyDevice("device1")
         self.dict_with_children = {
             "abc": DummyDevice("device2"),
-            123 : DummyDevice("device3")
+            123: DummyDevice("device3"),
         }
+        self.list_with_children = []
         super().__init__(prefix, name)
+
 
 def test_get_device_children():
     parent = Dummy("parent")
@@ -97,9 +111,16 @@ def test_get_device_children():
         assert name == names[idx]
         assert type(child) == DummyDevice
 
-def test_names_correctly_set_with():
+
+async def test_names_correctly_set_with():
     parent = DummyStandardReadable("parent")
     parent.set_name("parent")
     assert parent.child1.name == "parent-child1"
     assert parent.dict_with_children[123].name == "parent-dict_with_children-123"
     assert parent.dict_with_children["abc"].name == "parent-dict_with_children-abc"
+
+    await parent.connect()
+
+    assert parent.child1.connected == True
+    assert parent.dict_with_children[123].connected == True
+    assert parent.dict_with_children["abc"].connected == True

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -1,6 +1,6 @@
 import asyncio
 import re
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import pytest
 from bluesky.protocols import Status
@@ -98,10 +98,12 @@ class Dummy(DummyDevice):
 class DummyStandardReadable(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         self.child1 = DummyDevice("device1")
-        self.dict_with_children: Dict[Union[int, str], DummyDevice] = DeviceDict({
-            "abc": DummyDevice("device2"),
-            123: DummyDevice("device3"),
-        })
+        self.dict_with_children: Dict[Union[int, str], DummyDevice] = DeviceDict(
+            {
+                "abc": DummyDevice("device2"),
+                123: DummyDevice("device3"),
+            }
+        )
         super().__init__(prefix, name)
 
 
@@ -122,6 +124,6 @@ async def test_names_correctly_set_with():
 
     await parent.connect()
 
-    assert parent.child1.connected == True
-    assert parent.dict_with_children[123].connected == True
-    assert parent.dict_with_children["abc"].connected == True
+    assert parent.child1.connected
+    assert parent.dict_with_children[123].connected
+    assert parent.dict_with_children["abc"].connected

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -1,6 +1,5 @@
 import asyncio
 import re
-from typing import Dict, Union
 
 import pytest
 from bluesky.protocols import Status
@@ -9,7 +8,7 @@ from bluesky.run_engine import RunEngine, TransitionError
 from ophyd.v2.core import (
     AsyncStatus,
     Device,
-    DeviceDict,
+    DeviceVector,
     Signal,
     StandardReadable,
     get_device_children,
@@ -98,7 +97,7 @@ class Dummy(DummyDevice):
 class DummyStandardReadable(StandardReadable):
     def __init__(self, prefix: str, name: str = ""):
         self.child1 = DummyDevice("device1")
-        self.dict_with_children: Dict[Union[int, str], DummyDevice] = DeviceDict(
+        self.dict_with_children: DeviceVector[DummyDevice] = DeviceVector(
             {
                 "abc": DummyDevice("device2"),
                 123: DummyDevice("device3"),
@@ -118,7 +117,9 @@ def test_get_device_children():
 async def test_children_of_standard_readable_have_set_names_and_get_connected():
     parent = DummyStandardReadable("parent")
     parent.set_name("parent")
+    assert parent.name == "parent"
     assert parent.child1.name == "parent-child1"
+    assert parent.dict_with_children.name == "parent-dict_with_children"
     assert parent.dict_with_children[123].name == "parent-dict_with_children-123"
     assert parent.dict_with_children["abc"].name == "parent-dict_with_children-abc"
 

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -115,7 +115,7 @@ def test_get_device_children():
         assert type(child) == DummyDevice
 
 
-async def test_names_correctly_set_with():
+async def test_children_of_standard_readable_have_set_names_and_get_connected():
     parent = DummyStandardReadable("parent")
     parent.set_name("parent")
     assert parent.child1.name == "parent-child1"

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -4,8 +4,27 @@ import re
 import pytest
 from bluesky.protocols import Status
 
-from ophyd.v2.core import AsyncStatus, Signal
+from ophyd.v2.core import AsyncStatus, Device, Signal, StandardReadable, get_device_children
+from bluesky.run_engine import RunEngine, TransitionError
 
+@pytest.fixture(scope='function', params=[False, True])
+def RE(request):
+    loop = asyncio.new_event_loop()
+    loop.set_debug(True)
+    RE = RunEngine({}, call_returns_result=request.param, loop=loop)
+
+    def clean_event_loop():
+        if RE.state not in ('idle', 'panicked'):
+            try:
+                RE.halt()
+            except TransitionError:
+                pass
+        loop.call_soon_threadsafe(loop.stop)
+        RE._th.join()
+        loop.close()
+
+    request.addfinalizer(clean_event_loop)
+    return RE
 
 class MySignal(Signal):
     @property
@@ -41,3 +60,46 @@ async def test_async_status_success():
     await st
     assert st.done
     assert st.success
+
+class DummyDevice(Device):
+    def __init__(self, name) -> None:
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+    
+    def set_name(self, name: str = ""):
+        self._name = name
+
+    async def connect(self, prefix:str = "", sim=False):
+        ...
+
+class Dummy(DummyDevice):
+    def __init__(self, name) -> None:
+        self.child1 = DummyDevice("device1")
+        self.child2 = DummyDevice("device2")
+        super().__init__(name)
+
+class DummyStandardReadable(StandardReadable):
+    def __init__(self, prefix: str, name: str = ""):
+        self.child1 = DummyDevice("device1")
+        self.dict_with_children = {
+            "abc": DummyDevice("device2"),
+            123 : DummyDevice("device3")
+        }
+        super().__init__(prefix, name)
+
+def test_get_device_children():
+    parent = Dummy("parent")
+    names = ["child1", "child2"]
+    for idx, (name, child) in enumerate(get_device_children(parent)):
+        assert name == names[idx]
+        assert type(child) == DummyDevice
+
+def test_names_correctly_set_with():
+    parent = DummyStandardReadable("parent")
+    parent.set_name("parent")
+    assert parent.child1.name == "parent-child1"
+    assert parent.dict_with_children[123].name == "parent-dict_with_children-123"
+    assert parent.dict_with_children["abc"].name == "parent-dict_with_children-abc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 write_to = "ophyd/_version.py"
 
 [tool.pytest.ini_options]
-timeout = 20
+#timeout = 20
 log_format = "%(asctime)s,%(msecs)03d %(levelname)s (%(threadName)s) %(message)s"
 log_date_format = "%H:%M:%S"
 addopts = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 write_to = "ophyd/_version.py"
 
 [tool.pytest.ini_options]
-#timeout = 20
+timeout = 20
 log_format = "%(asctime)s,%(msecs)03d %(levelname)s (%(threadName)s) %(message)s"
 log_date_format = "%H:%M:%S"
 addopts = """

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ dev =
     black==22.3.0
     bluesky>=1.7.0
     caproto[standard] >=0.4.2rc1
-    codecov
+    pytest-codecov
     databroker>=1.0.0b1
     doctr
     epics-pypdb


### PR DESCRIPTION
The purpose of this PR is to be able to define v2 Devices with dictionary attributes containing (nested) devices, instead of just plain devices. i.e. something like:

```python
class myDevice(StandardReadable):
    def __init__(self, prefix: str, name: str = ""):
        self.child1 = DummyDevice("device1")
        self.dict_with_children =
            {
                "abc": DummyDevice("device2"),
                123: DummyDevice("device3"),
            }
      
        super().__init__(prefix, name)
```

The idea is, that these sub-devices will all be correctly named and connected. With the current master branch, "device2" and "device3" would be ignored (i.e. the devices in the dictionary).

## Initial approach
Initially, I allowed a user to create a dictionary as an attribute to a Device, as shown in the code snippet above. This worked OK; standard readable has a set_name and connect method that finds all the children of the object, so I extracted this into its own generator function (instead of duplicating this login in both). I then added a checker in this function which would extract device children from inside dictionaries, like so:

```python
def get_device_children(device: Device) -> Generator[Tuple[str, Device], None, None]:
    for attr_name, attr in device.__dict__.items():
        if isinstance(attr, Device):
            yield f"{attr_name.rstrip('_')}", attr
        elif isinstance(attr, Dict):
            for dict_key, dict_value in attr.items():
                if isinstance(dict_value, Device):
                    yield f"{attr_name.rstrip('_')}-{dict_key}", dict_value
```

The outcome of this approach, along with tests, can be seen by checking out commit 04ff4934.

## Current approach
It was discussed with @coretl that perhaps a better approach would be to make the dictionary typed, or write a wrapper around a dictionary which would have set_name and connect methods. I've experimented with this in the latest commit.

There are some benefits to this approach. Most importantly, with a wrapped dictionary users know exactly what they need to put in; the signature of this class explicitly states the types it allows. I've decided to type this class as:

```python
KT = TypeVar("KT")

class DeviceDict(MutableMapping[KT, Device]):
    def __init__(self, dictionary=None ...):
        ...

    def set_name(self, parent_name: str):
        ...
    async def connect(self, prefix: str, sim: bool):
        for _, device in self.data.items():
            await device.connect(prefix, sim)
```
this feels like a more pythonic approach, as it extracts connecting/setting names of dict elements into a seperate class (DeviceDict) rather than relying on the get_device_children function to do this for us.

## Further discussion...

I don't know if how I've written it here is the best way. The tests should provide a good overview of how they would be used, and I don't know if people would find this verbose.

This also touches on [this issue](https://github.com/bluesky/ophyd/issues/1090), and I don't know if it just runs parallel with it, because `DeviceDict` is only used for the purpose of the StandardReadable properly naming things and connecting them. And it feels like it should be more generic. 