### PR TITLE
Delay creation of temp directories until required

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -952,10 +952,7 @@ class SynSignalWithRegistry(SynSignal):
         self._resource_uid = None
         self._datum_counter = None
         self._asset_docs_cache = deque()
-        if save_path is None:
-            self.save_path = mkdtemp()
-        else:
-            self.save_path = save_path
+        self._save_path = save_path
         self._spec = save_spec  # spec name stored in resource doc
 
         self._file_stem = None
@@ -1034,6 +1031,13 @@ class SynSignalWithRegistry(SynSignal):
         self._file_stem = None
         self._path_stem = None
         self._result.clear()
+
+    @property
+    def save_path(self):
+        # delay creation of temp directory until required to prevent littering of empty directories in /tmp
+        if self._save_path is None:
+            self._save_path = mkdtemp(prefix="sim-signal")
+        return self._save_path
 
 
 class NumpySeqHandler:


### PR DESCRIPTION
When the `SynSignalWithRegistry` is created without a save_path, it creates a temp directory instead. As this directory was eagerly created, and the `ophyd.sim` module creates an instance as part of the demo devices in the module (via the `globals().update`), simply importing `ophyd.sim` was enough to create a directory that would never be deleted.

As it's in `/tmp` by default, it's not a huge issue, but in some environments, eg running pytest across multiple processes using xdist, it can leave 20+ of these empty directories per test run which quickly add up.

The temp directory is now created lazily when the `save_path` is first used. It is still not deleted but this was presumably the original intention given there may be data in it.