### PR TITLE
propagate errors through wait_for_connection

### DIFF
--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -180,7 +180,7 @@ async def wait_for_connection(**coros: Awaitable[None]):
     """
     ts = {k: asyncio.create_task(c) for (k, c) in coros.items()}  # type: ignore
     try:
-        await asyncio.wait(ts.values())
+        done, pending = await asyncio.wait(ts.values())
     except asyncio.CancelledError:
         for t in ts.values():
             t.cancel()
@@ -195,6 +195,10 @@ async def wait_for_connection(**coros: Awaitable[None]):
                     lines.append(f"{k}:")
                     lines += [f"  {line}" for line in e.lines]
         raise NotConnected(*lines)
+    else:
+        # Wait for everything to foreground the exceptions
+        for f in list(done) + list(pending):
+            await f
 
 
 async def connect_children(device: Device, prefix: str, sim: bool):

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import traceback
 from unittest.mock import Mock
 
 import pytest
@@ -12,6 +13,7 @@ from ophyd.v2.core import (
     Signal,
     StandardReadable,
     get_device_children,
+    wait_for_connection
 )
 
 
@@ -172,3 +174,30 @@ async def test_async_status_initialised_with_a_task():
 
     await status
     assert status.success is True
+
+
+async def test_wait_for_connection():
+    class DummyDeviceWithSleep(DummyDevice):
+        def __init__(self, name) -> None:
+            super().__init__(name)
+        
+        async def connect(self, prefix: str = "", sim=False):
+            asyncio.sleep(0.01)
+            self.connected = True
+
+    device1, device2 = DummyDeviceWithSleep("device1"), DummyDeviceWithSleep("device2")
+    
+    normal_coros = {"device1": device1.connect(), "device2": device2.connect()}
+
+    await wait_for_connection(**normal_coros)
+
+    assert device1.connected
+    assert device2.connected
+
+async def test_wait_for_connection_propagates_error():
+    failing_coros = {"test": normal_coroutine(0.01), "failing": failing_coroutine(0.01)}
+    
+    with pytest.raises(ValueError) as e:
+        await wait_for_connection(**failing_coros)
+        assert traceback.extract_tb(e.__traceback__)[-1].name == "failing_coroutine"
+    

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -13,7 +13,7 @@ from ophyd.v2.core import (
     Signal,
     StandardReadable,
     get_device_children,
-    wait_for_connection
+    wait_for_connection,
 )
 
 
@@ -180,13 +180,13 @@ async def test_wait_for_connection():
     class DummyDeviceWithSleep(DummyDevice):
         def __init__(self, name) -> None:
             super().__init__(name)
-        
+
         async def connect(self, prefix: str = "", sim=False):
             asyncio.sleep(0.01)
             self.connected = True
 
     device1, device2 = DummyDeviceWithSleep("device1"), DummyDeviceWithSleep("device2")
-    
+
     normal_coros = {"device1": device1.connect(), "device2": device2.connect()}
 
     await wait_for_connection(**normal_coros)
@@ -194,10 +194,10 @@ async def test_wait_for_connection():
     assert device1.connected
     assert device2.connected
 
+
 async def test_wait_for_connection_propagates_error():
     failing_coros = {"test": normal_coroutine(0.01), "failing": failing_coroutine(0.01)}
-    
+
     with pytest.raises(ValueError) as e:
         await wait_for_connection(**failing_coros)
         assert traceback.extract_tb(e.__traceback__)[-1].name == "failing_coroutine"
-    


### PR DESCRIPTION
Tom has noticed that sometimes, wait_for_connection fails quietly. He has fixed this, but in a PR with other things in it. This is a simple PR to isolate that fix.

first commit: copied over wait_for_connection function from ajgdls:pva-dev (PR 1096), and added some tests for it

relates to https://github.com/bluesky/ophyd/pull/1096