### PR TITLE
Fix use of default context in caproto shim

### DIFF
--- a/ophyd/_caproto_shim.py
+++ b/ophyd/_caproto_shim.py
@@ -148,18 +148,21 @@ def get_pv(
         whether to wait for connection (default False)
     context : int, optional
         PV threading context (defaults to current context)
+        Unused because the default context is the only context
+        setup with the event dispatcher
     timeout : float, optional
         connection timeout, in seconds (default 5.0)
     """
-    if context is None:
-        context = PV._default_context
-
+    if context is not None:
+        raise ValueError("context must be None")
+    context = PV.default_context()
     pv = PV(
         pvname,
         form=form,
         connection_callback=connection_callback,
         access_callback=access_callback,
         callback=callback,
+        context=context,
         **kwargs
     )
     pv._reference_count = 0
@@ -199,7 +202,7 @@ def setup(logger):
         _dispatcher = None
 
     logger.debug("Installing event dispatcher")
-    context = PV._default_context.broadcaster
+    context = PV.default_context().broadcaster
     _dispatcher = EventDispatcher(
         thread_class=CaprotoCallbackThread, context=context, logger=logger
     )

--- a/ophyd/_caproto_shim.py
+++ b/ophyd/_caproto_shim.py
@@ -155,7 +155,11 @@ def get_pv(
     """
     if context is not None:
         raise ValueError("context must be None")
-    context = PV.default_context()
+    if hasattr(PV, "default_context"):
+        context = PV.default_context()
+    else:
+        # Caproto <1.2.0 back-compat
+        context = PV._default_context  # type: ignore
     pv = PV(
         pvname,
         form=form,
@@ -202,7 +206,11 @@ def setup(logger):
         _dispatcher = None
 
     logger.debug("Installing event dispatcher")
-    context = PV.default_context().broadcaster
+    if hasattr(PV, "default_context"):
+        context = PV.default_context().broadcaster
+    else:
+        # Caproto <1.2.0 back-compat
+        context = PV._default_context.broadcaster  # type: ignore
     _dispatcher = EventDispatcher(
         thread_class=CaprotoCallbackThread, context=context, logger=logger
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ dev =
     attrs>=19.3.0
     black==22.3.0
     bluesky>=1.11.0
-    caproto[standard] >=0.4.2rc1,!=1.2.0
+    caproto[standard] >=0.4.2rc1
     pytest-codecov
     databroker>=1.0.0b1
     doctr

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ dev =
     attrs>=19.3.0
     black==22.3.0
     bluesky>=1.11.0
-    caproto[standard] >=0.4.2rc1
+    caproto[standard] >=0.4.2rc1,!=1.2.0
     pytest-codecov
     databroker>=1.0.0b1
     doctr


### PR DESCRIPTION
NOTE: To be merged after (and only if) https://github.com/caproto/caproto/pull/862 is merged and released.

Uses the default context as a cached class method rather than the instance method that was released in https://github.com/caproto/caproto/releases/tag/v1.2.0

It also ensures that a different context is not passed in to the `get_pv` function so that the same context is used by caproto as is used by the event dispatcher.

Ophyd can't make its own default context unless it overrides and monkey-patches the remaining `pyepics_compat` functions. We only override `get_pv` right now: https://github.com/bluesky/ophyd/blob/be3a5143beeb23cc7ece4abc6285197cc00af391/ophyd/_caproto_shim.py#L188-L189

Please let me know if I am missing something here!

