### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/user/how-to/pseudopositioner.md
+++ b/docs/user/how-to/pseudopositioner.md
@@ -7,7 +7,7 @@ one exposed by the hardware. One important use case is HKL scanning.
 
 ```py
 
-from ophyd.psuedopos import (
+from ophyd.pseudopos import (
     PseudoPositioner,
     PseudoSingle,
     pseudo_position_argument,


### PR DESCRIPTION
Someone here at DLS came across a ModuleNotFoundError following the tutorials