### PR TITLE
BUG: Change declaration of SynAxis components such that describe() works properly.

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -413,8 +413,8 @@ class SynAxis(Device):
         Default is 1.
     """
 
-    readback = Cpt(_ReadbackSignal, value=0, kind="hinted")
-    setpoint = Cpt(_SetpointSignal, value=0, kind="normal")
+    readback = Cpt(_ReadbackSignal, value=0.0, kind="hinted")
+    setpoint = Cpt(_SetpointSignal, value=0.0, kind="normal")
 
     velocity = Cpt(Signal, value=1, kind="config")
     acceleration = Cpt(Signal, value=1, kind="config")
@@ -529,7 +529,7 @@ class SynAxisEmptyHints(SynAxis):
 
 
 class SynAxisNoHints(SynAxis):
-    readback = Cpt(_ReadbackSignal, value=0, kind="omitted")
+    readback = Cpt(_ReadbackSignal, value=0.0, kind="omitted")
 
     @property
     def hints(self):


### PR DESCRIPTION
### What is this PR about?
When using SynAxis for simulated testing, calling `.describe()` on an instance returns a descriptor for integers rather than floats.

### Example code that demonstrates the issue
```python
from ophyd.sim import SynAxis

if __name__ == "__main__":
    sim_motor = SynAxis(name="motor1", value=3.14)
    print(sim_motor.describe())
```
Which produces:
```
OrderedDict([('motor1', {'source': 'SIM:motor1', 'dtype': 'integer', 'shape': [], 'precision': 3}), ('motor1_setpoint', {'source': 'SIM:motor1_setpoint', 'dtype': 'integer', 'shape': [], 'precision': 3})])
```
### What is the fix?
Declaring the components for SynAxis with a value of `0.0` rather than `0`. Running demonstration code above with the fix in this PR produces:
```
OrderedDict([('motor1', {'source': 'SIM:motor1', 'dtype': 'number', 'shape': [], 'precision': 3}), ('motor1_setpoint', {'source': 'SIM:motor1_setpoint', 'dtype': 'number', 'shape': [], 'precision': 3})])
```
### How did I encounter this issue?
While using the bluesky `LiveTable` callback, format errors were occurring where string `format` was being called for float values on integer format strings.

