### PR TITLE
Remove obsolete PV PoolMaxBuffers

### DIFF
--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -74,7 +74,6 @@ class CamBase(ADBase):
     nd_attributes_file = ADCpt(EpicsSignal, "NDAttributesFile", string=True)
     pool_alloc_buffers = ADCpt(EpicsSignalRO, "PoolAllocBuffers")
     pool_free_buffers = ADCpt(EpicsSignalRO, "PoolFreeBuffers")
-    pool_max_buffers = ADCpt(EpicsSignalRO, "PoolMaxBuffers")
     pool_max_mem = ADCpt(EpicsSignalRO, "PoolMaxMem")
     pool_used_buffers = ADCpt(EpicsSignalRO, "PoolUsedBuffers")
     pool_used_mem = ADCpt(EpicsSignalRO, "PoolUsedMem")


### PR DESCRIPTION
This PV was removed from ADCore since 3.3.1, see
https://github.com/areaDetector/ADCore/commit/47c70bf10644c63955c00646eaffd881f8a1a9bc