### PR TITLE
TYPO should be lower case to be consistent with others in this module

### DIFF
--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -98,7 +98,7 @@ class QuadEM(SingleTrigger, DetectorBase):
     position_offset_calc_y = Cpt(EpicsSignal, "ComputePosOffsetY")
 
     position_scale_x = Cpt(EpicsSignal, "PositionScaleX")
-    position_scale_Y = Cpt(EpicsSignal, "PositionScaleY")
+    position_scale_y = Cpt(EpicsSignal, "PositionScaleY")
 
     image = Cpt(ImagePlugin, "image1:")
     current1 = Cpt(StatsPlugin, "Current1:")


### PR DESCRIPTION
Somehow, this missed testing.  A long time ago.

```py
    tetramm = TetrAMM("8idTetra:QUAD1:", name="tetramm")
    for axis in "x y".split():
        for attr_name in "offset offset_calc scale".split():
            getattr(tetramm, f"position_{attr_name}_{axis}").kind = "config"
AttributeError: position_scale_y
```