### PR TITLE
Remove (obsolete) internal records from FileBase

### DIFF
--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -824,8 +824,6 @@ class FileBase(Device):
     file_format = Cpt(SignalWithRBV, "FileFormat", kind="config")
     file_name = Cpt(SignalWithRBV, "FileName", string=True, kind="config")
     file_number = Cpt(SignalWithRBV, "FileNumber")
-    file_number_sync = Cpt(EpicsSignal, "FileNumber_Sync")
-    file_number_write = Cpt(EpicsSignal, "FileNumber_write")
     file_path = Cpt(
         EpicsPathSignal, "FilePath", string=True, kind="config", path_semantics="posix"
     )


### PR DESCRIPTION
These two were internal implementation details in NDFile.template to sync FileNumber. There is no use to expose them.

Moreover they have been removed since areaDetector 2.2, https://github.com/areaDetector/ADCore/commit/6fb231f5269adcbea01a93247a45255057577c07