### PR TITLE
Unpin numpy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ setup_requires =
 # Specify any package dependencies below.
 install_requires =
     networkx>=2.0
-    numpy<2.0
+    numpy
     opentelemetry-api
     packaging
     pint


### PR DESCRIPTION
Related to https://github.com/bluesky/bluesky/pull/1813. As I said over there:

> Should we double our CI matrix to test against numpy 1.x and 2.x? I lean "no", it is good enough to test against latest numpy, particularly because bluesky itself does not have any deep numpy integrations or compiled code directly in ophyd.