### PR TITLE
Test on prereleases of bluesky, event-model.

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -46,6 +46,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        prerelease: [false]
+        # Add one more job that runs on prereleases
+        include:
+          - python-version: "3.12"
+            prerelease: true
     runs-on: ubuntu-latest
     env:
       TEST_CL: pyepics
@@ -62,6 +67,10 @@ jobs:
 
       - name: Install dependencies
         run: pip install --upgrade setuptools && pip install -e .[dev] && pipdeptree
+
+      - name: Install prereleases of certain dependencies.
+        run: pip install --upgrade --pre bluesky event-model
+        when: matrix.prerelease
 
       - name: Start IOCs in containers.
         run: |

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install prereleases of certain dependencies.
         run: pip install --upgrade --pre bluesky event-model
-        when: ${{ matrix.prerelease }}
+        if: ${{ matrix.prerelease }}
 
       - name: Start IOCs in containers.
         run: |

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install prereleases of certain dependencies.
         run: pip install --upgrade --pre bluesky event-model
-        when: matrix.prerelease
+        when: ${{ matrix.prerelease }}
 
       - name: Start IOCs in containers.
         run: |


### PR DESCRIPTION
This adds a single build to the matrix that tests against prereleases of bluesky and event-model.

Relevant section of GH Actions docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#example-adding-configurations
