### PR TITLE
v2 Fix traceback of a failed AsyncStatus object

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ dev =
     %(pva)s
     attrs>=19.3.0
     black==22.3.0
-    bluesky>=1.7.0
+    bluesky>=1.11.0
     caproto[standard] >=0.4.2rc1
     pytest-codecov
     databroker>=1.0.0b1


### PR DESCRIPTION
Something in the catch-throw-catch-throw cycle was confusing the traceback. Either way, this is clearer. Added a test to check.