### PR TITLE
Handle case where data_type field is disabled for make_data_key

### DIFF
--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -103,6 +103,7 @@ class CamBase(ADBase):
     bin_y = ADCpt(SignalWithRBV, "BinY")
     color_mode = ADCpt(SignalWithRBV, "ColorMode")
     data_type = ADCpt(SignalWithRBV, "DataType")
+    data_type_disabled = ADCpt(EpicsSignalRO, "DataType_RBV.DISA")
     detector_state = ADCpt(EpicsSignalRO, "DetectorState_RBV")
     frame_type = ADCpt(SignalWithRBV, "FrameType")
     gain = ADCpt(SignalWithRBV, "Gain")

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -118,7 +118,7 @@ class DetectorBase(ADBase):
             external="FILESTORE:",
         )
 
-        # Some IOCs disable the data type, so we can't rely on its value
+        # If the data type isn't disabled, we assume it is accurate
         if self.cam.data_type_disabled.get() == 0:
             ret["dtype_numpy"] = np.dtype(
                 self.cam.data_type.get(as_string=True).lower()

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -110,19 +110,21 @@ class DetectorBase(ADBase):
             self.cam.array_size.array_size_y.get(),
             self.cam.array_size.array_size_x.get(),
         )
-        # Some IOCs disable the data type, so we can't rely on its value
-        dtype_numpy = (
-            np.dtype(self.cam.data_type.get(as_string=True).lower()).str
-            if self.cam.data_type_disabled.get() == 0
-            else ""
-        )
-        return dict(
+
+        ret = dict(
             shape=shape,
             source=source,
             dtype="array",
             external="FILESTORE:",
-            dtype_numpy=dtype_numpy,
         )
+
+        # Some IOCs disable the data type, so we can't rely on its value
+        if self.cam.data_type_disabled.get() == 0:
+            ret["dtype_numpy"] = np.dtype(
+                self.cam.data_type.get(as_string=True).lower()
+            ).str
+
+        return ret
 
     def collect_asset_docs(self):
         file_plugins = [

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -110,7 +110,12 @@ class DetectorBase(ADBase):
             self.cam.array_size.array_size_y.get(),
             self.cam.array_size.array_size_x.get(),
         )
-        dtype_numpy = np.dtype(self.cam.data_type.get(as_string=True).lower()).str
+        # Some IOCs disable the data type, so we can't rely on its value
+        dtype_numpy = (
+            np.dtype(self.cam.data_type.get(as_string=True).lower()).str
+            if self.cam.data_type_disabled.get() == 0
+            else ""
+        )
         return dict(
             shape=shape,
             source=source,

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -1060,6 +1060,7 @@ def test_make_data_key(param, expected):
         dtype_numpy=expected,
     )
 
+
 @pytest.mark.parametrize("param", [0, 1])
 def test_make_data_key_disabled(param):
     FakeAreaDetector = make_fake_device(AreaDetector)

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -1059,3 +1059,21 @@ def test_make_data_key(param, expected):
         external="FILESTORE:",
         dtype_numpy=expected,
     )
+
+@pytest.mark.parametrize("param", [0, 1])
+def test_make_data_key_disabled(param):
+    FakeAreaDetector = make_fake_device(AreaDetector)
+    det = FakeAreaDetector("PREFIX:", name="det")
+    det.cam.data_type.sim_put("Float32")
+    det.cam.data_type_disabled.sim_put(param)
+    det.cam.num_images.sim_put(100)
+    det.cam.array_size.array_size_y.sim_put(1024)
+    det.cam.array_size.array_size_x.sim_put(1980)
+    data_key = det.make_data_key()
+    assert data_key == dict(
+        shape=(100, 1024, 1980),
+        source="PV:PREFIX:",
+        dtype="array",
+        external="FILESTORE:",
+        dtype_numpy="<f4" if param == 0 else "",
+    )

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -1071,10 +1071,18 @@ def test_make_data_key_disabled(param):
     det.cam.array_size.array_size_y.sim_put(1024)
     det.cam.array_size.array_size_x.sim_put(1980)
     data_key = det.make_data_key()
-    assert data_key == dict(
-        shape=(100, 1024, 1980),
-        source="PV:PREFIX:",
-        dtype="array",
-        external="FILESTORE:",
-        dtype_numpy="<f4" if param == 0 else "",
-    )
+    if param == 1:
+        assert data_key == dict(
+            shape=(100, 1024, 1980),
+            source="PV:PREFIX:",
+            dtype="array",
+            external="FILESTORE:",
+        )
+    else:
+        assert data_key == dict(
+            shape=(100, 1024, 1980),
+            source="PV:PREFIX:",
+            dtype="array",
+            external="FILESTORE:",
+            dtype_numpy="<f4",
+        )


### PR DESCRIPTION
Fixes problem with Pilatus IOC and others that disable `data_type` even though you can still read a value from this PV (the wrong value).

- [x] unit test
- [x] test with ADSim