### PR TITLE
CI: do not try to start docker images that no longer exist

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -78,7 +78,7 @@ jobs:
           source ${GITHUB_WORKSPACE}/scripts/epics_docker.sh
 
       - name: Test with pytest
-        run: pytest -k "${TEST_CL}"
+        run: pytest -k "${TEST_CL}" -m "not motorsim" --strict-markers
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/docs/user/reference/release_notes.rst
+++ b/docs/user/reference/release_notes.rst
@@ -9,7 +9,7 @@ Added
 -----
 
 * ``count`` parameter to Signal.get (same as pv.get)
-* ``.locate()` method to EpicsMotor, returning setpoint and readback
+* ``.locate()`` method to EpicsMotor, returning setpoint and readback
 * ``dtype`` and ``shape`` keywords can be specified in Signal constructor to avoid type inference
 * ``describe()`` returns ``dtype_numpy``, if available
 

--- a/ophyd/tests/test_issue944.py
+++ b/ophyd/tests/test_issue944.py
@@ -10,6 +10,7 @@ Needs this set in the top-most conftest.py file to enable 'testdir':
 
     echo "pytest_plugins = 'pytester'" >> conftest.py
 """
+import pytest
 
 from .config import motor_recs
 
@@ -22,6 +23,7 @@ def run_test_code(testdir, code):
     result.stdout.fnmatch_lines(["* 1 passed*"])
 
 
+@pytest.mark.motorsim
 def test_local_without_defaults_no_string(testdir):
     from ophyd import EpicsSignal
 
@@ -32,6 +34,7 @@ def test_local_without_defaults_no_string(testdir):
     assert desc["signal"]["dtype"] == "integer"
 
 
+@pytest.mark.motorsim
 def test_without_defaults_no_string(testdir):
     run_test_code(
         testdir,
@@ -51,6 +54,7 @@ def test_without_defaults_no_string(testdir):
     )
 
 
+@pytest.mark.motorsim
 def test_without_defaults_as_string(testdir):
     run_test_code(
         testdir,
@@ -70,6 +74,7 @@ def test_without_defaults_as_string(testdir):
     )
 
 
+@pytest.mark.motorsim
 def test_with_all_defaults_no_string(testdir):
     run_test_code(
         testdir,
@@ -96,6 +101,7 @@ def test_with_all_defaults_no_string(testdir):
     )
 
 
+@pytest.mark.motorsim
 def test_with_all_defaults_as_string(testdir):
     run_test_code(
         testdir,
@@ -123,6 +129,7 @@ def test_with_all_defaults_as_string(testdir):
     )
 
 
+@pytest.mark.motorsim
 def test_with_all_defaults_auto_monitor(testdir):
     run_test_code(
         testdir,
@@ -147,6 +154,7 @@ def test_with_all_defaults_auto_monitor(testdir):
     )
 
 
+@pytest.mark.motorsim
 def test_with_all_defaults_connection_timeout(testdir):
     run_test_code(
         testdir,
@@ -171,6 +179,7 @@ def test_with_all_defaults_connection_timeout(testdir):
     )
 
 
+@pytest.mark.motorsim
 def test_with_all_defaults_timeout(testdir):
     run_test_code(
         testdir,
@@ -195,6 +204,7 @@ def test_with_all_defaults_timeout(testdir):
     )
 
 
+@pytest.mark.motorsim
 def test_with_all_defaults_write_timeout(testdir):
     run_test_code(
         testdir,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ markers = [
 asyncio_mode = "auto"
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
 # filterwarnings = "error"
+python_files = "test_*.py"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-
-python_files = test_*.py

--- a/scripts/epics_docker.sh
+++ b/scripts/epics_docker.sh
@@ -11,12 +11,8 @@ sudo cp $SCRIPTS_DIR/docker.conf $file
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 
-MOTOR_DOCKERIMAGE="nsls2/epics-docker:latest"
-PE_DOCKERIMAGE="nsls2/pyepics-docker:latest"
 AD_DOCKERIMAGE="prjemian/synapps-6.1-ad-3.7:latest"
 
-docker pull ${MOTOR_DOCKERIMAGE}
-docker pull ${PE_DOCKERIMAGE}
 docker pull ${AD_DOCKERIMAGE}
 
 mkdir -p /tmp/ophyd_AD_test/
@@ -26,9 +22,6 @@ mkdir -p /tmp/ophyd_AD_test/
 # does not create missing directories.
 python $SCRIPTS_DIR/create_directories.py /tmp/ophyd_AD_test/data1
 
-docker run --rm -d -v /tmp/ophyd_AD_test:/tmp/ophyd_AD_test/ ${MOTOR_DOCKERIMAGE}
 docker run --name=area-detector --rm -dit -v /tmp/ophyd_AD_test:/tmp/ophyd_AD_test/ -e AD_PREFIX="ADSIM:" ${AD_DOCKERIMAGE} /bin/bash
 sleep 1  # Probably not needed?
 docker exec area-detector iocSimDetector/simDetector.sh start
-docker run --rm -d ${PE_DOCKERIMAGE}
-


### PR DESCRIPTION
For reasons not yet understood, these images now have 0 size on dockerhub