### PR TITLE
Add class for bad pixel plugin

### DIFF
--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -47,6 +47,7 @@ __all__ = [
     "AttrPlotPlugin",
     "AttributeNPlugin",
     "AttributePlugin",
+    "BadPixelPlugin",
     "CircularBuffPlugin",
     "CodecPlugin",
     "ColorConvPlugin",
@@ -917,6 +918,14 @@ class NexusPlugin(FilePlugin, version=(1, 9, 1), version_type="ADCore"):
         SignalWithRBV, "TemplateFilePath", string=True, kind="config"
     )
 
+@register_plugin
+class BadPixelPlugin(PluginBase, version=(3, 11), version_type="ADCore"):
+    _default_suffix = "BadPix1:"
+    _suffix_re = r"BadPix\d:"
+    _html_docs = ["NDBadPix.html"]
+    _plugin_type = "NDBadPixel"
+
+    badpixel_json_filename = Cpt(EpicsSignal, "FileName")
 
 @register_plugin
 class HDF5Plugin(FilePlugin, version=(1, 9, 1), version_type="ADCore"):

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -922,7 +922,7 @@ class NexusPlugin(FilePlugin, version=(1, 9, 1), version_type="ADCore"):
 class BadPixelPlugin(PluginBase, version=(3, 11), version_type="ADCore"):
     _default_suffix = "BadPix1:"
     _suffix_re = r"BadPix\d:"
-    _html_docs = ["NDBadPix.html"]
+    _html_docs = ["NDPluginBadPixel.html"]
     _plugin_type = "NDBadPixel"
 
     badpixel_json_filename = Cpt(EpicsSignal, "FileName")


### PR DESCRIPTION
New plugin for handling bad pixels in areaDetector introduced in recent version of ADCore.

It has a single unique signal - a filename that lists a path to a JSON file that outlines pixel coordinates for bad pixels and how to handle them.

Documentation for plugin: https://areadetector.github.io/areaDetector/ADCore/NDPluginBadPixel.html

EPICS database for plugin: https://github.com/areaDetector/ADCore/blob/master/ADApp/Db/NDBadPixel.template