### PR TITLE
v2: make device class concrete

### DIFF
--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -143,7 +143,6 @@ class Device(HasName):
         """Return the name of the Device"""
         return self._name
 
-    @abstractmethod
     def set_name(self, name: str):
         """Set ``self.name=name`` and each ``self.child.name=name+"-child"``.
 
@@ -155,7 +154,6 @@ class Device(HasName):
         self._name = name
         name_children(self, name)
 
-    @abstractmethod
     async def connect(self, sim: bool = False):
         """Connect self and all child Devices.
 

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -162,7 +162,7 @@ class Device(HasName):
         sim:
             If True then connect in simulation mode.
         """
-        await connect_children(self, sim)  # TODO: check this.
+        await connect_children(self, sim)
 
 
 class NotConnected(Exception):

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -130,14 +130,14 @@ class AsyncStatus(Status):
 
 class Device(HasName):
     """Common base class for all Ophyd.v2 Devices.
-    
+
     By default, names and connects all Device children.
     """
 
     _name: str = ""
     #: The parent Device if it exists
     parent: Optional[Device] = None
-    
+
     @property
     def name(self) -> str:
         """Return the name of the Device"""
@@ -164,8 +164,7 @@ class Device(HasName):
         sim:
             If True then connect in simulation mode.
         """
-        await connect_children(self, sim) #TODO: check this.
-        
+        await connect_children(self, sim)  # TODO: check this.
 
 
 class NotConnected(Exception):
@@ -230,6 +229,7 @@ def name_children(device: Device, name: str):
     for child_name, child in get_device_children(device):
         child.set_name(f"{name}-{child_name.rstrip('_')}")
         child.parent = device
+
 
 def get_device_children(device: Device) -> Generator[Tuple[str, Device], None, None]:
     for attr_name, attr in device.__dict__.items():

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -129,15 +129,19 @@ class AsyncStatus(Status):
 
 
 class Device(HasName):
-    """Common base class for all Ophyd.v2 Devices"""
+    """Common base class for all Ophyd.v2 Devices.
+    
+    By default, names and connects all Device children.
+    """
 
+    _name: str = ""
     #: The parent Device if it exists
     parent: Optional[Device] = None
-
+    
     @property
-    @abstractmethod
     def name(self) -> str:
         """Return the name of the Device"""
+        return self._name
 
     @abstractmethod
     def set_name(self, name: str):
@@ -148,6 +152,8 @@ class Device(HasName):
         name:
             New name to set
         """
+        self._name = name
+        name_children(self, name)
 
     @abstractmethod
     async def connect(self, sim: bool = False):
@@ -158,6 +164,8 @@ class Device(HasName):
         sim:
             If True then connect in simulation mode.
         """
+        await connect_children(self, sim) #TODO: check this.
+        
 
 
 class NotConnected(Exception):
@@ -216,6 +224,12 @@ async def connect_children(device: Device, sim: bool):
     if coros:
         await wait_for_connection(**coros)
 
+
+def name_children(device: Device, name: str):
+    """Call ``child.set_name(child_name)`` on all child devices in series."""
+    for child_name, child in get_device_children(device):
+        child.set_name(f"{name}-{child_name.rstrip('_')}")
+        child.parent = device
 
 def get_device_children(device: Device) -> Generator[Tuple[str, Device], None, None]:
     for attr_name, attr in device.__dict__.items():
@@ -841,8 +855,6 @@ class StandardReadable(Readable, Configurable, Stageable, Device):
     - These signals will be subscribed for read() between stage() and unstage()
     """
 
-    _name = ""
-
     def __init__(
         self,
         name: str = "",
@@ -875,19 +887,6 @@ class StandardReadable(Readable, Configurable, Stageable, Device):
         # Call this last so child Signals are renamed
         if name:
             self.set_name(name)
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    def set_name(self, name: str):
-        self._name = name
-        for child_name, child in get_device_children(self):
-            child.set_name(f"{name}-{child_name.rstrip('_')}")
-            child.parent = self
-
-    async def connect(self, sim=False):
-        await connect_children(self, sim)
 
     def stage(self) -> List[Any]:
         self._staged = True
@@ -922,13 +921,6 @@ VT = TypeVar("VT", bound=Device)
 
 
 class DeviceVector(Dict[int, VT], Device):
-
-    _name = ""
-
-    @property
-    def name(self) -> str:
-        return self._name
-
     def set_name(self, parent_name: str):
         self._name = parent_name
         for name, device in self.items():

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -182,7 +182,7 @@ async def test_async_status_initialised_with_a_task():
 async def test_wait_for_connection():
     class DummyDeviceWithSleep(DummyBaseDevice):
         def __init__(self, name) -> None:
-            super().__init__(name)
+            self.set_name(name)
 
         async def connect(self, sim=False):
             await asyncio.sleep(0.01)

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -9,10 +9,10 @@ from bluesky.protocols import Status
 from ophyd.v2.core import (
     AsyncStatus,
     Device,
+    DeviceCollector,
     DeviceVector,
     Signal,
     SimSignalBackend,
-    DeviceCollector,
     get_device_children,
     wait_for_connection,
 )
@@ -69,9 +69,7 @@ class DummyDeviceGroup(Device):
         self.child1 = DummyBaseDevice()
         self.child2 = DummyBaseDevice()
         self.dict_with_children: DeviceVector[DummyBaseDevice] = DeviceVector(
-            {
-                123: DummyBaseDevice()
-            }
+            {123: DummyBaseDevice()}
         )
         self.set_name(name)
 
@@ -82,7 +80,11 @@ def test_get_device_children():
     names = ["child1", "child2", "dict_with_children"]
     for idx, (name, child) in enumerate(get_device_children(parent)):
         assert name == names[idx]
-        assert type(child) == DummyBaseDevice if name.startswith('child') else type(child) == DeviceVector
+        assert (
+            type(child) == DummyBaseDevice
+            if name.startswith("child")
+            else type(child) == DeviceVector
+        )
 
 
 async def test_children_of_device_have_set_names_and_get_connected():

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -60,7 +60,7 @@ class DummyBaseDevice(Device):
     def __init__(self) -> None:
         self.connected = False
 
-    async def connect(self, prefix: str = "", sim=False):
+    async def connect(self, sim=False):
         self.connected = True
 
 


### PR DESCRIPTION
resolves https://github.com/bluesky/ophyd/issues/1090

made Device a concrete class rather that ABC, simplified logic in corresponding child classes like StandardReadable and DeviceVector.

