### PR TITLE
MNT: do not try to use PAT for release token

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           sudo systemctl start docker
           docker version
-          docker compose --version 
+          docker compose --version
 
       - name: Create AD data directories
         run: |
@@ -138,7 +138,6 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
-          token: ${{ secrets.RELEASE_ON_GH_TOKEN }}
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -123,6 +123,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
+
     # upload to PyPI and make a release on every tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:


### PR DESCRIPTION
Let it use the short-term one that GH already provides.

Not sure how we can test this without doing a tag.