### PR TITLE
v2: Add set_and_wait_for_value()

### DIFF
--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -732,7 +732,31 @@ async def observe_value(signal: SignalR[T]) -> AsyncGenerator[T, None]:
         signal.clear_sub(q.put_nowait)
 
 
-async def wait_for_value(signal: SignalR[T], match, timeout=None):
+class _ValueChecker(Generic[T]):
+    def __init__(self, matcher: Callable[[T], bool], matcher_name: str):
+        self._last_value: Optional[T]
+        self._matcher = matcher
+        self._matcher_name = matcher_name
+
+    async def _wait_for_value(self, signal: SignalR[T]):
+        async for value in observe_value(signal):
+            self._last_value = value
+            if self._matcher(value):
+                return
+
+    async def wait_for_value(self, signal: SignalR[T], timeout: float):
+        try:
+            await asyncio.wait_for(self._wait_for_value(signal), timeout)
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(
+                f"{signal.name} didn't match {self._matcher_name} in {timeout}s, "
+                f"last value {self._last_value!r}"
+            ) from e
+
+
+async def wait_for_value(
+    signal: SignalR[T], match: Union[T, Callable[[T], bool]], timeout: float
+):
     """Wait for a signal to have a matching value.
 
     Parameters
@@ -757,18 +781,46 @@ async def wait_for_value(signal: SignalR[T], match, timeout=None):
         wait_for_value(device.num_captured, lambda v: v > 45, timeout=1)
     """
     if callable(match):
-        match_function = match
+        checker = _ValueChecker(match, match.__name__)
     else:
+        checker = _ValueChecker(lambda v: v == match, repr(match))
+    await checker.wait_for_value(signal, timeout)
 
-        def match_function(value):
-            return value == match
 
-    async def _wait_for_value():
-        async for value in observe_value(signal):
-            if match_function(value):
-                return
+async def set_and_wait_for_value(
+    signal: SignalRW[T],
+    value: T,
+    timeout: float = DEFAULT_TIMEOUT,
+    status_timeout: Optional[float] = None,
+) -> AsyncStatus:
+    """Set a signal and monitor it until it has that value.
 
-    await asyncio.wait_for(_wait_for_value(), timeout)
+    Useful for busy record, or other Signals with pattern:
+
+    - Set Signal with wait=True and stash the Status
+    - Read the same Signal to check the operation has started
+    - Return the Status so calling code can wait for operation to complete
+
+    Parameters
+    ----------
+    signal:
+        The signal to set and monitor
+    value:
+        The value to set it to
+    timeout:
+        How long to wait for the signal to have the value
+    status_timeout:
+        How long the returned Status will wait for the set to complete
+
+    Notes
+    -----
+    Example usage::
+
+        set_and_wait_for_value(device.acquire, 1)
+    """
+    status = signal.set(value, timeout=status_timeout)
+    await wait_for_value(signal, value, timeout=timeout)
+    return status
 
 
 async def merge_gathered_dicts(

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import time
 import traceback
 from unittest.mock import Mock
 
@@ -14,10 +15,14 @@ from ophyd.v2.core import (
     DeviceCollector,
     DeviceVector,
     Signal,
+    SignalRW,
     SimSignalBackend,
     get_device_children,
+    set_and_wait_for_value,
     set_sim_put_proceeds,
+    set_sim_value,
     wait_for_connection,
+    wait_for_value,
 )
 
 
@@ -285,3 +290,68 @@ async def test_sim_backend_descriptor_fails_for_invalid_class():
 
     with pytest.raises(AssertionError):
         await sim_signal._backend.get_descriptor()
+
+
+async def time_taken_by(coro) -> float:
+    start = time.monotonic()
+    await coro
+    return time.monotonic() - start
+
+
+async def test_wait_for_value_with_value():
+    sim_signal = SignalRW(SimSignalBackend(str, "test"))
+    sim_signal.set_name("sim_signal")
+    await sim_signal.connect(sim=True)
+    set_sim_value(sim_signal, "blah")
+
+    with pytest.raises(
+        TimeoutError,
+        match="sim_signal didn't match 'something' in 0.1s, last value 'blah'",
+    ):
+        await wait_for_value(sim_signal, "something", timeout=0.1)
+    assert await time_taken_by(wait_for_value(sim_signal, "blah", timeout=2)) < 0.1
+    t = asyncio.create_task(
+        time_taken_by(wait_for_value(sim_signal, "something else", timeout=2))
+    )
+    await asyncio.sleep(0.2)
+    assert not t.done()
+    set_sim_value(sim_signal, "something else")
+    assert 0.2 < await t < 1.0
+
+
+async def test_wait_for_value_with_funcion():
+    sim_signal = SignalRW(SimSignalBackend(float, "test"))
+    sim_signal.set_name("sim_signal")
+    await sim_signal.connect(sim=True)
+    set_sim_value(sim_signal, 45.8)
+
+    def less_than_42(v):
+        return v < 42
+
+    with pytest.raises(
+        TimeoutError,
+        match="sim_signal didn't match less_than_42 in 0.1s, last value 45.8",
+    ):
+        await wait_for_value(sim_signal, less_than_42, timeout=0.1)
+    t = asyncio.create_task(
+        time_taken_by(wait_for_value(sim_signal, less_than_42, timeout=2))
+    )
+    await asyncio.sleep(0.2)
+    assert not t.done()
+    set_sim_value(sim_signal, 41)
+    assert 0.2 < await t < 1.0
+    assert (
+        await time_taken_by(wait_for_value(sim_signal, less_than_42, timeout=2)) < 0.1
+    )
+
+
+async def test_set_and_wait_for_value():
+    sim_signal = SignalRW(SimSignalBackend(int, "test"))
+    sim_signal.set_name("sim_signal")
+    await sim_signal.connect(sim=True)
+    set_sim_value(sim_signal, 0)
+    set_sim_put_proceeds(sim_signal, False)
+    st = await set_and_wait_for_value(sim_signal, 1)
+    assert not st.done
+    set_sim_put_proceeds(sim_signal, True)
+    assert await time_taken_by(st) < 0.1


### PR DESCRIPTION
Useful for busy record, or other Signals with pattern:
- Set Signal with wait=True and stash the Status
- Read the same Signal to check the operation has started
- Return the Status so calling code can wait for operation to complete

Merge after #1123 