### PR TITLE
status: do not create thread to run callbacks if timeout is None

### DIFF
--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -445,6 +445,29 @@ def test_status_timeout_with_settle_time():
         st.wait(2)
 
 
+def test_status_timeout_infinite_with_settle_time():
+    """
+    When no timeout is specified, a "_run_callbacks" thread is not started,
+    it is called upon termination of the status ("set_finished" or exception).
+    However, if settle_time is given the callbacks will be called only
+    after the settle time has expired (from a timer thread).
+    """
+    cb = Mock()
+    st = StatusBase(settle_time=1)
+    st.add_callback(cb)
+
+    # there is no timeout, explicitely set finished ;
+    # the callback should be called after "settle_time"
+    st.set_finished()
+
+    assert cb.call_count == 0
+    with pytest.raises(WaitTimeoutError):
+        # not ready yet
+        st.wait(0.5)
+    st.wait(0.6)
+    cb.assert_called_once()
+
+
 def test_external_timeout():
     """
     A TimeoutError is raised, not StatusTimeoutError or WaitTimeoutError,


### PR DESCRIPTION
Here is a merge request that mitigates concern expressed here: https://github.com/bluesky/ophyd/pull/837#discussion_r409007458 (also linked with issue #844).

I have the impression, a simple optimization is to not create a thread if it is not needed (in particular when timeout is set to `None`, which seems to be most of the time).

Otherwise some background about the problem `Status` objects want to solve with the callbacks thread would be insightful.

