### PR TITLE
Add .1% threshold for codecov CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,8 +5,10 @@ coverage:
     project:
       default:
         target: auto
+        threshold: 0.1%
     patch:
       default:
         target: auto
+        threshold: 0.1%
 github_checks:
   annotations: false


### PR DESCRIPTION
Fixes https://github.com/bluesky/ophyd/issues/1149