### PR TITLE
Consistent numpy byte order in Ophyd Signal

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -915,13 +915,14 @@ class EpicsSignalBase(Signal):
         timeout=DEFAULT_TIMEOUT,
         write_timeout=DEFAULT_WRITE_TIMEOUT,
         connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
+        fix_byteorder=True,
         **kwargs,
     ):
         self._metadata_lock = threading.RLock()
         self._read_pv = None
         self._read_pvname = read_pv
         self._string = bool(string)
-
+        self._fixbyteorder = fix_byteorder
         self._signal_is_ready = threading.Event()
         self._first_connection = True
 
@@ -1422,6 +1423,8 @@ class EpicsSignalBase(Signal):
         "Cast the given value according to the data type of this EpicsSignal"
         if self._string:
             value = waveform_to_string(value)
+        if self._fixbyteorder and isinstance(value, np.ndarray) and value.dtype.byteorder == ">":
+            value = value.byteswap().newbyteorder()
 
         return value
 


### PR DESCRIPTION
This is a _very_ niche issue, but important for some of the pod systems I'm running.

# Description of the problem
Some time ago, I started running Ophyd and friends in a pod. However, I quickly ran into problems trying to move data over Kafka, which were related to the following behavior of `tiled.utils.safe_json_dump` when big-endian data is passed in:
```python
In [82]: safe_json_dump({"test": np.array([0.0, 1.1, 2.2], dtype='<f8')})
Out[82]: b'{"test":[0.0,1.1,2.2]}'

In [83]: safe_json_dump({"test": np.array([0.0, 1.1, 2.2], dtype='>f8')})
Out[83]: b'{"test":[0.0,-1.5423487136706484e-180,-1.5423487136574978e-180]}' 
```
The json serializer in tiled relies very directly on the `orjson` package, which just doesn't care about byte order at all, meaning that data does not _round trip_.

But why was my data big-endian in the first-place? This turns out to come directly from the Ophyd signal
```python
In [9]: tes.energies.cl.caget(tes.energies.pvname)
Out[9]: 
array([200.5, 201.5, 202.5, 203.5, 204.5, 205.5, 206.5, 207.5, 208.5,
       ...
       992.5, 993.5, 994.5, 995.5, 996.5, 997.5, 998.5, 999.5],
      dtype='>f8')
```
Which means that something in my container's network stack is prompting Caproto/EPICS to pass around big-endian data. This makes sense, as networking is pretty much the only place that big-endian data is used.

# Where could I fix this?
This could probably be fixed in _several_ places. In rough order of data-handling, they are
* caproto
* my container's network configuration
* ophyd
* tiled
* orjson

# Why fix this in Ophyd?
I believe that Ophyd is the most plausible/helpful place to correct the endianness issue.

## Why not fix Caproto/EPICS/my network configuration?
I personally haven't been able to figure out _why_ my container is causing Caproto to send big-endian data, but even if the underlying issue is in Caproto, or even in EPICS, I believe that Ophyd should be able to handle this case more gracefully for maximum compatibility. Sometimes you'll get big-endian data, apparently, and Ophyd should be able to handle that.

## Why not fix the serializer in Tiled?
This was my initial thought -- just add some checks to `safe_json_dump` in Tiled! Unfortunately, by the time you get to Tiled, you are dealing with highly nested data. It was really easy to serialize a solitary array. But to serialize Tiled data correctly, I would need to delve into the values of the dictionary, see if any of those were a numpy array, and change its byte order. But now the Tiled serializer has _side effects_ unless you make a deep copy of all the content that gets passed in. And you are on the hook for going through all the nested entries of any dictionary, list, or other container. No thanks!

## Why not fix orjson?
This is plausible, and I have submitted an issue to orjson. I don't know if they'll fix it, or even if they view it as a bug, or the serializer working as intended. However, even if it's fixed in orjson, it wouldn't help anybody else who's using a different serializer, or who has other issues related to inconsistent endianness in Ophyd.

## Summary
I think that fixing this in Ophyd would be the most practical, consistent solution. We can check all the data that we ingest, and at least make sure that it's converted to a consistent byte order in Ophyd.

# Where should we fix this in Ophyd?
The most immediate place to fix this, to me, was in the existing `_fix_type` method of `EpicsSignalBase`. It's a logical place for this kind of kludge. It's really the first place that Ophyd handles values that come in from the outside.

I don't think it's possible to go lower, as the control layer is really just a shim around pyepics, caproto, etc. But I'm open to suggestions.