### PR TITLE
Add children property to a device

### DIFF
--- a/ophyd/v2/core.py
+++ b/ophyd/v2/core.py
@@ -155,6 +155,12 @@ class Device(HasName):
         """Return the name of the Device"""
         return self._name
 
+    @property
+    def children(self) -> Generator[Tuple[str, Device], None, None]:
+        for attr_name, attr in self.__dict__.items():
+            if attr_name != "parent" and isinstance(attr, Device):
+                yield attr_name, attr
+
     def set_name(self, name: str):
         """Set ``self.name=name`` and each ``self.child.name=name+"-child"``.
 
@@ -164,7 +170,10 @@ class Device(HasName):
             New name to set
         """
         self._name = name
-        name_children(self, name)
+        for attr_name, child in self.children:
+            child_name = f"{name}-{attr_name.rstrip('_')}" if name else ""
+            child.set_name(child_name)
+            child.parent = self
 
     async def connect(self, sim: bool = False):
         """Connect self and all child Devices.
@@ -174,7 +183,11 @@ class Device(HasName):
         sim:
             If True then connect in simulation mode.
         """
-        await connect_children(self, sim)
+        coros = {
+            name: child_device.connect(sim) for name, child_device in self.children
+        }
+        if coros:
+            await wait_for_connection(**coros)
 
 
 class NotConnected(Exception):
@@ -215,37 +228,6 @@ async def wait_for_connection(**coros: Awaitable[None]):
         # Wait for everything to foreground the exceptions
         for f in list(done) + list(pending):
             await f
-
-
-async def connect_children(device: Device, sim: bool):
-    """Call ``child.connect(sim)`` on all child devices in parallel.
-
-    Typically used to implement `Device.connect` like this::
-
-        async def connect(self, sim=False):
-            await connect_children(self, sim)
-    """
-
-    coros = {
-        name: child_device.connect(sim)
-        for name, child_device in get_device_children(device)
-    }
-    if coros:
-        await wait_for_connection(**coros)
-
-
-def name_children(device: Device, name: str):
-    """Call ``child.set_name(child_name)`` on all child devices in series."""
-    for attr_name, child in get_device_children(device):
-        child_name = f"{name}-{attr_name.rstrip('_')}" if name else ""
-        child.set_name(child_name)
-        child.parent = device
-
-
-def get_device_children(device: Device) -> Generator[Tuple[str, Device], None, None]:
-    for attr_name, attr in device.__dict__.items():
-        if attr_name != "parent" and isinstance(attr, Device):
-            yield attr_name, attr
 
 
 class DeviceCollector:
@@ -981,15 +963,21 @@ VT = TypeVar("VT", bound=Device)
 
 
 class DeviceVector(Dict[int, VT], Device):
-    def set_name(self, parent_name: str):
-        self._name = parent_name
-        for name, device in self.items():
-            device.set_name(f"{parent_name}-{name}")
-            device.parent = self
+    # def set_name(self, parent_name: str):
+    #     self._name = parent_name
+    #     for name, device in self.items():
+    #         device.set_name(f"{parent_name}-{name}")
+    #         device.parent = self
 
-    async def connect(self, sim: bool = False):
-        coros = {str(k): d.connect(sim) for k, d in self.items()}
-        await wait_for_connection(**coros)
+    @property
+    def children(self) -> Generator[Tuple[str, Device], None, None]:
+        for attr_name, attr in self.items():
+            if isinstance(attr, Device):
+                yield str(attr_name), attr
+
+    # async def connect(self, sim: bool = False):
+    #     coros = {str(k): d.connect(sim) for k, d in self.items()}
+    #     await wait_for_connection(**coros)
 
 
 def get_unique(values: Dict[str, T], types: str) -> T:

--- a/ophyd/v2/tests/test_core.py
+++ b/ophyd/v2/tests/test_core.py
@@ -23,7 +23,6 @@ from ophyd.v2.core import (
     SignalRW,
     SimSignalBackend,
     T,
-    get_device_children,
     set_and_wait_for_value,
     set_sim_put_proceeds,
     set_sim_value,
@@ -205,17 +204,27 @@ class DummyDeviceGroup(Device):
         self.set_name(name)
 
 
-def test_get_device_children():
+def test_device_children():
     parent = DummyDeviceGroup("parent")
 
     names = ["child1", "child2", "dict_with_children"]
-    for idx, (name, child) in enumerate(get_device_children(parent)):
+    for idx, (name, child) in enumerate(parent.children):
         assert name == names[idx]
         assert (
             type(child) == DummyBaseDevice
             if name.startswith("child")
             else type(child) == DeviceVector
         )
+        assert child.parent == parent
+
+
+def test_device_vector_children():
+    parent = DummyDeviceGroup("root")
+
+    device_vector_children = [
+        (name, child) for name, child in parent.dict_with_children.children
+    ]
+    assert device_vector_children == [("123", parent.dict_with_children[123])]
 
 
 async def test_children_of_device_have_set_names_and_get_connected():


### PR DESCRIPTION
It was recently discovered that `get_device_children()` doesn't work for devices that are device_vectors.

To fix this issue, this PR removes `get_device_children`, `connect_children` and `name_children` and instead defines a `children` property on a device which effectively does what `get_device_children` did. 

This simplifies the code for DeviceVector somewhat, which only needs to define a `children` property and no longer needs to redefine `connect` and `name` class methods that it inherits from `Device`.