### PR TITLE
v2: remove monitor

### DIFF
--- a/ophyd/v2/_aioca.py
+++ b/ophyd/v2/_aioca.py
@@ -4,7 +4,15 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Sequence, Type, Union
 
-from aioca import FORMAT_CTRL, FORMAT_RAW, FORMAT_TIME, Subscription, caget, camonitor, caput
+from aioca import (
+    FORMAT_CTRL,
+    FORMAT_RAW,
+    FORMAT_TIME,
+    Subscription,
+    caget,
+    camonitor,
+    caput,
+)
 from aioca.types import AugmentedValue, Dbr, Format
 from bluesky.protocols import Descriptor, Dtype, Reading
 from epicscorelibs.ca import dbr

--- a/ophyd/v2/_aioca.py
+++ b/ophyd/v2/_aioca.py
@@ -230,3 +230,5 @@ class CaSignalBackend(SignalBackend[T]):
                 datatype=self.converter.read_dbr,
                 format=FORMAT_TIME,
             )
+        else:
+            self.subscription = None

--- a/ophyd/v2/_aioca.py
+++ b/ophyd/v2/_aioca.py
@@ -220,10 +220,10 @@ class CaSignalBackend(SignalBackend[T]):
         return self.converter.value(value)
 
     def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
-        if self.subscription:
-            self.subscription.close()
-            self.subscription = None
         if callback:
+            assert (
+                not self.subscription
+            ), "Cannot set a callback when one is already set"
             self.subscription = camonitor(
                 self.read_pv,
                 lambda v: callback(self.converter.reading(v), self.converter.value(v)),

--- a/ophyd/v2/_aioca.py
+++ b/ophyd/v2/_aioca.py
@@ -231,4 +231,6 @@ class CaSignalBackend(SignalBackend[T]):
                 format=FORMAT_TIME,
             )
         else:
+            if self.subscription:
+                self.subscription.close()
             self.subscription = None

--- a/ophyd/v2/_aioca.py
+++ b/ophyd/v2/_aioca.py
@@ -4,13 +4,12 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Sequence, Type, Union
 
-from aioca import FORMAT_CTRL, FORMAT_RAW, FORMAT_TIME, caget, camonitor, caput
+from aioca import FORMAT_CTRL, FORMAT_RAW, FORMAT_TIME, Subscription, caget, camonitor, caput
 from aioca.types import AugmentedValue, Dbr, Format
 from bluesky.protocols import Descriptor, Dtype, Reading
 from epicscorelibs.ca import dbr
 
 from .core import (
-    Monitor,
     NotConnected,
     ReadingValueCallback,
     SignalBackend,
@@ -158,6 +157,7 @@ class CaSignalBackend(SignalBackend[T]):
         self.initial_values: Dict[str, AugmentedValue] = {}
         self.converter: CaConverter = DisconnectedCaConverter(None, None)
         self.source = f"ca://{self.read_pv}"
+        self.subscription: Optional[Subscription] = None
 
     async def _store_initial_value(self, pv):
         try:
@@ -211,10 +211,14 @@ class CaSignalBackend(SignalBackend[T]):
         value = await self._caget(FORMAT_RAW)
         return self.converter.value(value)
 
-    def monitor_reading_value(self, callback: ReadingValueCallback[T]) -> Monitor:
-        return camonitor(
-            self.read_pv,
-            lambda v: callback(self.converter.reading(v), self.converter.value(v)),
-            datatype=self.converter.read_dbr,
-            format=FORMAT_TIME,
-        )
+    def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
+        if self.subscription:
+            self.subscription.close()
+            self.subscription = None
+        if callback:
+            self.subscription = camonitor(
+                self.read_pv,
+                lambda v: callback(self.converter.reading(v), self.converter.value(v)),
+                datatype=self.converter.read_dbr,
+                format=FORMAT_TIME,
+            )

--- a/ophyd/v2/_p4p.py
+++ b/ophyd/v2/_p4p.py
@@ -224,10 +224,10 @@ class PvaSignalBackend(SignalBackend[T]):
         return self.converter.value(value)
 
     def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
-        if self.subscription:
-            self.subscription.close()
-            self.subscription = None
         if callback:
+            assert (
+                not self.subscription
+            ), "Cannot set a callback when one is already set"
 
             async def async_callback(v):
                 callback(self.converter.reading(v), self.converter.value(v))

--- a/ophyd/v2/_p4p.py
+++ b/ophyd/v2/_p4p.py
@@ -235,3 +235,5 @@ class PvaSignalBackend(SignalBackend[T]):
             self.subscription = self.ctxt.monitor(
                 self.read_pv, async_callback, request="field(value,alarm,timestamp)"
             )
+        else:
+            self.subscription = None

--- a/ophyd/v2/_p4p.py
+++ b/ophyd/v2/_p4p.py
@@ -228,6 +228,7 @@ class PvaSignalBackend(SignalBackend[T]):
             self.subscription.close()
             self.subscription = None
         if callback:
+
             async def async_callback(v):
                 callback(self.converter.reading(v), self.converter.value(v))
 

--- a/ophyd/v2/_p4p.py
+++ b/ophyd/v2/_p4p.py
@@ -236,4 +236,6 @@ class PvaSignalBackend(SignalBackend[T]):
                 self.read_pv, async_callback, request="field(value,alarm,timestamp)"
             )
         else:
+            if self.subscription:
+                self.subscription.close()
             self.subscription = None

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -802,13 +802,13 @@ class _ReadableRenamer(AsyncReadable, Stageable):
 
     def stage(self) -> List[Any]:
         if isinstance(self.readable, Stageable):
-            return self.readable.stage()
+            return self.readable.stage()  # type: ignore
         else:
             return []
 
     def unstage(self) -> List[Any]:
         if isinstance(self.readable, Stageable):
-            return self.readable.unstage()
+            return self.readable.unstage()  # type: ignore
         else:
             return []
 
@@ -885,7 +885,7 @@ class StandardReadable(Readable, Configurable, Stageable, Device):
         staged = [self]
         for sig in self._read_signals + self._conf_signals:
             if isinstance(sig, Stageable):
-                staged += sig.stage()
+                staged += sig.stage()  # type: ignore
         return staged
 
     def unstage(self) -> List[Any]:
@@ -893,7 +893,7 @@ class StandardReadable(Readable, Configurable, Stageable, Device):
         unstaged = [self]
         for sig in self._read_signals + self._conf_signals:
             if isinstance(sig, Stageable):
-                unstaged += sig.unstage()
+                unstaged += sig.unstage()  # type: ignore
         return unstaged
 
     async def describe(self) -> Dict[str, Descriptor]:

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -415,7 +415,7 @@ class SimSignalBackend(SignalBackend[T]):
         #: If cleared, then any ``put(wait=True)`` will wait until it is set
         self.put_proceeds = asyncio.Event()
         self.put_proceeds.set()
-        
+
         self.callback: Optional[ReadingValueCallback[T]] = None
 
         if datatype is None:
@@ -493,7 +493,6 @@ def set_sim_put_proceeds(signal: Signal[T], proceeds: bool):
         event.clear()
 
 
-##USED TO BE monitor_sim_value
 def set_sim_callback(signal: Signal[T], callback: ReadingValueCallback[T]) -> None:
     """Monitor the value of a signal that is in sim mode"""
     return _sim_backends[signal].set_callback(callback)

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -465,8 +465,10 @@ class SimSignalBackend(SignalBackend[T]):
     async def get_value(self) -> T:
         return self._value
 
-    def set_callback(self, callback: ReadingValueCallback[T]) -> None:
-        callback(self._reading, self._value)
+    def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
+        if callback:
+            callback(self._reading, self._value)
+
         self.callback = callback
 
     def set_value(self, value: T) -> None:

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -467,8 +467,8 @@ class SimSignalBackend(SignalBackend[T]):
 
     def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
         if callback:
+            assert not self.callback, "Cannot set a callback when one is already set"
             callback(self._reading, self._value)
-
         self.callback = callback
 
     def set_value(self, value: T) -> None:

--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -357,13 +357,6 @@ class DeviceCollector:
 ReadingValueCallback = Callable[[Reading, T], None]
 
 
-class Monitor(Protocol):
-    """The kind of handle we expect camonitor/pvmonitor to return"""
-
-    def close(self):
-        """Close the monitor so no more subscription callbacks happen"""
-
-
 class SignalBackend(Generic[T]):
     """A read/write/monitor backend for a Signals"""
 
@@ -394,7 +387,7 @@ class SignalBackend(Generic[T]):
         """The current value"""
 
     @abstractmethod
-    def monitor_reading_value(self, callback: ReadingValueCallback[T]) -> Monitor:
+    def set_callback(self, callback: Optional[ReadingValueCallback[T]]) -> None:
         """Observe changes to the current value, timestamp and severity"""
 
 
@@ -407,20 +400,6 @@ primitive_dtypes: Dict[type, Dtype] = {
     float: "number",
     bool: "boolean",
 }
-
-
-class SimMonitor(Generic[T]):
-    """Handle that is returned when monitoring a Signal in sim mode"""
-
-    def __init__(
-        self, callback: ReadingValueCallback[T], listeners: List[SimMonitor[T]]
-    ):
-        self.callback = callback
-        self._listeners = listeners
-        self._listeners.append(self)
-
-    def close(self):
-        self._listeners.remove(self)
 
 
 class SimSignalBackend(SignalBackend[T]):
@@ -436,7 +415,9 @@ class SimSignalBackend(SignalBackend[T]):
         #: If cleared, then any ``put(wait=True)`` will wait until it is set
         self.put_proceeds = asyncio.Event()
         self.put_proceeds.set()
-        self.listeners: List[SimMonitor[T]] = []
+        
+        self.callback: Optional[ReadingValueCallback[T]] = None
+
         if datatype is None:
             self._initial_value = cast(T, None)
         elif issubclass(datatype, Enum):
@@ -484,16 +465,16 @@ class SimSignalBackend(SignalBackend[T]):
     async def get_value(self) -> T:
         return self._value
 
-    def monitor_reading_value(self, callback: ReadingValueCallback[T]) -> Monitor:
+    def set_callback(self, callback: ReadingValueCallback[T]) -> None:
         callback(self._reading, self._value)
-        return SimMonitor(callback, self.listeners)
+        self.callback = callback
 
     def set_value(self, value: T) -> None:
         """Set the simulated value, and set timestamp to now"""
         self._value = value
         self._timestamp = time.monotonic()
-        for rl in self.listeners:
-            rl.callback(self._reading, self._value)
+        if self.callback:
+            self.callback(self._reading, self._value)
 
 
 def set_sim_value(signal: Signal[T], value: T):
@@ -510,9 +491,10 @@ def set_sim_put_proceeds(signal: Signal[T], proceeds: bool):
         event.clear()
 
 
-def monitor_sim_value(signal: Signal[T], callback: ReadingValueCallback[T]) -> Monitor:
+##USED TO BE monitor_sim_value
+def set_sim_callback(signal: Signal[T], callback: ReadingValueCallback[T]) -> None:
     """Monitor the value of a signal that is in sim mode"""
-    return _sim_backends[signal].monitor_reading_value(callback)
+    return _sim_backends[signal].set_callback(callback)
 
 
 def _fail(self, other, *args, **kwargs):
@@ -585,10 +567,12 @@ class _SignalCache(Generic[T]):
         self._valid = asyncio.Event()
         self._reading: Optional[Reading] = None
         self._value: Optional[T] = None
-        self._monitor = backend.monitor_reading_value(self._callback)
+
+        self.backend = backend
+        backend.set_callback(self._callback)
 
     def close(self):
-        self._monitor.close()
+        self.backend.set_callback(None)
 
     async def get_reading(self) -> Reading:
         await self._valid.wait()

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -273,3 +273,15 @@ async def test_set_sim_put_proceeds():
     assert sim_signal._backend.put_proceeds.is_set() is False
     set_sim_put_proceeds(sim_signal, True)
     assert sim_signal._backend.put_proceeds.is_set() is True
+
+
+async def test_sim_backend_descriptor_fails_for_invalid_class():
+    class myClass:
+        def __init__(self) -> None:
+            pass
+
+    sim_signal = Signal(SimSignalBackend(myClass, "test"))
+    await sim_signal.connect(sim=True)
+
+    with pytest.raises(AssertionError):
+        await sim_signal._backend.get_descriptor()

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -16,6 +16,7 @@ from ophyd.v2.core import (
     Signal,
     SimSignalBackend,
     get_device_children,
+    set_sim_put_proceeds,
     wait_for_connection,
 )
 
@@ -260,3 +261,15 @@ async def test_status_propogates_traceback_under_RE() -> None:
     assert expected_call_stack == [
         x.name for x in traceback.extract_tb(exception.__traceback__)
     ]
+
+
+async def test_set_sim_put_proceeds():
+    sim_signal = Signal(SimSignalBackend(str, "test"))
+    await sim_signal.connect(sim=True)
+
+    assert sim_signal._backend.put_proceeds.is_set() is True
+
+    set_sim_put_proceeds(sim_signal, False)
+    assert sim_signal._backend.put_proceeds.is_set() is False
+    set_sim_put_proceeds(sim_signal, True)
+    assert sim_signal._backend.put_proceeds.is_set() is True

--- a/ophyd/v2/tests/test_epics.py
+++ b/ophyd/v2/tests/test_epics.py
@@ -75,7 +75,7 @@ def ioc(request):
 class MonitorQueue:
     def __init__(self, backend: SignalBackend):
         self.backend = backend
-        self.subscription = backend.monitor_reading_value(self.add_reading_value)
+        self.subscription = backend.set_callback(self.add_reading_value)
         self.updates: asyncio.Queue[Tuple[Reading, Any]] = asyncio.Queue()
 
     def add_reading_value(self, reading: Reading, value):
@@ -92,7 +92,7 @@ class MonitorQueue:
         assert reading == expected_reading == await self.backend.get_reading()
 
     def close(self):
-        self.subscription.close()
+        self.backend.set_callback(None)
 
 
 async def assert_monitor_then_put(

--- a/ophyd/v2/tests/test_epicsdemo.py
+++ b/ophyd/v2/tests/test_epicsdemo.py
@@ -10,7 +10,7 @@ from ophyd.v2 import epicsdemo
 from ophyd.v2.core import (
     DeviceCollector,
     NotConnected,
-    monitor_sim_value,
+    set_sim_callback,
     set_sim_value,
 )
 
@@ -88,7 +88,7 @@ async def test_mover_moving_well(sim_mover: epicsdemo.Mover) -> None:
 
 async def test_mover_stopped(sim_mover: epicsdemo.Mover):
     callbacks = []
-    monitor_sim_value(sim_mover.stop_, lambda r, v: callbacks.append(v))
+    set_sim_callback(sim_mover.stop_, lambda r, v: callbacks.append(v))
     # We get one update as soon as we connect
     assert callbacks == [None]
     await sim_mover.stop()

--- a/ophyd/v2/tests/test_epicsdemo.py
+++ b/ophyd/v2/tests/test_epicsdemo.py
@@ -7,12 +7,7 @@ from bluesky.protocols import Reading
 from bluesky.run_engine import RunEngine
 
 from ophyd.v2 import epicsdemo
-from ophyd.v2.core import (
-    DeviceCollector,
-    NotConnected,
-    set_sim_callback,
-    set_sim_value,
-)
+from ophyd.v2.core import DeviceCollector, NotConnected, set_sim_callback, set_sim_value
 
 # Long enough for multiple asyncio event loop cycles to run so
 # all the tasks have a chance to run


### PR DESCRIPTION
simple PR to remove `Monitor` and `SimMonitor` from ophyd/v2/core.py.

It has been agreed that it makes sense if the backend only keeps track of one single callback. Therefore, we no longer need a `Monitor` to keep track of potentially several callbacks.