### PR TITLE
V2 minor async status changes

### DIFF
--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -78,9 +78,7 @@ class AsyncStatus(Status):
             for callback in self._callbacks:
                 callback(self)
 
-    def exception(
-        self, timeout: Optional[float] = 0.0
-    ) -> Optional[Union[Exception, asyncio.CancelledError]]:
+    def exception(self, timeout: Optional[float] = 0.0) -> Optional[BaseException]:
         if timeout != 0.0:
             raise Exception(
                 "cannot honour any timeout other than 0 in an asynchronous function"
@@ -124,6 +122,18 @@ class AsyncStatus(Status):
             return AsyncStatus(f(self))
 
         return wrap_f
+
+    def __repr__(self) -> str:
+        if self.done:
+            if self.exception() is not None:
+                status = "errored"
+            else:
+                status = "done"
+        else:
+            status = "pending"
+        return f"<AsyncStatus {status}>"
+
+    __str__ = __repr__
 
 
 class Device(HasName):

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -172,3 +172,24 @@ async def test_async_status_initialised_with_a_task():
 
     await status
     assert status.success is True
+
+
+async def test_async_status_str_for_normal_coroutine():
+    normal_task = asyncio.Task(normal_coroutine(0.01))
+    status = AsyncStatus(normal_task)
+
+    assert str(status) == "<AsyncStatus pending>"
+    await status
+
+    assert str(status) == "<AsyncStatus done>"
+
+
+async def test_async_status_str_for_failing_coroutine():
+    failing_task = asyncio.Task(failing_coroutine(0.01))
+    status = AsyncStatus(failing_task)
+
+    assert str(status) == "<AsyncStatus pending>"    
+    with pytest.raises(ValueError):
+        await status
+
+    assert str(status) == "<AsyncStatus errored>"


### PR DESCRIPTION
Related to https://github.com/bluesky/ophyd/pull/1096

This just adds a `__repr__` and `__str__` method (the latter pointing to the former) to AsyncStatus for ophyd v2. It also changes the return type of AsyncStatus.exception().