### PR TITLE
use `type.__dir__` instead of `dir(...)` for attribute discovery

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -235,7 +235,7 @@ class OphydObject:
         cls.subscriptions = frozenset(
             {
                 getattr(cls, key)
-                for key in dir(cls)
+                for key in type.__dir__(cls)
                 if key.startswith("SUB") or key.startswith("_SUB")
             }
         )


### PR DESCRIPTION
Use `type.__dir__` for (slightly more) accurate attribute discovery on `OpyhdObject` subclasses when attempting to identify automatic subscriptions. `dir(...)` may trigger `__dir__` in a metaclass (and `inspect.getmembers` follows the same path.)

**Explanation**

While I am overall very skeptical of (name-based) automatic discovery mechanisms like this (preferring either a before-the-fact mechanism like a metaclass, an explicit after-the-fact mechanism like extra kwargs passed into `__init_subclass`, or a mechanism like descriptor `__set_name__`,) it seems that using `builtins.dir` is less nearly correct than `type.__dir__` in this case, because `builtins.dir` will respect a metaclass `__dir__`. 

```python
from inspect import getmembers

class OphydObject:
    def __init_subclass__(cls):
        assert 'x' not in dir(cls)
        assert 'x' in type.__dir__(cls)
        assert not getmembers(cls)

class TMeta(type):
    def __dir__(cls):
        return []

class T(OphydObject, metaclass=TMeta):
    x = ...
```

It occurs to me that a metaclass `__dir__` would most likely be present to support better `dir(…)` when used as a human debugging tool—eliminate all the noise typically present in `__dir__`.

(As a follow-up, since `OpyhdObject` already makes so many assumptions of its subclasses, would it be worthwhile to add an initial dummy metaclass to prevent metaclasses appearing as poorly-thought-through workarounds at lower levels?)