### PR TITLE
dtype_numpy property on DetectorBase, Fix Pilatus to int32 dtype

### DIFF
--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -6,6 +6,7 @@
 .. _areaDetector: https://areadetector.github.io/master/index.html
 """
 import warnings
+from typing import Optional
 
 import numpy as np
 
@@ -103,7 +104,7 @@ class DetectorBase(ADBase):
     dispatch.__doc__ = generate_datum.__doc__
 
     @property
-    def dtype_numpy(self) -> str | None:
+    def dtype_numpy(self) -> Optional[str]:
         """The data type of the image in numpy style"""
         # If the data type isn't disabled, we assume it is accurate
         return (
@@ -236,7 +237,7 @@ class PilatusDetector(DetectorBase):
     cam = C(cam.PilatusDetectorCam, "cam1:")
 
     @property
-    def dtype_numpy(self) -> str | None:
+    def dtype_numpy(self) -> Optional[str]:
         return np.dtype(np.int32).str
 
 

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -129,7 +129,7 @@ class DetectorBase(ADBase):
         )
 
         dtype_numpy = self.dtype_numpy
-        if dtype_numpy:
+        if dtype_numpy is not None:
             ret["dtype_numpy"] = dtype_numpy
 
         return ret

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -102,6 +102,16 @@ class DetectorBase(ADBase):
 
     dispatch.__doc__ = generate_datum.__doc__
 
+    @property
+    def dtype_numpy(self) -> str | None:
+        """The data type of the image in numpy style"""
+        # If the data type isn't disabled, we assume it is accurate
+        return (
+            np.dtype(self.cam.data_type.get(as_string=True).lower()).str
+            if self.cam.data_type_disabled.get() == 0
+            else None
+        )
+
     def make_data_key(self):
         source = "PV:{}".format(self.prefix)
         # This shape is expected to match arr.shape for the array.
@@ -118,11 +128,9 @@ class DetectorBase(ADBase):
             external="FILESTORE:",
         )
 
-        # If the data type isn't disabled, we assume it is accurate
-        if self.cam.data_type_disabled.get() == 0:
-            ret["dtype_numpy"] = np.dtype(
-                self.cam.data_type.get(as_string=True).lower()
-            ).str
+        dtype_numpy = self.dtype_numpy
+        if dtype_numpy:
+            ret["dtype_numpy"] = dtype_numpy
 
         return ret
 
@@ -226,6 +234,10 @@ class PICamDetector(DetectorBase):
 class PilatusDetector(DetectorBase):
     _html_docs = ["pilatusDoc.html"]
     cam = C(cam.PilatusDetectorCam, "cam1:")
+
+    @property
+    def dtype_numpy(self) -> str | None:
+        return np.dtype(np.int32).str
 
 
 class PixiradDetector(DetectorBase):

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -24,7 +24,7 @@ from ophyd import (
     wait,
 )
 from ophyd.areadetector.base import NDDerivedSignal
-from ophyd.areadetector.detectors import AreaDetector
+from ophyd.areadetector.detectors import AreaDetector, PilatusDetector
 from ophyd.areadetector.filestore_mixins import (
     FileStoreHDF5,
     FileStoreIterativeWrite,
@@ -1058,6 +1058,22 @@ def test_make_data_key(param, expected):
         dtype="array",
         external="FILESTORE:",
         dtype_numpy=expected,
+    )
+
+
+def test_make_data_key_pilatus():
+    FakePilatusDetector = make_fake_device(PilatusDetector)
+    det = FakePilatusDetector("PREFIX:", name="det")
+    det.cam.num_images.sim_put(100)
+    det.cam.array_size.array_size_y.sim_put(1024)
+    det.cam.array_size.array_size_x.sim_put(1980)
+    data_key = det.make_data_key()
+    assert data_key == dict(
+        shape=(100, 1024, 1980),
+        source="PV:PREFIX:",
+        dtype="array",
+        external="FILESTORE:",
+        dtype_numpy="<i4",
     )
 
 


### PR DESCRIPTION
Does two things:
- Enables easy override of `dtype_numpy` by simply overriding the property when inheriting from `DetectorBase`
- Forces Pilatus to use int32 dtype since this is always fixed at the IOC (and not reported correctly through `DataType_RBV`)