### PR TITLE
Add initial orchestrators idea

### DIFF
--- a/ophyd/areadetector/__init__.py
+++ b/ophyd/areadetector/__init__.py
@@ -9,6 +9,8 @@ from .cam import *  # noqa: F401, F402, E402, F403
 from .common_plugins import *  # noqa: F401, F402, E402, F403
 from .detectors import *  # noqa: F401, F402, E402, F403
 from .paths import EpicsPathSignal  # noqa: F401, F402, E402, F403
+from .detectors_orchestrators import *
+from .plugins_orchestrators import *
 
 # NOTE: the following imports are here for backward compatibility with
 # previous ophyd versions. This does not represent all available plugins

--- a/ophyd/areadetector/detectors_orchestrators.py
+++ b/ophyd/areadetector/detectors_orchestrators.py
@@ -1,0 +1,41 @@
+from .detectors import *
+
+
+class SimDetectorOrch(SimDetector):
+
+    def configure_peaks(self, **kwargs):
+        '''
+        Grid: dict {"Start": (M,N), "Width": (J,K), "Num": (W,L), 
+                    "Step": (P,Q)}
+
+        Configures the driver to create a grid of Peaks.
+        '''
+
+        grid = kwargs.get("grid")
+
+        # Most intuitive configuration is set
+        # using grid.
+        if grid is not None:
+            start_tuple = grid["Start"]
+            width_tuple = grid["Width"]
+            num_tuple = grid["Num"]
+            step_tuple = grid["Step"]
+
+            self.cam.peak_start.put(start_tuple)
+            self.cam.peak_width.put(width_tuple)
+            self.cam.peak_num.put(num_tuple)
+            self.cam.peak_step.put(step_tuple)
+
+        # Making it possible to oberride other parameters that
+        # are not basically necessary but influence on the
+        # configuration
+        properties = {kwargs.get("variation"): self.cam.peak_variation,
+                      kwargs.get("gain"): self.cam.gain,
+                      kwargs.get("gain_xy"): self.cam.gain_xy
+                      }
+
+        for _property in properties.keys():
+            if _property is not None:
+                properties[_property].put(_property)
+
+        self.cam.sim_mode.put(1)

--- a/ophyd/areadetector/plugins_orchestrators.py
+++ b/ophyd/areadetector/plugins_orchestrators.py
@@ -1,0 +1,44 @@
+from .plugins import *
+
+
+class ProcessPluginOrch(ProcessPlugin):
+
+    def configure_average(self, num_to_avg=1, **kwargs):
+        '''
+        num_to_avg: int
+
+        Configures ProcessPlugin to output
+        and average of the last num_to_avg images
+        '''
+
+        # Most intuitive configuration is
+        # set by default. Can be overriden by user with kwargs.
+        self.enable_background.put(0)
+        self.enable_flat_field.put(0)
+        self.enable_offset_scale.put(0)
+
+        self.enable_filter.put(1)
+        self.enable.put(1)
+        self.filter_type.put(1)  # Average
+
+        self.auto_reset_filter.put(num_to_avg)
+        self.filter_callbacks.put(1)  # Array N only
+        self.num_filter.put(num_to_avg)
+
+        # Overriding with kwargs part
+        properties = {
+            kwargs.get("enable_background"): self.enable_background,
+            kwargs.get("enable_flat_field"): self.enable_flat_field,
+            kwargs.get("enable_offset_scale"): self.enable_offset_scale,
+            kwargs.get("enable_filter"): self.enable_filter,
+            kwargs.get("enable"): self.enable,
+            kwargs.get("filter_type"): self.filter_type,
+            kwargs.get("auto_reset_filter"): self.auto_reset_filter,
+            kwargs.get("filter_callbacks"): self.filter_callbacks,
+            kwargs.get("num_filter"): self.num_filter,
+            kwargs.get("reset_filter"): self.reset_filter
+        }
+
+        for _property in properties.keys():
+            if _property is not None:
+                properties[_property].put(_property)


### PR DESCRIPTION
Im not sure if the general ideia fits in ophyd scope, but this is an initial attempt.
The idea is to have abstractions to perform tasks that are possibly frequent to the plugins and drivers, but not basic enough to be put in the initial plugin/driver abstractions. For example, a common method to configure a grid of peaks in SimDetector or one to define how to average images in processPlugin.

I wanted to set a default behavior in the method but in a way that default parameter values could be overriden by an user who knows what they are doing.

Unfortunately, the only way i could come up to do this was by manually coding the properties as possible keys to kwargs (eg. line 22 in ProcessPluginOrchestrator). I tried dynamically checking if any argument in kwargs was equal to one of the component_names but for that i needed to use something like getattr(self.cam, component_name).put() and for some reason that didnt work.

I appreciate any feedback.  