### PR TITLE
Fix connection state machine races on fast control layers

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1439,7 +1439,7 @@ class Device(BlueskyInterface, OphydObject):
             for event_type, functions in cpt._subscriptions.items():
                 for func in functions:
                     method = getattr(self, func.__name__)
-                    sig.subscribe(method, event_type=event_type, run=sig.connected)
+                    sig.subscribe(method, event_type=event_type, run=True)
         except AttributeError as ex:
             # Raise a different Exception, as AttributeError will be shadowed
             # during initial access


### PR DESCRIPTION
We are developing [epics-rs](https://github.com/epics-rs/epics-rs), a pure-Rust EPICS Channel Access implementation, and [ophyd-epicsrs](https://github.com/physwkim/ophyd-epicsrs), a PyO3-based ophyd control layer backend that replaces pyepics. The ophyd integration lives on the [feature/epicsrs-backend](https://github.com/physwkim/ophyd/tree/feature/epicsrs-backend) branch of our ophyd fork.

During real beamline testing (200+ PVs, areaDetector, motors), we discovered that some devices stayed `connected=False` permanently despite all PVs being reachable. The Rust backend connects PVs significantly faster than pyepics because it uses background prefetch — a tokio task that connects and fetches metadata concurrently for all PVs at creation time, before Python even calls `wait_for_connection`.

This speed exposed two latent race conditions in ophyd's connection state machine. With pyepics, the dispatcher queue introduces enough latency that events always arrive in the expected order. With faster backends, PVs can be fully connected with cached values before ophyd's `Device._instantiate_component` attaches its subscribers, causing the initial value replay and readiness evaluation to be missed.

## Changes

### 1. Reset `_received_first_metadata` on disconnect (`signal.py`)

When a PV disconnects, `_received_first_metadata` was not reset to `False`. On reconnection, `_pv_connected` saw it as `True` and skipped the metadata fetch (`get_all_metadata_callback`). This left stale `enum_strs`, limits, and units from the previous IOC session.

```python
# Before
if not conn:
    self._signal_is_ready.clear()
    self._metadata["connected"] = False
    self._access_rights_valid[pvname] = False

# After
if not conn:
    self._signal_is_ready.clear()
    self._metadata["connected"] = False
    self._access_rights_valid[pvname] = False
    self._received_first_metadata[pvname] = False  # force fresh fetch
```

### 2. Always replay initial value in component subscription (`device.py`)

`Device._instantiate_component` used `run=sig.connected` for the initial subscription replay. When the control layer connects fast enough, the signal already has a cached value but `sig.connected` may evaluate to `False` at the exact moment of subscription — the connection callback is still in the dispatcher queue. The initial value is never delivered, and the device never transitions to `connected=True`.

```python
# Before
sig.subscribe(method, event_type=event_type, run=sig.connected)

# After
sig.subscribe(method, event_type=event_type, run=True)
```

This is safe because `add_callback(run_now=True)` only fires the callback when a cached value actually exists. If the signal has no value yet, nothing happens.

## Impact

These two fixes make ophyd's connection state machine robust regardless of event ordering. They benefit all control layer backends:

- **pyepics**: no behavioral change in practice (events already arrive in the expected order due to dispatcher latency), but the code is now correct by construction rather than by coincidence.
- **Fast backends (epicsrs, future backends)**: devices reliably reach `connected=True` even when PVs connect before callback registration completes.
- **Reconnection**: metadata is always refreshed after IOC restart, preventing stale enum labels, limits, or units.

See also, bluesky/bluesky#2000