### PR TITLE
v2: Initial support for NTNDArray and correct timestamp -> timeStamp

### DIFF
--- a/ophyd/v2/_p4p.py
+++ b/ophyd/v2/_p4p.py
@@ -110,7 +110,7 @@ def make_converter(datatype: Optional[Type], values: Dict[str, Any]) -> PvaConve
         if datatype and datatype != Sequence[str]:
             raise TypeError(f"{pv} has type [str] not {datatype.__name__}")
         return PvaArrayConverter()
-    elif "NTScalarArray" in typeid:
+    elif "NTScalarArray" in typeid or "NTNDArray" in typeid:
         pv_dtype = get_unique(
             {k: v["value"].dtype for k, v in values.items()}, "dtypes"
         )
@@ -215,7 +215,7 @@ class PvaSignalBackend(SignalBackend[T]):
 
     async def get_reading(self) -> Reading:
         value = await self.ctxt.get(
-            self.read_pv, request="field(value,alarm,timestamp)"
+            self.read_pv, request="field(value,alarm,timeStamp)"
         )
         return self.converter.reading(value)
 
@@ -233,7 +233,7 @@ class PvaSignalBackend(SignalBackend[T]):
                 callback(self.converter.reading(v), self.converter.value(v))
 
             self.subscription = self.ctxt.monitor(
-                self.read_pv, async_callback, request="field(value,alarm,timestamp)"
+                self.read_pv, async_callback, request="field(value,alarm,timeStamp)"
             )
         else:
             if self.subscription:

--- a/ophyd/v2/tests/test_epics.py
+++ b/ophyd/v2/tests/test_epics.py
@@ -300,6 +300,31 @@ async def test_pva_table(ioc: IOC) -> None:
             q.close()
 
 
+async def test_pva_ntdarray(ioc: IOC):
+    if ioc.protocol == "ca":
+        # CA can't do ndarray
+        return
+    initial = np.zeros(4, np.int64)
+    put = np.ones_like(initial)
+
+    descriptor = dict(dtype="array", shape=[4])
+
+    for i, p in [(initial, put), (put, initial)]:
+        backend = await ioc.make_backend(npt.NDArray[np.int64], "ntndarray")
+        # Make a monitor queue that will monitor for updates
+        q = MonitorQueue(backend)
+        try:
+            # Check descriptor
+            assert dict(source=backend.source, **descriptor) == await backend.get_descriptor()
+            # Check initial value
+            await q.assert_updates(pytest.approx(i))
+            # Put to new value and check that
+            await backend.put(p)
+            await q.assert_updates(pytest.approx(p))
+        finally:
+            q.close()
+
+
 async def test_non_existant_errors(ioc: IOC):
     backend = await ioc.make_backend(str, "non-existant", connect=False)
     # Can't use asyncio.wait_for on python3.8 because of

--- a/ophyd/v2/tests/test_epics.py
+++ b/ophyd/v2/tests/test_epics.py
@@ -315,7 +315,10 @@ async def test_pva_ntdarray(ioc: IOC):
         q = MonitorQueue(backend)
         try:
             # Check descriptor
-            assert dict(source=backend.source, **descriptor) == await backend.get_descriptor()
+            assert (
+                dict(source=backend.source, **descriptor)
+                == await backend.get_descriptor()
+            )
             # Check initial value
             await q.assert_updates(pytest.approx(i))
             # Put to new value and check that

--- a/ophyd/v2/tests/test_epics.py
+++ b/ophyd/v2/tests/test_epics.py
@@ -328,6 +328,17 @@ async def test_pva_ntdarray(ioc: IOC):
             await q.assert_updates(pytest.approx(p))
 
 
+async def test_writing_to_ndarray_raises_typeerror(ioc: IOC):
+    if ioc.protocol == "ca":
+        # CA can't do ndarray
+        return
+
+    backend = await ioc.make_backend(npt.NDArray[np.int64], "ntndarray")
+
+    with pytest.raises(TypeError):
+        await backend.put(np.zeros((6,), dtype=np.int64))
+
+
 async def test_non_existant_errors(ioc: IOC):
     backend = await ioc.make_backend(str, "non-existant", connect=False)
     # Can't use asyncio.wait_for on python3.8 because of

--- a/ophyd/v2/tests/test_records.db
+++ b/ophyd/v2/tests/test_records.db
@@ -243,11 +243,31 @@ record(waveform, "$(P)table:enum")
     })
 }
 
-record(waveform, "$(P)ntndarray")
+record(longout, "$(P)ntndarray:ArraySize0_RBV") {
+    field(VAL, "3")
+    field(PINI, "YES")
+    info(Q:group, {
+        "$(P)ntndarray":{
+            "dimension[0].size":{+channel:"VAL", +type:"plain", +putorder:0}
+        }
+    })
+}
+
+record(longout, "$(P)ntndarray:ArraySize1_RBV") {
+    field(VAL, "2")
+    field(PINI, "YES")
+    info(Q:group, {
+        "$(P)ntndarray":{
+            "dimension[1].size":{+channel:"VAL", +type:"plain", +putorder:0}
+        }
+    })
+}
+
+record(waveform, "$(P)ntndarray:data")
 {
   field(FTVL, "INT64")
-  field(NELM, "4")
-  field(INP, {const:[0, 0, 0, 0]})
+  field(NELM, "6")
+  field(INP, {const:[0, 0, 0, 0, 0, 0]})
   field(PINI, "YES")
   info(Q:group, {
         "$(P)ntndarray":{
@@ -257,7 +277,7 @@ record(waveform, "$(P)ntndarray")
                 +channel:"VAL",
                 +trigger:"*",
             },
-            "": {+type:"meta", +channel:"VAL"}
+            "": {+type:"meta", +channel:"SEVR"}
         }
     })
 }

--- a/ophyd/v2/tests/test_records.db
+++ b/ophyd/v2/tests/test_records.db
@@ -242,3 +242,22 @@ record(waveform, "$(P)table:enum")
         }
     })
 }
+
+record(waveform, "$(P)ntndarray")
+{
+  field(FTVL, "INT64")
+  field(NELM, "4")
+  field(INP, {const:[0, 0, 0, 0]})
+  field(PINI, "YES")
+  info(Q:group, {
+        "$(P)ntndarray":{
+            +id:"epics:nt/NTNDArray:1.0",
+            "value":{
+                +type:"any",
+                +channel:"VAL",
+                +trigger:"*",
+            },
+            "": {+type:"meta", +channel:"VAL"}
+        }
+    })
+}


### PR DESCRIPTION
Allow Ophyd V2 to read from an `NTNDArray` type `pva` variable.

At the moment it is using the standard array converter, which means that the array is always provided downstream as 1-D - it might be better to eventually do the reshaping into a correctly-shaped NTNDArray in the converter, but this is sufficient for my simple use-case at the moment and it wasn't entirely clear to me how to get at the metadata (i.e. shape) from within the current converter mechanism.

Also fixes a typo (?) of `timestamp` -> `timeStamp`, which I think would have affected *every* pva variable and was preventing me from reading array data over PVA. As far as I can tell from the various PVAccess specs/documents online, `timeStamp` is always the standard name that is used. Happy to be corrected on this if I'm wrong though...