### PR TITLE
BUG: consume and ignore additional kwargs to PyepicsShimPV

### DIFF
--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -62,6 +62,7 @@ class PyepicsShimPV(epics.PV):
         connection_callback=None,
         connection_timeout=None,
         access_callback=None,
+        default_monitor=None,
     ):
         connection_callback = wrap_callback(
             _dispatcher, "metadata", connection_callback


### PR DESCRIPTION
# Summary
* New pyepics (3.5.8) adds support for a new kwarg in `PV`: `monitor_delta`
* ophyd patches this with a subclass `PyepicsShimPV` that consumes mostly the same kwargs, but very specifically those kwargs

Approach: consume any extra kwargs and drop them on the floor

# Context
See #1251 

It's possible we want to use this information, but I see that ophyd doesn't explicitly list pyepics as a core dependency.  The dev dependency itself pins pyepics to a lower version than this, but downstream consumers of ophyd likely don't install ophyd[dev] so they don't pick up this pin