### PR TITLE
Add Long name to OphydObj

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -36,7 +36,6 @@ try:
         ...
 
 except ImportError:
-
     IFBase = IntFlag
 
 

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -148,7 +148,16 @@ class OphydObject:
     __any_instantiated = False
     subscriptions: ClassVar[FrozenSet[str]] = frozenset()
 
-    def __init__(self, *, name=None, attr_name="", parent=None, labels=None, kind=None):
+    def __init__(
+        self,
+        *,
+        name=None,
+        attr_name="",
+        parent=None,
+        labels=None,
+        kind=None,
+        long_name=None,
+    ):
         if labels is None:
             labels = set()
         self._ophyd_labels_ = set(labels)
@@ -166,7 +175,7 @@ class OphydObject:
             raise ValueError("name must be a string.")
         self._name = name
         self._parent = parent
-
+        self._long_name = long_name
         # dictionary of wrapped callbacks
         self._callbacks = {k: {} for k in self.subscriptions}
         # this is to maintain api on clear_sub
@@ -330,6 +339,18 @@ class OphydObject:
     @name.setter
     def name(self, name):
         self._name = name
+
+    @property
+    def long_name(self):
+        """name of the device"""
+        if self._long_name is not None:
+            return self._long_name
+        else:
+            return self._name
+
+    @name.setter
+    def long_name(self, name):
+        self._long_name = name
 
     @property
     def attr_name(self):

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -348,7 +348,7 @@ class OphydObject:
         else:
             return self._name
 
-    @name.setter
+    @long_name.setter
     def long_name(self, name):
         self._long_name = name
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -105,10 +105,11 @@ class Signal(OphydObject):
         metadata=None,
         cl=None,
         attr_name="",
+        long_name=None,
     ):
 
         super().__init__(
-            name=name, parent=parent, kind=kind, labels=labels, attr_name=attr_name
+            name=name, parent=parent, kind=kind, labels=labels, attr_name=attr_name, long_name=long_name
         )
 
         if cl is None:

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -107,9 +107,13 @@ class Signal(OphydObject):
         attr_name="",
         long_name=None,
     ):
-
         super().__init__(
-            name=name, parent=parent, kind=kind, labels=labels, attr_name=attr_name, long_name=long_name
+            name=name,
+            parent=parent,
+            kind=kind,
+            labels=labels,
+            attr_name=attr_name,
+            long_name=long_name,
         )
 
         if cl is None:
@@ -1719,7 +1723,6 @@ class EpicsSignal(EpicsSignalBase):
         name=None,
         **kwargs,
     ):
-
         self._write_pv = None
         self._use_limits = bool(limits)
         self._put_complete = put_complete


### PR DESCRIPTION
As discussed in #1161 this adds an attribute `long_name` to the base OphydObj, and also slightly modifies the Signal classes to pass `long_name` through.

If `long_name` is not set, it will default to returning `name`, so that you can just use the attribute as a display label without worrying about whether or not it was set.

`long_name` can be passed into components. It is _not_ concatenated with its parent device's `long_name`, which I think would be undesirable behavior. It is something that should be very intentionally set to provide a self-contained descriptive label for whatever it is passed to.