### PR TITLE
FIX: do not leak the book-keeping float sub-class out of __init__

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -10,14 +10,14 @@ repos:
     hooks:
       - id: black
         name: Run black
-        stages: [commit]
+        stages: [pre-commit]
         language: system
         entry: black --check --diff
         types: [python]
 
       - id: flake8
         name: Run flake8
-        stages: [commit]
+        stages: [pre-commit]
         language: system
         entry: flake8
         types: [python]

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -180,6 +180,9 @@ class Signal(OphydObject):
                     f"The value {value} does not have the required shape {shape}."
                 )
 
+        if isinstance(value, _DefaultFloat):
+            value = float(value)
+
         self._readback = value
 
         if timestamp is None:

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -803,3 +803,8 @@ def test_signal_dtype_shape_info(fake_motor_ioc, cleanup):
         name="ok_value", dtype="int64", shape=(2, 2), value=[[1, 2], [3, 4]]
     )
     assert ok_default_shape._value_shape == (2, 2)
+
+
+def test_signal_default_type():
+    s = Signal(name="aardvark")
+    assert type(s.read()["aardvark"]["value"]) is float

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ dev =
     epics-pypdb
     # Upper bound on flake8 while flake8-isort catches up
     # https://github.com/gforcada/flake8-isort/issues/115
-    flake8<5.0.0
+    flake8
     flake8-isort
     h5py
     inflection


### PR DESCRIPTION
Not all serializers (e.g. orjson) will fallback to the float behavior.