### PR TITLE
Missing destroyed attribute on OphydObject

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -166,6 +166,7 @@ class OphydObject:
             raise ValueError("name must be a string.")
         self._name = name
         self._parent = parent
+        self._destroyed = False
 
         # dictionary of wrapped callbacks
         self._callbacks = {k: {} for k in self.subscriptions}
@@ -345,6 +346,7 @@ class OphydObject:
     def destroy(self):
         """Disconnect the object from the underlying control layer"""
         self.unsubscribe_all()
+        self._destroyed = True
 
     @property
     def parent(self):


### PR DESCRIPTION
## Description

While `OphydObject` implements the `destroy` method, it does not provide the `_destroyed` attribute. The latter is only implemented on `Device`. Given the "_", I assume it is not meant to be used directly, yet I'm not aware of another way to check whether an object was destroyed. In the absence of a more elegant solution, I'd suggest to add the `_destroyed` attribute to the `OphydObject` class to make available e.g. to a `SoftPositioner`. 

## Related Issues

https://github.com/bluesky/ophyd/issues/1095

## Type of Change

- Added `_destroyed` attribute to `OphydObject`
- Set `_destroyed` to True after a call to `destroyed`
