### PR TITLE
Use classes for fallback epics signal backends

### DIFF
--- a/ophyd/v2/epics.py
+++ b/ophyd/v2/epics.py
@@ -11,16 +11,18 @@ try:
     from ._aioca import CaSignalBackend
 except ImportError as ca_error:
 
-    def CaSignalBackend(*args, ca_error=ca_error, **kwargs):  # type: ignore
-        raise NotImplementedError("CA support not available") from ca_error
+    class CaSignalBackend:  # type: ignore
+        def __init__(*args, ca_error=ca_error, **kwargs):
+            raise NotImplementedError("CA support not available") from ca_error
 
 
 try:
     from ._p4p import PvaSignalBackend
 except ImportError as pva_error:
 
-    def PvaSignalBackend(*args, pva_error=pva_error, **kwargs):  # type: ignore
-        raise NotImplementedError("PVA support not available") from pva_error
+    class PvaSignalBackend:  # type: ignore
+        def __init__(*args, pva_error=pva_error, **kwargs):
+            raise NotImplementedError("PVA support not available") from pva_error
 
 
 class EpicsTransport(Enum):


### PR DESCRIPTION
Using functions means that the enums referencing them do not behave as
expected. eg

    def foo(): pass

    class Transport(Enum):
        a = foo

In this setup, `Transport` will have no member named `a` (only a class
method), and `Transport.a.value()` will raise an AttributeError.
