### PR TITLE
Added ability to configure wait_for_connection timeout

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -172,6 +172,8 @@ class Component(typing.Generic[K]):
     add_prefix: Tuple[str, ...]
     #: Subscription name -> subscriptions marked by decorator.
     _subscriptions: DefaultDict[str, List[Callable]]
+    # timeout for wait_for_connection
+    connection_timeout: float = 10.0
 
     def __init__(
         self,
@@ -183,6 +185,7 @@ class Component(typing.Generic[K]):
         add_prefix: Optional[Sequence[str]] = None,
         doc: Optional[str] = None,
         kind: Union[str, Kind] = Kind.normal,
+        connection_timeout: float = 10.0,
         **kwargs,
     ):
         self.attr = None  # attr is set later by the device when known
@@ -196,6 +199,7 @@ class Component(typing.Generic[K]):
         if add_prefix is None:
             add_prefix = ("suffix", "write_pv")
         self.add_prefix = tuple(add_prefix)
+        self.connection_timeout = connection_timeout
         self._subscriptions = collections.defaultdict(list)
 
     def _get_class_from_annotation(self) -> Optional[Type[K]]:
@@ -271,7 +275,7 @@ class Component(typing.Generic[K]):
 
         if self.lazy and hasattr(self.cls, "wait_for_connection"):
             if getattr(instance, "lazy_wait_for_connection", True):
-                cpt_inst.wait_for_connection()
+                cpt_inst.wait_for_connection(timeout=self.connection_timeout)
 
         return cpt_inst
 
@@ -1246,7 +1250,7 @@ class Device(BlueskyInterface, OphydObject):
 
         return "\n".join(out)
 
-    def wait_for_connection(self, all_signals=False, timeout=2.0):
+    def wait_for_connection(self, all_signals=False, timeout=10.0):
         """Wait for signals to connect
 
         Parameters

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -31,7 +31,7 @@ class FakeSignal(Signal):
         self._waited_for_connection = False
         self._subscriptions = []
 
-    def wait_for_connection(self):
+    def wait_for_connection(self, timeout: float = 0.0):
         self._waited_for_connection = True
 
     def subscribe(self, method, event_type, **kw):


### PR DESCRIPTION
In trying to set up integration tests for a beamline profile with many connections, I ran into a timeout error waiting for a device to connect. The default of 2 seconds is too low so I bumped it up to 10 seconds.

I also added the ability to configure this for individual `Component`s that may have many sub-`Component`s that try to connect at the same time.

The timeout occurred [here](https://github.com/bluesky/ophyd/blob/main/ophyd/quadem.py#L119-L121). It was running on a single locally hosted IOC that [accepts all connections and returns 0 for everything](https://github.com/NSLS2/gha-beamline-integration-test/blob/2025-1.0-test/spoof_beamline.py).
