### PR TITLE
BUG: PyepicsShimPV to consume monitor_delta instead of default monitor

### DIFF
--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -62,7 +62,7 @@ class PyepicsShimPV(epics.PV):
         connection_callback=None,
         connection_timeout=None,
         access_callback=None,
-        default_monitor=None,
+        monitor_delta=None,
     ):
         connection_callback = wrap_callback(
             _dispatcher, "metadata", connection_callback


### PR DESCRIPTION
Fixing the incorrect kwarg consumption in #1252 (apologies)

I've tested this locally and can create EpicsSignal's now with pyepics 3.5.8

```python
In [1]: from ophyd import EpicsSignal

In [2]: EpicsSignal("name", "PV")
Out[2]: EpicsSignal(read_pv='name', name='name', timestamp=1749832452.107589, auto_monitor=False, string=False, write_pv='PV', limits=False, put_complete=False)

In [3]: import epics

In [4]: epics.__version__
Out[4]: '3.5.8'
```