### PR TITLE
Enh/control child name mangling

### DIFF
--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -7,6 +7,10 @@ from packaging.version import parse
 
 from ._dispatch import EventDispatcher, _CallbackThread, wrap_callback
 
+# suspect attempt to monkey-patch printf is causing segfaults
+if hasattr(ca, "WITH_CA_MESSAGES"):
+    ca.WITH_CA_MESSAGES = True
+
 _min_pyepics = "3.4.2"
 
 if parse(epics.__version__) < parse(_min_pyepics):

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -234,7 +234,7 @@ class Component(typing.Generic[K]):
             suffix from.
 
         kw : str
-            The key of associated with the suffix.  If this key is
+            The key of associated with the suffix.  If this key is in
             self.add_prefix than prepend the prefix to the suffix and
             return, else just return the suffix.
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -253,10 +253,12 @@ class Component(typing.Generic[K]):
         "Instantiate the object described by this Component for a Device"
         kwargs = self.kwargs.copy()
         kwargs.update(
-            name=f"{instance.name}_{self.attr}",
+            name=f"{instance.name}{instance._child_name_separator}{self.attr}",
             kind=instance._component_kinds[self.attr],
             attr_name=self.attr,
         )
+        if issubclass(self.cls, Device):
+            kwargs.setdefault("child_name_separator", instance._child_name_separator)
 
         for kw, val in list(kwargs.items()):
             kwargs[kw] = self.maybe_add_prefix(instance, kw, val)
@@ -839,10 +841,11 @@ class Device(BlueskyInterface, OphydObject):
         read_attrs=None,
         configuration_attrs=None,
         parent=None,
+        child_name_separator="_",
         **kwargs,
     ):
         self._destroyed = False
-
+        self._child_name_separator = child_name_separator
         # Store EpicsSignal objects (only created once they are accessed)
         self._signals = {}
 

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -969,3 +969,31 @@ def test_trigger_value(initial, after):
 
     d.trigger()
     assert d.strigger.get() == after
+
+
+def test_child_separator():
+    class Test(Device):
+        a = Component(Signal)
+        b = Component(Signal)
+
+    t = Test(name="bob")
+    assert t.a.name == "bob_a"
+
+    t = Test(name="bob", child_name_separator="-")
+    assert t.a.name == "bob-a"
+
+    class Test2(Device):
+        c = Component(Signal)
+        d = Component(Signal)
+        t = Component(Test)
+        s = Component(Test, child_name_separator="?")
+
+    t2 = Test2(name="bob", child_name_separator="!")
+
+    assert t2.c.name == "bob!c"
+    assert t2.d.name == "bob!d"
+
+    assert t2.t.a.name == "bob!t!a"
+    assert t2.t.b.name == "bob!t!b"
+    assert t2.s.a.name == "bob!s?a"
+    assert t2.s.b.name == "bob!s?b"

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ dev =
     numpydoc
     pre-commit
     pydata-sphinx-theme
-    pyepics>=3.4.2
+    pyepics>=3.4.2,<3.5.7
     pytest
     pytest-asyncio
     pytest-cov


### PR DESCRIPTION
The Python name (via attributes) of a child device is `foo.bar.baz`, however
for a number of historical reasons (allowed keys in mongo and for attribute
access in Pandas data frames with columns named from the data keys in an event
stream) ophyd-sync has replaced '.' with '_' in the names.  This leads to
ambiguity when looking at the (default) name to which component on which device
the data came from as there may be `_` in the attribute names.  Ophyd-async
used '-' which does allow for round tripping.

This makes it controllable on per-instance basis in ophyd-sync so that users
can either make a different set of trade offs.

xref bluesky/ophyd-async#666