### PR TITLE
Propagate exceptions in AndStatus and Signal.set to the user

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -225,7 +225,7 @@ class Signal(OphydObject):
         # NOTE: this is a no-op that exists here for bluesky purposes
         #       it may need to be moved in the future
         d = Status(self)
-        d._finished()
+        d.set_finished()
         return d
 
     def wait_for_connection(self, timeout=0.0):
@@ -2247,7 +2247,7 @@ class EpicsSignal(EpicsSignalBase):
         st = Status(self, timeout=timeout, settle_time=settle_time)
 
         def put_callback(**kwargs):
-            st._finished(success=True)
+            st.set_finished()
 
         self.put(value, use_complete=True, callback=put_callback)
         return st

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -2,7 +2,6 @@ import json
 import threading
 import time
 from collections import deque
-from functools import partial
 from logging import LoggerAdapter
 from warnings import warn
 
@@ -599,7 +598,7 @@ class AndStatus(StatusBase):
 
                         elif l_success and r_success and l_done and r_done:
                             # Both are done, successfully.
-                            self._finished(success=True)
+                            self.set_finished()
                         # Else one is done, successfully, and we wait for #2,
                         # when this function will be called again.
 
@@ -793,7 +792,7 @@ class SubscriptionStatus(DeviceStatus):
 
         # If successfull indicate completion
         if success:
-            self._finished(success=True)
+            self.set_finished()
 
     def set_finished(self):
         """
@@ -863,9 +862,7 @@ class StableSubscriptionStatus(SubscriptionStatus):
                 f"Stability time ({stability_time}) must be less than full status timeout ({timeout})"
             )
         self._stability_time = stability_time
-        self._stable_timer = threading.Timer(
-            self._stability_time, partial(self._finished, success=True)
-        )
+        self._stable_timer = threading.Timer(self._stability_time, self.set_finished)
 
         # Start timeout thread in the background
         super().__init__(
@@ -891,7 +888,7 @@ class StableSubscriptionStatus(SubscriptionStatus):
             else:
                 self._stable_timer.cancel()
                 self._stable_timer = threading.Timer(
-                    self._stability_time, partial(self._finished, success=True)
+                    self._stability_time, self.set_finished
                 )
 
         # Do not fail silently

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -592,9 +592,9 @@ class AndStatus(StatusBase):
                         # At least one is done.
                         # If it failed, do not wait for the second one.
                         if (not l_success) and l_done:
-                            self._finished(success=False)
+                            self.set_exception(self.left.exception())
                         elif (not r_success) and r_done:
-                            self._finished(success=False)
+                            self.set_exception(self.right.exception())
 
                         elif l_success and r_success and l_done and r_done:
                             # Both are done, successfully.


### PR DESCRIPTION
This PR replaces some deprecated usages of `_finished(success=...)` with their non-deprecated forms `set_finished()` and `set_exception(...)`.

In particular, this enables propagation of some exceptions back to the user, easing some debugging of issues (I hate seeing the `To obtain more specific, helpful errors in the future, update the Device to use set_exception(...) instead of _finished(success=False)` message every time something goes wrong haha :sweat_smile:)

Let me know if I missed something!