### PR TITLE
EpicsSignalBase connection timeout fix + Device connection timeout

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -916,10 +916,6 @@ class Device(BlueskyInterface, OphydObject):
             self.configuration_attrs = list(configuration_attrs)
 
         if not self.__any_instantiated:
-            self.log.debug(
-                "This is the first instance of Device. "
-                "name={self.name}, id={id(self)}"
-            )
             Device._mark_as_instantiated()
 
         with do_not_wait_for_lazy_connection(self):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1349,7 +1349,6 @@ class EpicsSignalBase(Signal):
 
     def wait_for_connection(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
         """Wait for the underlying signals to initialize or connect"""
-        print(f"{timeout=}")
         if timeout is DEFAULT_CONNECTION_TIMEOUT:
             timeout = self.connection_timeout
         try:

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1349,6 +1349,7 @@ class EpicsSignalBase(Signal):
 
     def wait_for_connection(self, timeout=DEFAULT_CONNECTION_TIMEOUT):
         """Wait for the underlying signals to initialize or connect"""
+        print(f"{timeout=}")
         if timeout is DEFAULT_CONNECTION_TIMEOUT:
             timeout = self.connection_timeout
         try:

--- a/ophyd/tests/__init__.py
+++ b/ophyd/tests/__init__.py
@@ -23,9 +23,12 @@ def subprocess_run_for_testing(
     mark fork() failures on Cygwin as expected failures: not a
     success, but not indicating a problem with the code either.
 
+    Borrowed from
+    https://github.com/matplotlib/matplotlib/blob/e1887b8d0d44d66103f0e3c787cfe7281daa7c63/lib/matplotlib/testing/__init__.py#L55
+
     Parameters
     ----------
-    args : list of str
+    command : list of str
     env : dict[str, str]
     timeout : float
     stdout, stderr
@@ -86,6 +89,9 @@ def subprocess_run_for_testing(
 def subprocess_run_helper(func, *args, timeout, extra_env=None):
     """
     Run a function in a sub-process.
+
+    Borrowed from
+    https://github.com/matplotlib/matplotlib/blob/e1887b8d0d44d66103f0e3c787cfe7281daa7c63/lib/matplotlib/testing/__init__.py#L111
 
     Parameters
     ----------

--- a/ophyd/tests/__init__.py
+++ b/ophyd/tests/__init__.py
@@ -71,12 +71,11 @@ def subprocess_run_for_testing(
             pytest.xfail("Fork failure")
         raise
     except subprocess.CalledProcessError as e:
-        import pytest
-
-        pytest.fail(
-            f"Subprocess failed with exit code {e.returncode}:\n{e.stdout}\n{e.stderr}"
-        )
-    # TODO: How to show this in the test output when `pytest -s` is used?
+        if e.stdout:
+            logger.info(f"Subprocess output:\n{e.stdout}")
+        if e.stderr:
+            logger.error(f"Subprocess error:\n{e.stderr}")
+        raise e
     if proc.stdout:
         logger.info(f"Subprocess output:\n{proc.stdout}")
     if proc.stderr:

--- a/ophyd/tests/__init__.py
+++ b/ophyd/tests/__init__.py
@@ -1,1 +1,100 @@
 import logging  # noqa: F401
+import os
+import subprocess
+import sys
+
+
+def subprocess_run_for_testing(command, env=None, timeout=60, stdout=None,
+                               stderr=None, check=False, text=True,
+                               capture_output=False):
+    """
+    Create and run a subprocess.
+
+    Thin wrapper around `subprocess.run`, intended for testing.  Will
+    mark fork() failures on Cygwin as expected failures: not a
+    success, but not indicating a problem with the code either.
+
+    Parameters
+    ----------
+    args : list of str
+    env : dict[str, str]
+    timeout : float
+    stdout, stderr
+    check : bool
+    text : bool
+        Also called ``universal_newlines`` in subprocess.  I chose this
+        name since the main effect is returning bytes (`False`) vs. str
+        (`True`), though it also tries to normalize newlines across
+        platforms.
+    capture_output : bool
+        Set stdout and stderr to subprocess.PIPE
+
+    Returns
+    -------
+    proc : subprocess.Popen
+
+    See Also
+    --------
+    subprocess.run
+
+    Raises
+    ------
+    pytest.xfail
+        If platform is Cygwin and subprocess reports a fork() failure.
+    """
+    if capture_output:
+        stdout = stderr = subprocess.PIPE
+    try:
+        proc = subprocess.run(
+            command, env=env,
+            timeout=timeout, check=check,
+            stdout=stdout, stderr=stderr,
+            text=text,
+        )
+    except BlockingIOError:
+        if sys.platform == "cygwin":
+            # Might want to make this more specific
+            import pytest
+            pytest.xfail("Fork failure")
+        raise
+    except subprocess.CalledProcessError as e:
+        import pytest
+        pytest.fail(f"Subprocess failed with exit code {e.returncode}:\n{e.stdout}\n{e.stderr}")
+    return proc
+
+
+def subprocess_run_helper(func, *args, timeout, extra_env=None):
+    """
+    Run a function in a sub-process.
+
+    Parameters
+    ----------
+    func : function
+        The function to be run.  It must be in a module that is importable.
+    *args : str
+        Any additional command line arguments to be passed in
+        the first argument to ``subprocess.run``.
+    extra_env : dict[str, str]
+        Any additional environment variables to be set for the subprocess.
+    """
+    target = func.__name__
+    module = func.__module__
+    file = func.__code__.co_filename
+    proc = subprocess_run_for_testing(
+        [
+            sys.executable,
+            "-c",
+            f"import importlib.util;"
+            f"_spec = importlib.util.spec_from_file_location({module!r}, {file!r});"
+            f"_module = importlib.util.module_from_spec(_spec);"
+            f"_spec.loader.exec_module(_module);"
+            f"_module.{target}()",
+            *args
+        ],
+        env={**os.environ, "SOURCE_DATE_EPOCH": "0", **(extra_env or {})},
+        timeout=timeout, check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return proc

--- a/ophyd/tests/test_timeout.py
+++ b/ophyd/tests/test_timeout.py
@@ -39,6 +39,19 @@ def test_timeout():
 
 
 def _test_epics_signal_base_connection_timeout():
+    """
+    Tests that the connection timeout is applied correctly to EpicsSignalBase.
+
+    We mock the ensure_connected method to raise a TimeoutError if the timeout
+    is less than 1.0 seconds which tests that the default connection timeout
+    is applied correctly.
+
+    We also test that the default connection timeout can be overidden by individual
+    Component connection timeouts.
+
+    NOTE: This test does NOT try to connect to a running IOC.
+    """
+
     def mock_ensure_connected(self, *pvs, timeout=None):
         """Assume that the connection occurs in 1.0 seconds"""
         if timeout < 1.0:
@@ -53,6 +66,7 @@ def _test_epics_signal_base_connection_timeout():
         # Should *not* timeout using custom connection timeout
         cpt2 = Component(EpicsSignalBase, "2", lazy=True, connection_timeout=3.0)
 
+    # Connect to fake device
     device = MyDevice("prefix:", name="dev")
     with pytest.raises(TimeoutError):
         device.cpt1.kind = "hinted"
@@ -65,6 +79,18 @@ def test_epics_signal_base_connection_timeout():
 
 
 def _test_device_connection_timeout():
+    """
+    Tests that the connection timeout is applied correctly to Device.
+
+    We mock the connected property of the underlying EpicsSignalBase
+    to raise a TimeoutError if the number of connections exceeds a limit
+    which tests that the default connection timeout is applied correctly.
+
+    We also test that the default connection timeout can be overidden by individual
+    Component connection timeouts.
+
+    NOTE: This test does NOT try to connect to a running IOC.
+    """
     # Track connection property access counts
     access_counts = {}
 
@@ -103,6 +129,7 @@ def _test_device_connection_timeout():
         # Should *not* timeout using custom connection timeout
         dev2 = Component(SubDevice, "dev2:", lazy=True, connection_timeout=1.0)
 
+    # Connect to fake device
     device = MyDevice("prefix:", name="dev")
 
     # This should fail - default timeout is too short for ATTEMPTS_BEFORE_CONNECTED checks

--- a/ophyd/tests/test_timeout.py
+++ b/ophyd/tests/test_timeout.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from ophyd import Component, Device, EpicsSignal
+from ophyd.signal import EpicsSignalBase
 
 logger = logging.getLogger(__name__)
 
@@ -34,3 +35,20 @@ def test_timeout():
     assert "prefix:_4" in ex_msg
     assert "prefix:_sub_5" in ex_msg
     assert "prefix:3" in ex_msg
+
+
+def test_epics_signal_base_connection_timeout():
+    EpicsSignalBase.set_defaults(connection_timeout=1e-6)
+    class MyDevice(Device):
+        # Should timeout using default connection timeout
+        cpt1 = Component(EpicsSignal, "1")
+        # Should *not* timeout using custom connection timeout
+        cpt2 = Component(EpicsSignal, "2", connection_timeout=1.0)
+
+    device = MyDevice("prefix:", name="dev")
+    with pytest.raises(TimeoutError) as cm:
+        device.cpt1.kind = "hinted"
+    device.cpt2.kind = "hinted"
+
+    ex_msg = str(cm.value)
+    print(ex_msg)


### PR DESCRIPTION
## Overview

See #1242 for a description of the issue that this PR solves.

In addition to the bug fix, we also add the ability to set default class-wide connection timeouts for `Device`s as well as individual `Device`s. This is the amount of time it takes for all sub-devices or signals to connect.

This is mirrored by the `EpicsSignalBase.set_defaults` method to set class-wide connection timeouts.

## Examples

### Set class-wide default connection timeout
```python
from ophyd.device import Device

Device.set_defaults(connection_timeout=20.0)
```

### Set instance-specific connection timeout
```python
from ophyd.device import Component, Device

class MyDevice(Device):
    sub_device = Component(Device, "Device:", connection_timeout=10)
```

Closes #1242 

