### PR TITLE
Incompatiblity with caproto v1.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ dev =
     attrs>=19.3.0
     black==22.3.0
     bluesky>=1.11.0
-    caproto[standard] >=0.4.2rc1
+    caproto[standard] >=0.4.2rc1,!=1.2.0
     pytest-codecov
     databroker>=1.0.0b1
     doctr


### PR DESCRIPTION
A new release of caproto is breaking functionality with the `_caproto_shim.py`. We should avoid v1.2.0 for the time being.