### PR TITLE
Add two new kwargs to ADTriggerStatus __init__, to allow for using different signals than default AD

### DIFF
--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -27,18 +27,29 @@ class ADTriggerStatus(DeviceStatus):
     based on comparing device.cam.array_counter to  device.cam.num_images.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, counter_signal = None, target_signal = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.start_ts = ttime.time()
+
+        # Provide option to override which signals are watched to specify a "done" condition
+        self.counter_signal = counter_signal
+        self.target_signal = target_signal
+
+        # If not specified, just use the default array counter and num images signals.
+        if counter_signal is None:
+            self.counter_signal = self.device.cam.array_counter
+
+        if target_signal is None:
+            self.target_signal = self.device.cam.num_images
 
         # Notify watchers (things like progress bars) of new values
         # at the device's natural update rate.
         if not self.done:
-            self.device.cam.array_counter.subscribe(self._notify_watchers)
+            self.counter_signal.subscribe(self._notify_watchers)
             # some state needed only by self._notify_watchers
             self._name = self.device.name
-            self._initial_count = self.device.cam.array_counter.get()
-            self._target_count = self.device.cam.num_images.get()
+            self._initial_count = self.counter_signal.get()
+            self._target_count = self.target_signal.get()
 
     def watch(self, func):
         self._watchers.append(func)
@@ -46,7 +57,7 @@ class ADTriggerStatus(DeviceStatus):
     def _notify_watchers(self, value, *args, **kwargs):
         # *args and **kwargs catch extra inputs from pyepics, not needed here
         if self.done:
-            self.device.cam.array_counter.clear_sub(self._notify_watchers)
+            self.counter_signal.clear_sub(self._notify_watchers)
         if not self._watchers:
             return
         # Always start progress bar at 0 regardless of starting value of


### PR DESCRIPTION
Currently `ADTriggerStatus` essentially hard codes the two signals that are watched/compared when reporting the progress of a trigger execution. I know of at least a few cases where this isn't desirable due to either non-standard AD driver behavior, or because the underlying detector relies on a different progress metric than completed/readout frames.

I'd like to get some feedback on whether or not this approach is reasonable, and if yes I can write up a unit test or two to check behavior when either or both signals are overridden.