### PR TITLE
Update status.rst SubscriptionStatus example

### DIFF
--- a/docs/user/explanations/status.rst
+++ b/docs/user/explanations/status.rst
@@ -176,7 +176,7 @@ to this:
                "Return True when the acquisition is complete, False otherwise."
                return (old_value == 1 and value == 0)
 
-           status = SubscriptionStatus(self.acquire, check_value)
+           status = SubscriptionStatus(self.acquire, check_value, run=False)
            self.acquire.set(1)
            return status
 


### PR DESCRIPTION
When you use subscription status you almost never want the subscription to run immediately when you instantiate it. The docs have caused us a number of problems with people copying the example and seeing multiple values in their readings when a trigger executes at a time they don't expect. 

I changed the example to fit what is commonly done (in my experience)