### PR TITLE
Temporary fix for #1163

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -e .[dev] && pipdeptree
+        run: pip install --upgrade setuptools && pip install -e .[dev] && pipdeptree
 
       - name: Start IOCs in containers.
         run: |


### PR DESCRIPTION
The long term fix is to upgrade to pyproject.toml, but this will quell the warnings for now